### PR TITLE
Remove sudo from apt-key in function add_repository.

### DIFF
--- a/lib/Rex/Pkg/Debian.pm
+++ b/lib/Rex/Pkg/Debian.pm
@@ -147,7 +147,7 @@ sub add_repository {
    $fh->close;
 
    if(exists $data{"key_url"}) {
-      run "wget -O - " . $data{"key_url"} . " | sudo apt-key add -";
+      run "wget -O - " . $data{"key_url"} . " | apt-key add -";
    }
 
    if(exists $data{"key-id"} && $data{"key_server"}) {


### PR DESCRIPTION
I've overlooked that there was a sudo at "apt-key add -" in function Pkg::Debian::add_repository".
