### PR TITLE
Make quiet mode not mute warnings and errors.

### DIFF
--- a/lib/Rex/Logger.pm
+++ b/lib/Rex/Logger.pm
@@ -138,10 +138,10 @@ sub info {
    }
 
    if($no_color) {
-      print STDERR "$msg\n" unless($::QUIET);
+      print STDERR "$msg\n" if ((defined $type and not $type eq 'info') or not ($::QUIET));
    }
    else {
-      print STDERR colored([$color], "$msg\n") unless($::QUIET);
+      print STDERR colored([$color], "$msg\n") if ((defined $type and not $type eq 'info') or not ($::QUIET));
    }
 
    # workaround for windows Sys::Syslog behaviour on forks


### PR DESCRIPTION
Before -q (quiet mode) would mute not only 'info' type
of messages but also errors and warnings, with
high parallelism and quiet flag it was impossible to
find remote boxes that rex failed to execute to.

If one really desire muting everything, should consider
redirecting stderr and stdout to /dev/null.
