### PR TITLE
I had a few issues with before/after for tasks that didn't exist

### DIFF
--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -795,14 +795,7 @@ Note: must come after the definition of the specified task
 sub before {
    my ($task, $code) = @_;
    my ($package, $file, $line) = caller;
-   if($package ne "main") {
-      if($task !~ m/:/) {
-         $package =~ s/::/:/g;
-         $task = $package . ":" . $task;
-      }
-   }
-
-   Rex::TaskList->get_task($task)->modify("before" => $code);
+   Rex::TaskList->modify('around', $task, $code, $package, $file, $line);
 }
 
 =item after($task => sub {})
@@ -823,14 +816,8 @@ Note: must come after the definition of the specified task
 sub after {
    my ($task, $code) = @_;
    my ($package, $file, $line) = caller;
-   if($package ne "main") {
-      if($task !~ m/:/) {
-         $package =~ s/::/:/g;
-         $task = $package . ":" . $task;
-      }
-   }
 
-   Rex::TaskList->get_task($task)->modify("after" => $code);
+   Rex::TaskList->modify('around', $task, $code, $package, $file, $line);
 }
 
 =item around($task => sub {})
@@ -855,14 +842,8 @@ Note: must come after the definition of the specified task
 sub around {
    my ($task, $code) = @_;
    my ($package, $file, $line) = caller;
-   if($package ne "main") {
-      if($task !~ m/:/) {
-         $package =~ s/::/:/g;
-         $task = $package . ":" . $task;
-      }
-   }
-
-   Rex::TaskList->get_task($task)->modify("around" => $code);
+   
+   Rex::TaskList->modify('around', $task, $code, $package, $file, $line);
 }
 
 

--- a/lib/Rex/TaskList.pm
+++ b/lib/Rex/TaskList.pm
@@ -198,4 +198,25 @@ sub run {
    $fm->wait_for_all;
 }
 
+sub modify {
+   my ($class, $type, $task, $code, $package, $file, $line) = @_;
+
+   if($package ne "main") {
+      if($task !~ m/:/) {
+         #do we need to detect for base -Rex ?
+         $package =~ s/^Rex:://;
+         $package =~ s/::/:/g;
+         $task = $package . ":" . $task;
+      }
+   }
+
+   my $taskref = Rex::TaskList->get_task($task);
+   if (defined($taskref)) {
+      $taskref->modify($type => $code);
+   } else {
+      Rex::Logger::info("can't add $type $task, as its not yet defined\nsee $file line $line");
+   }
+}
+
+
 1;


### PR DESCRIPTION
and tasks referenced locally to a module

ie

before 'not_there'

and 

package Rex::Assembly;
task create, sub {
};
before create ...

this patch resolves it, extracts the duplicated code and also tells the user what's gone wrong

before it would die with an undefined var - so you might like to add a die..
