### PR TITLE
Support password-less sudo

### DIFF
--- a/lib/Rex/Interface/Exec/Sudo.pm
+++ b/lib/Rex/Interface/Exec/Sudo.pm
@@ -39,7 +39,13 @@ sub exec {
    }
 
    my $sudo_password = task->get_sudo_password;
-   return $exec->exec("echo '$sudo_password' | sudo -p '' -S sh -c 'LC_ALL=C $path $cmd'");
+   if(defined($sudo_password) && length($sudo_password)) {
+      return $exec->exec("echo '$sudo_password' | sudo -p '' -S sh -c 'LC_ALL=C $path $cmd'");
+   } else {
+      # support password-less sudo for restrictive sudo configurations
+      # where no (password-less) sh is allowed
+      return $exec->exec("sudo $cmd");
+   }
 }
 
 1;


### PR DESCRIPTION
This commit implements a workaround to make Rex work
with limit sudo rights without a password.

There are setups where certain users are allowed to
use only some commands via sudo but those only without
a password. Those users may even not have any password,
so sudo with a password will obviously not work.

The drawback of this commit is that it looses some features
that come with the former approach (like setting LC_ALL and PATH).
