### PR TITLE
'-t' option should work with '-e' option.

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -302,6 +302,10 @@ sub __run__ {
          exit 1;
       }
 
+      if(exists $opts{'t'}) {
+         parallelism($opts{'t'});
+      }
+
       my $pass_auth = 0;
 
       if($opts{'u'}) {


### PR DESCRIPTION
`rex -t 2 -H "hostA hostB" -e 'run "sleep 10"; say run "uptime"'`
should run in parallel.
