### PR TITLE
add Pod encoding marker

### DIFF
--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -4,6 +4,8 @@
 # vim: set ts=3 sw=3 tw=0:
 # vim: set expandtab:
 
+=encoding UTF-8
+
 =head1 NAME
 
 Rex - Remote Execution


### PR DESCRIPTION
Hi,

The lack of explicit encoding marker causes mojibakes in place of non-ASCII symbols on [sco](http://search.cpan.org/~jfried/Rex-0.43.7/lib/Rex.pm): `Boris DÃ¤ppen`. [MetaCPAN](https://metacpan.org/pod/Rex) gets it right, but warns at the bottom of the page.

Explicit encoding marker should fix both of those.

Cheers,
Sergey
