### PR TITLE
updated most of Rsync with server-specific auth

### DIFF
--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -87,6 +87,7 @@ sub sync {
    my ($source, $dest, $opt) = @_;
 
    my $current_connection = Rex::get_current_connection();
+   my $server = $current_connection->{server};
    my $cmd;
 
    if(! exists $opt->{download} && $source !~ m/^\//) {
@@ -115,16 +116,16 @@ sub sync {
 
    if($opt && exists $opt->{'download'} && $opt->{'download'} == 1) {
       Rex::Logger::debug("Downloading $source -> $dest");
-      $cmd = "rsync -a -e '\%s' --verbose --stats $params " . Rex::Config->get_user . "\@" . $current_connection->{"server"} . ":"
+      $cmd = "rsync -a -e '\%s' --verbose --stats $params " . $server->get_user . "\@" . $server . ":"
                      . $source . " " . $dest;
    }
    else {
       Rex::Logger::debug("Uploading $source -> $dest");
-      $cmd = "rsync -a -e '\%s' --verbose --stats $params $source " . Rex::Config->get_user . "\@" . $current_connection->{"server"} . ":"
+      $cmd = "rsync -a -e '\%s' --verbose --stats $params $source " . $server->get_user . "\@" . $server . ":"
                      . $dest;
    }
 
-   my $pass = Rex::Config->get_password;
+   my $pass = $server->get_password;
    my @expect_options = ();
 
    if(Rex::Config->get_password_auth) {
@@ -151,7 +152,7 @@ sub sync {
       );
    }
    else {
-      $cmd = sprintf($cmd, 'ssh -i ' . Rex::Config->get_private_key . " -o StrictHostKeyChecking=no ");
+      $cmd = sprintf($cmd, 'ssh -i ' . $server->get_private_key . " -o StrictHostKeyChecking=no ");
       push(@expect_options, [
                               qr{Are you sure you want to continue connecting},
                               sub {


### PR DESCRIPTION
As it was, the Rsync module/command was taking most of its config directly from `Rex::Config`, when `get_current_connection->{server}` is a `Rex::Group::Entry::Server` that has proxy methods for most of what it was using, so now it supports group-specific/server-specific auth for the most part.

I think the only notably missing method during my light conversions here was `get_password_auth`, but I'm not sure it's even supported to have password auth globally and private/public key auth for just one group (or vice versa).
