### PR TITLE
Relax ssh config file parsing

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -453,16 +453,19 @@ sub read_config_file {
    }
 }
 
-sub import {
-   if(-f _home_dir() . "/.ssh/config") {
+sub read_ssh_config_file {
+   my ($config_file) = @_;
+   $config_file ||= _home_dir() . '/.ssh/config';
+   
+   if(-f $config_file) {
       my (@host, $in_host);
-      if(open(my $fh, "<", _home_dir() . "/.ssh/config")) {
+      if(open(my $fh, '<', $config_file)) {
          while(my $line = <$fh>) {
             chomp $line;
             next if ($line =~ m/^#/);
             next if ($line =~ m/^\s*$/);
 
-            if($line =~ m/^Host (.*)$/) {
+            if($line =~ m/^Host\s+=?\s*(.*)$/) {
                my $host_tmp = $1; 
                @host = split(/\s+/, $host_tmp);
                $in_host = 1;
@@ -472,7 +475,9 @@ sub import {
                next;
             }   
             elsif($in_host) {
-               my ($key, $val) = ($line =~ m/^\s*([^\s]+)\s+(.*)$/);
+               my ($key, $val) = ($line =~ m/^\s*([^\s]+)\s+=?\s*(.*)$/);
+               $val =~ s/^\s+//;
+               $val =~ s/\s+$//;
                for my $h (@host) {
                   $SSH_CONFIG_FOR{$h}->{lc($key)} = $val;
                }
@@ -481,7 +486,10 @@ sub import {
          close($fh);
       }
    }
+}
 
+sub import {
+   read_ssh_config_file();
    read_config_file();   
 }
 

--- a/t/config-ssh.t
+++ b/t/config-ssh.t
@@ -1,0 +1,70 @@
+use strict;
+use warnings;
+
+use File::Temp;
+use Test::More tests => 18;
+
+use_ok 'Rex';
+use_ok 'Rex::Config';
+
+my $ssh_cfg1 = <<EOF;
+
+# Sample SSH config w/o equal signs
+
+Host frontend1
+Hostname fe80::1
+User bogey
+Port 35221
+
+Host web
+Hostname 192.168.1.1
+User root 
+
+EOF
+
+my $ssh_cfg2 = <<EOF;
+
+Host = frontend2
+Hostname = this.is.a.domain.tld
+User = 123
+Port = 1005
+
+Host = some other hosts
+Port = 3306
+
+EOF
+
+my $tempdir = File::Temp::tempdir( CLEANUP => 1 );
+ok(open(my $FH1, '>', $tempdir.'/cfg1'),'Opened cfg1');
+print $FH1 $ssh_cfg1;
+ok(close($FH1),'Closed cfg1');
+
+%Rex::Config::SSH_CONFIG_FOR = ();
+Rex::Config::read_ssh_config_file($tempdir.'/cfg1');
+my $c = \%Rex::Config::SSH_CONFIG_FOR;
+
+is($c->{'web'}->{'user'},'root');
+isnt($c->{'web'}->{'user'},'root ');
+is($c->{'web'}->{'hostname'},'192.168.1.1');
+
+is($c->{'frontend1'}->{'user'},'bogey');
+is($c->{'frontend1'}->{'hostname'},'fe80::1');
+is($c->{'frontend1'}->{'port'},35221);
+
+ok(open(my $FH2, '>', $tempdir.'/cfg2'),'Opened cfg2');
+print $FH2 $ssh_cfg2;
+ok(close($FH2),'Closed cfg2');
+
+%Rex::Config::SSH_CONFIG_FOR = ();
+Rex::Config::read_ssh_config_file($tempdir.'/cfg2');
+
+is($c->{'frontend2'}->{'user'},'123');
+is($c->{'frontend2'}->{'hostname'},'this.is.a.domain.tld');
+is($c->{'frontend2'}->{'port'},1005);
+
+is($c->{'some'}->{'port'},'3306');
+is($c->{'other'}->{'port'},'3306');
+is($c->{'hosts'}->{'port'},'3306');
+
+1;
+


### PR DESCRIPTION
This commit relaxes the handling of ssh config files. Rex used to fail
to parse my ssh config due to my habit of placing equal signs
between the keys and the values (which is perfectly fine with ssh).

It also introduces trimming of values read from this file and some testcases
covering this patch.
