### PR TITLE
update the regexp for ifconfig. be possible to match ppp0.

### DIFF
--- a/lib/Rex/Hardware/Network/Linux.pm
+++ b/lib/Rex/Hardware/Network/Linux.pm
@@ -21,7 +21,7 @@ sub get_network_devices {
 
    for my $dev (@proc_net_dev) {
       my $ifconfig = run("ifconfig $dev");
-      if($ifconfig =~ m/Link encap:Ethernet/m) {
+      if($ifconfig =~ m/Link encap:(?:Ethernet|Point-to-Point Protocol)/m) {
          push(@device_list, $dev);
       }
    }


### PR DESCRIPTION
Hi.

I updated the regexp for matching ppp0 when called network_interfaces() on Linux.

Please merge this appropriate.

Cheers,
Tomohiro Hosaka
