### PR TITLE
Specify the sudo password prompt to avoid different prompts in different...

### DIFF
--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -163,10 +163,10 @@ sub sudo {
       $cmd_out .= $str;
    });
 
-   $exp->spawn("sudo", $cmd);
+   $exp->spawn("sudo -p Password: $cmd");
 
    $exp->expect($timeout, [
-                              qr/Password:|\[sudo\] password for [^:]+:/i => sub {
+                              "Password:" => sub {
                                           Rex::Logger::debug("Sending password");
                                           my ($exp, $line) = @_;
                                           $exp->send($sudo_password . "\n");


### PR DESCRIPTION
... locales.

In Japanese locale such as ja_JP.utf8, the sudo password propmt becomes Japanese characters.
It is tedious for us to write regular expressions in every locale, so it is easier to specify the sudo
password prompt using "-p" option.
