### PR TITLE
fix losing port forwarding info except the last one

### DIFF
--- a/lib/Rex/Box/VBox.pm
+++ b/lib/Rex/Box/VBox.pm
@@ -324,10 +324,12 @@ sub info {
    # get forwarded ports
    my @forwarded_ports = grep { m/^Forwarding/ } keys %{ $vm_info };
 
+   my %forward_port;
    for my $fwp (@forwarded_ports) {
       my ($name, $proto, $host_ip, $host_port, $vm_ip, $vm_port) = split(/,/, $vm_info->{$fwp});
-      $self->forward_port($name => [$host_port, $vm_port]);
+      $forward_port{$name} = [$host_port, $vm_port];
    }
+   $self->forward_port(%forward_port);
 
    return $self->{info};
 }


### PR DESCRIPTION
Current forward_port() of Rex::Box::VBox could handle
port forwarding information at one shot.
So at the end of the loop there is only one port forwarding
information is left and other one will be lost.

This patch does gather all port forwarding information
then save them after the loop.
