### PR TITLE
Uninitialized value in OpenSSH.pm

### DIFF
--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -98,7 +98,7 @@ sub connect {
    $self->{ssh} = Net::OpenSSH->new(@connection_props);
 
    if($self->{ssh} && $self->{ssh}->error) {
-      Rex::Logger::info("Can't connect to $server (" . $self->{ssh}->{error} . ")", "warn");
+      Rex::Logger::info("Can't connect to $server (" . $self->{ssh}->error() . ")", "warn");
       $self->{connected} = 0;
 
       return;


### PR DESCRIPTION
This should fix the following warning when a host is unreachable:
Use of uninitialized value in concatenation (.) or string at /usr/local/share/perl/5.14.2/Rex/Interface/Connection/OpenSSH.pm line 101
