### PR TITLE
Rex::Pkg::Gentoo: Fix separator character between package name and version

### DIFF
--- a/lib/Rex/Pkg/Gentoo.pm
+++ b/lib/Rex/Pkg/Gentoo.pm
@@ -57,7 +57,7 @@ sub update {
 
    my $version = $option->{'version'} || '';
    if($version) {
-      $pkg = "=$pkg=$version";
+      $pkg = "=$pkg-$version";
    }
 
    Rex::Logger::debug("Installing $pkg / $version");


### PR DESCRIPTION
Using "=" between package name and version on Gentoo causes emerge to fail with the following error:

!!! '=packagename=version' is not a valid package atom.
!!! Please check ebuild(5) for full details.

This commit fixes that.
