### PR TITLE
Turn "eval your Rexfile" into a debug message

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -249,7 +249,7 @@ sub __run__ {
 
       eval {
          my $ok = do($::rexfile);
-         Rex::Logger::info("eval your Rexfile.");
+         Rex::Logger::debug("eval your Rexfile.");
          if(! $ok) {
             Rex::Logger::info("There seems to be an error on some of your required files. $@", "error");
             my @dir = (dirname($::rexfile));


### PR DESCRIPTION
There is no need for this message to be printed on every standard run and it adds noise, which can be particularly annoying for cronjobs.
