### PR TITLE
Update Task.pm

### DIFF
--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -536,11 +536,11 @@ sub connect {
    $profiler->end("connect");
 
    if($self->connection->is_authenticated) {
-      Rex::Logger::info("Successfully authenticated.") if($self->connection->get_connection_type ne "Local");
+      Rex::Logger::info("Successfully authenticated on $server.") if($self->connection->get_connection_type ne "Local");
       $self->{"__was_authenticated"} = 1;
    }
    else {
-      Rex::Logger::info("Wrong username or password. Or wrong key.", "warn");
+      Rex::Logger::info("Wrong username/password or wrong key on $server.", "warn");
       CORE::exit(1);
    }
 


### PR DESCRIPTION
Add server name to "Successfully authenticated" and "Wrong username" messages. Otherwise, with parallelism, you can't see which server refused you.
