### PR TITLE
Unwrapped double looping over files and regexes and adding $new_line if not present in absence of regexes

### DIFF
--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -424,7 +424,9 @@ sub delete_lines_matching {
 
 =item append_if_no_such_line($file, $new_line, @regexp)
 
-Append $new_line to $file if none in @regexp is found.
+Append $new_line to $file if none in @regexp is found. If no regexp is
+supplied, the line is appended unless there already an identical line
+in $file.
 
  task "add-group", sub {
     append_if_no_such_line "/etc/groups", "mygroup:*:100:myuser1,myuser2", on_change => sub { service sshd => "restart"; };
@@ -446,37 +448,35 @@ sub append_if_no_such_line {
       die("$file not writable");
    }
 
-   my $nl = $/;
-   my @content = split(/$nl/, cat ($file));
-   my $i;
-   my $on_change = sub {};
-
-   for my $line (@content) {
-      $i = 0;
-      for my $match (@m) {
-         $i++;
-         if(! ref($match) eq "Regexp") {
-            $match = qr{$match};
-         }
-         if ( $match eq "on_change" && ref($m[$i]) eq "CODE" ) {
-             $on_change = $m[$i];
-             next;
-         }
-         if($line =~ $match) {
-            return 0;
-         }
+   my $on_change;
+   for (my $i = 0; $i<$#m; $i++ ) {
+      if ( $m[$i] eq "on_change" && ref($m[$i+1]) eq "CODE" ) {
+         $on_change = $m[$i+1];
+         splice(@m,$i,2);
+         last;
       }
    }
 
-   push @content, $new_line;
+   if ( !@m ) {
+      push @m, qr{^\Q$new_line\E$}m;
+   }
+
+   my $content = cat ($file);
+   for my $match (@m) {
+      if ( $content =~ /$match/m ) {
+         return 0;
+      }
+   }
+
+   $content .= "$new_line\n";
    my $fh = file_write $file;
    unless($fh) {
       die("Can't open $file for writing");
    }
-   $fh->write(join($nl, @content));
+   $fh->write($content);
    $fh->close;
 
-   &$on_change();
+   &$on_change() if defined $on_change;
 }
 
 =item extract($file [, %options])

--- a/t/file.t
+++ b/t/file.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 11;
+use Test::More tests => 12;
 use Data::Dumper;
 
 use_ok 'Rex';
@@ -47,7 +47,12 @@ append_if_no_such_line("test.txt", "change", qr{change},
 
 ok($changed == 1, "nothing was changed in the file");
 
+append_if_no_such_line("test.txt", "change",
+   on_change => sub {
+      $changed = 0;
+   });
+
+ok($changed == 1, "nothing was changed in the file without regexp");
 
 
 Rex::Commands::Fs::unlink("test.txt");
-


### PR DESCRIPTION
Hi, i had a lot of repeated configuration where i just wanted to append a line to a file if it wasn't present already. This resulted in a lot of copying $new_line as the one and only regexp. The diff adds code that use $new_line as regexp if no other @regexps are supplied.  It should also run faster for big files or a lot of regexps by not checking all regexps for all lines . That shouldn't change any semantics but this definitely needs some testing. Seems okay here.

Cheers, Mario
