### PR TITLE
Silent yum operations, releated to issue #214

### DIFF
--- a/lib/Rex/Pkg/Redhat.pm
+++ b/lib/Rex/Pkg/Redhat.pm
@@ -157,13 +157,13 @@ sub rm_repository {
 sub _yum {
    my (@cmd) = @_;
 
-   my $str = "yum ";
+   my $str;
 
    if($Rex::Logger::debug) {
-      $str .= join(" ", @cmd);
+      $str = join('', "yum", @cmd);
    }
    else {
-      $str .= join(" -q ", @cmd);
+      $str = join('', "yum -q ", @cmd);
    }
 
    return $str;


### PR DESCRIPTION
Corrected command composition with join. Slightly different, without usage of the operator ".=".

The original version didn't work at least with perl 5.10.1
