### PR TITLE
added equery for Rex::Pkg::Gentoo in get_installed

### DIFF
--- a/lib/Rex/Pkg/Gentoo.pm
+++ b/lib/Rex/Pkg/Gentoo.pm
@@ -103,7 +103,7 @@ sub get_installed {
       '((?:-r\d+)?)$';                            # revision, eg r12
 
    my @ret;
-   for my $line (run("epm -qa")) {
+   for my $line (can_run("equery") ? run("equery -qC list '*'") : run("epm -qa")) {
       my $r = qr{$pkgregex};
       my ($name, $version, $suffix, $revision) = ($line =~ $r);
       push(@ret, {


### PR DESCRIPTION
Since epm is hardmasked, it's not very likely that most Gentoo users will have it installed.

equery comes from gentoolkit, and is much more likely to be installed, and can generate equivalent output to epm -qa very easily, so I've added a can_run('equery') check to get_installed to toggle behavior.

Cheers!
