### PR TITLE
Always print the environments title with the -T option

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -435,7 +435,7 @@ sub __run__ {
              _print_color("      " . join(" ", Rex::Batch->get_batch($batch)) . "\n");
          }
       }
-      _print_color("Environments\n", "yellow") if(Rex::Commands->get_environments);
+      _print_color("Environments\n", "yellow");
       print "  " . join("\n  ", Rex::Commands->get_environments()) . "\n";
 
       my %groups = Rex::Group->get_groups;


### PR DESCRIPTION
The check if there are custom environments is removed because it does not work and the "Environments" headtitle is not displayed.
When listing Enviroments and Task, this prevents environment names looks like tasks.
