### PR TITLE
Support for DBI \%attr hashref in Rex::Commands::DB

### DIFF
--- a/lib/Rex/Commands/DB.pm
+++ b/lib/Rex/Commands/DB.pm
@@ -195,7 +195,7 @@ sub import {
    my ($class, $opt) = @_;
 
    if($opt) {
-      $dbh = DBI->connect($opt->{"dsn"}, $opt->{"user"}, $opt->{"password"} || "");  
+      $dbh = DBI->connect($opt->{"dsn"}, $opt->{"user"}, $opt->{"password"} || "", $opt->{"attr"} );  
       $dbh->{mysql_auto_reconnect} = 1;
    }
 


### PR DESCRIPTION
This is needed to correctly use DBD::CSV or other special DBD
parameters.
