### PR TITLE
Better handling of $option parameter for 'install'

### DIFF
--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -123,8 +123,9 @@ This is deprecated since 0.9. Please use L<File> I<file> instead.
 
 sub install {
 
-   my ($type, $package, $option) = @_;
-
+   my $type = shift;
+   my $package = shift;
+   my $option = ( @_ == 1 ) ? shift : { @_ };   
 
    if($type eq "file") {
 
@@ -243,7 +244,7 @@ sub install {
    }
    else {
       # unknown type, be a package
-      install("package", @_); 
+      install("package", $type, $package, $option); 
    }
 
 }


### PR DESCRIPTION
I found this while trying to setup a specific package version, I had to write in the Rexfile this way :

install "ntp", { version => '1:4.2.6.p3+dfsg-1ubuntu5' };

Now you can write easier with the following :+1: 

   install "ntp", version => '1:4.2.6.p3+dfsg-1ubuntu5';

I hope it doesn't break anything else.
