### PR TITLE
Fix $? when a command is run locally.

### DIFF
--- a/lib/Rex/Interface/Exec/Local.pm
+++ b/lib/Rex/Interface/Exec/Local.pm
@@ -38,6 +38,7 @@ sub exec {
       $path ||= "";
 
       $out = qx{LC_ALL=C $path $cmd};
+      $? >>= 8;
    }
    Rex::Commands::profiler()->end("exec: $cmd");
 


### PR DESCRIPTION
When run Locally, a command return value is left-shifted 8 times.
This behavior isn't noticed when the exact same command is run through SSH.

$ perldoc -f system

This is by design, but Rex needs to stay the same wherever we are running locally or remotely.
