### PR TITLE
about "gpgcheck"

### DIFF
--- a/lib/Rex/Pkg/Redhat.pm
+++ b/lib/Rex/Pkg/Redhat.pm
@@ -123,6 +123,7 @@ sub add_repository {
    $fh->write("name=$desc\n");
    $fh->write("baseurl=" . $data{"url"} . "\n");
    $fh->write("enabled=1\n");
+   $fh->write("gpgcheck=" . $data{"gpgcheck"} ."\n") if defined $data{"gpgcheck"};
 
    $fh->close;
 }


### PR DESCRIPTION
Hi,

I tried to install 'opsview-*' on my server (CentOS-5.x) using Rex, but there is a problem.

```
[2012-02-15 18:27:36] (4891) - INFO - Error installing opsview-agent.
[2012-02-15 18:27:36] (4891) - INFO - Error running task/batch: Error installing opsview-agent at  /home/jeen/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/Rex/Pkg/Redhat.pm line 57.
```

And, I tried to

```
 $ yum -y install opsview-agent
```

but, It failed

```
Package opsview-agent-3.13.2.7042-1.ct5.x86_64.rpm is not signed
```

So, I added

```
gpgcheck=0
```

on `/etc/yum.repos.d/rex.repo`.

And, I tried again, It works fine.
