### PR TITLE
fix the bad pkg_info execution on freebsd.

### DIFF
--- a/lib/Rex/Pkg/FreeBSD.pm
+++ b/lib/Rex/Pkg/FreeBSD.pm
@@ -27,7 +27,7 @@ sub is_installed {
 
    Rex::Logger::debug("Checking if $pkg is installed");
 
-   run("pkg_info $pkg-*");
+   run("pkg_info $pkg-\\*");
 
    unless($? == 0) {
       Rex::Logger::debug("$pkg is NOT installed.");


### PR DESCRIPTION
Hi.

I fixed the problem that $pkg->is_installed was called on FreeBSD.

Please merge this appropriate.

Cheers,
Tomohiro Hosaka
