### PR TITLE
Add service status support for OpenWrt

### DIFF
--- a/lib/Rex/Service/OpenWrt.pm
+++ b/lib/Rex/Service/OpenWrt.pm
@@ -29,8 +29,13 @@ sub new {
 sub status {
    my($self, $service) = @_;
 
-   Rex::Logger::info("status on openwrt not available.", "warn");
-   return 1;
+   i_run "/sbin/start-stop-daemon -K -t -q -n $service";
+
+   if($? == 0) {
+      return 1;
+   }
+
+   return 0;
 }
 
 sub ensure {


### PR DESCRIPTION
This solution is implemented in OpenWrt's built-in service_check()
function as well but it seems that only a few initscripts using it so
far.

This also expects the executable name of the service which is sometimes
different from the service name.
