### PR TITLE
missing update_system sub export

### DIFF
--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -52,7 +52,7 @@ require Rex::Exporter;
 use base qw(Rex::Exporter);
 use vars qw(@EXPORT);
 
-@EXPORT = qw(install update remove installed_packages is_installed update_package_db repository package_provider_for);
+@EXPORT = qw(install update remove update_system installed_packages is_installed update_package_db repository package_provider_for);
 
 =item install($type, $data, $options)
 


### PR DESCRIPTION
Looks like update_system sub is not exported in lib/Rex/Commands/Pkg.pm as I got the following error while tried to use it:

> Bareword "update_system" not allowed while "strict subs" in use
