### PR TITLE
Rex::Pkg::Gentoo: Replace get_installed checking method

### DIFF
--- a/lib/Rex/Pkg/Gentoo.pm
+++ b/lib/Rex/Pkg/Gentoo.pm
@@ -103,7 +103,7 @@ sub get_installed {
       '((?:-r\d+)?)$';                            # revision, eg r12
 
    my @ret;
-   for my $line (run("epm -qa")) {
+   for my $line (run("ls -d /var/db/pkg/*/* | cut -d '/' -f6-")) {
       my $r = qr{$pkgregex};
       my ($name, $version, $suffix, $revision) = ($line =~ $r);
       push(@ret, {


### PR DESCRIPTION
Get list of installed packages simply and quickly from /var/db/pkg in
order to don't depend on epm, equery or similar tools.
