### PR TITLE
Improve user and group management on OpenWrt

### DIFF
--- a/lib/Rex/User/Linux.pm
+++ b/lib/Rex/User/Linux.pm
@@ -246,7 +246,7 @@ sub user_groups {
 
    my $data_str = i_run "perl $rnd_file $user";
    if($? != 0) {
-      die("Error getting  user list");
+      die("Error getting group list");
    }
 
    Rex::Interface::Fs->create()->unlink($rnd_file);
@@ -280,7 +280,7 @@ sub user_list {
 
    my $data_str = i_run "perl $rnd_file";
    if($? != 0) {
-      die("Error getting  user list");
+      die("Error getting user list");
    }
 
    Rex::Interface::Fs->create()->unlink($rnd_file);
@@ -307,7 +307,7 @@ sub get_user {
 
    my $data_str = i_run "perl $rnd_file $user";
    if($? != 0) {
-      die("Error getting  user information for $user");
+      die("Error getting user information for $user");
    }
 
    Rex::Interface::Fs->create()->unlink($rnd_file);

--- a/lib/Rex/User/OpenWrt.pm
+++ b/lib/Rex/User/OpenWrt.pm
@@ -58,7 +58,7 @@ sub user_groups {
 
    my $data_str = i_run "/usr/bin/id -Gn $user";
    if($? != 0) {
-      die("Error getting  user list");
+      die("Error getting group list");
    }
 
    my $wantarray = wantarray();


### PR DESCRIPTION
These improvements are the results of extensive local testing with rex-build. Generally the aim was to enhance user and group management support on OpenWrt while trying to avoid increasing code complexity by using as most standard/common solutions as possible. Mainly:
- use passwd instead of chpasswd for setting user passwords
- use groupdel and userdel installed from repo and through Rex::User::Linux instead of trying to replicate their functionality
- add Rex::User::OpenWrt::user_list
- various minor fixes

Please review the proposed changes and let me know if something needs to be modified.

ps.: I also prepared a changeset for rex-build to enable tests for OpenWrt related to user/group management
