### PR TITLE
Match comments better

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -467,7 +467,7 @@ sub read_ssh_config_file {
       if(open(my $fh, '<', $config_file)) {
          while(my $line = <$fh>) {
             chomp $line;
-            next if ($line =~ m/^#/);
+            next if ($line =~ m/^\s*#/);
             next if ($line =~ m/^\s*$/);
 
             if($line =~ m/^Host\s+=?\s*(.*)$/) {


### PR DESCRIPTION
This patch removes a bunch of warnings of the form:

```
Use of uninitialized value $val in substitution (s///) at /usr/share/perl5/site_perl/Rex/Config.pm line 484, <$fh> line 165.
Use of uninitialized value $val in substitution (s///) at /usr/share/perl5/site_perl/Rex/Config.pm line 485, <$fh> line 165.
Use of uninitialized value $key in lc at /usr/share/perl5/site_perl/Rex/Config.pm line 487, <$fh> line 165.
Use of uninitialized value $val in substitution (s///) at /usr/share/perl5/site_perl/Rex/Config.pm line 484, <$fh> line 119.
Use of uninitialized value $val in substitution (s///) at /usr/share/perl5/site_perl/Rex/Config.pm line 485, <$fh> line 119.
Use of uninitialized value $key in lc at /usr/share/perl5/site_perl/Rex/Config.pm line 487, <$fh> line 119.
Use of uninitialized value $val in substitution (s///) at /usr/share/perl5/site_perl/Rex/Config.pm line 484, <$fh> line 165.
Use of uninitialized value $val in substitution (s///) at /usr/share/perl5/site_perl/Rex/Config.pm line 485, <$fh> line 165.
Use of uninitialized value $key in lc at /usr/share/perl5/site_perl/Rex/Config.pm line 487, <$fh> line 165.
```
