### PR TITLE
Support LibVirt connect URI parameter (fix #291)

### DIFF
--- a/lib/Rex/Virtualization/LibVirt/blklist.pm
+++ b/lib/Rex/Virtualization/LibVirt/blklist.pm
@@ -19,6 +19,8 @@ sub execute {
    shift;
    my $vmname = shift;
    my %options = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($vmname) {
       die("You have to define the vm name!");
@@ -26,7 +28,7 @@ sub execute {
 
    Rex::Logger::debug("Getting block list of domain: $vmname");
 
-   my @blklist = i_run "virsh domblklist $vmname --details";
+   my @blklist = i_run "virsh -c $uri domblklist $vmname --details";
 
    if($? != 0) {
       die("Error running virsh domblklist $vmname");
@@ -50,7 +52,7 @@ sub execute {
       if ($options{details}) {
          my $unit = $options{unit} || 1;
          for my $target (keys %ret) {
-            my @infos = i_run "virsh domblkinfo $vmname $target 2>/dev/null";
+            my @infos = i_run "virsh -c $uri domblkinfo $vmname $target 2>/dev/null";
             if($? == 0) {
                for my $line (@infos) {
                   my ($k, $v) = split(/:\s+/, $line);

--- a/lib/Rex/Virtualization/LibVirt/create.pm
+++ b/lib/Rex/Virtualization/LibVirt/create.pm
@@ -38,6 +38,8 @@ my @data = <DATA>;
 
 sub execute {
    my ($class, $name, %opt) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    my $opts = \%opt;
    $opts->{"name"} = $name;
@@ -104,7 +106,7 @@ sub execute {
    file "$file_name",
       content => $parsed_template;
 
-   i_run "virsh define $file_name";
+   i_run "virsh -c $uri define $file_name";
    unlink($file_name);
    if($? != 0) {
      die("Error defining vm $opts->{name}");

--- a/lib/Rex/Virtualization/LibVirt/delete.pm
+++ b/lib/Rex/Virtualization/LibVirt/delete.pm
@@ -14,6 +14,8 @@ use Rex::Helper::Run;
 
 sub execute {
    my ($class, $arg1) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($arg1) {
       die("You have to define the vm name!");
@@ -26,7 +28,7 @@ sub execute {
       die("VM $dom not found.");
    }
 
-   i_run "virsh undefine $dom";
+   i_run "virsh -c $uri undefine $dom";
    if($? != 0) {
       die("Error destroying vm $dom");
    }

--- a/lib/Rex/Virtualization/LibVirt/destroy.pm
+++ b/lib/Rex/Virtualization/LibVirt/destroy.pm
@@ -14,6 +14,8 @@ use Rex::Helper::Run;
 
 sub execute {
    my ($class, $arg1, %opt) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($arg1) {
       die("You have to define the vm name!");
@@ -26,7 +28,7 @@ sub execute {
       die("VM $dom not found.");
    }
 
-   i_run "virsh destroy $dom";
+   i_run "virsh -c $uri destroy $dom";
    if($? != 0) {
       die("Error destroying vm $dom");
    }

--- a/lib/Rex/Virtualization/LibVirt/dumpxml.pm
+++ b/lib/Rex/Virtualization/LibVirt/dumpxml.pm
@@ -18,6 +18,8 @@ use Data::Dumper;
 
 sub execute {
    my ($class, $vmname) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($vmname) {
       die("You have to define the vm name!");
@@ -27,7 +29,7 @@ sub execute {
 
    my $xml;
 
-   my $dumpxml = i_run "virsh dumpxml $vmname";
+   my $dumpxml = i_run "virsh -c $uri dumpxml $vmname";
   
    if($? != 0) {
       die("Error running virsh dumpxml $vmname");

--- a/lib/Rex/Virtualization/LibVirt/hypervisor.pm
+++ b/lib/Rex/Virtualization/LibVirt/hypervisor.pm
@@ -18,6 +18,8 @@ use Data::Dumper;
 
 sub execute {
    my ($class, $arg1, %opt) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($arg1) {
       die("You have to define the vm name!");
@@ -25,7 +27,7 @@ sub execute {
 
    my ($xml, @dominfo, $dom);
    if ($arg1 eq 'capabilities') {
-      @dominfo = i_run "virsh capabilities";
+      @dominfo = i_run "virsh -c $uri capabilities";
       if($? != 0) {
          die("Error running virsh dominfo $dom");
       }

--- a/lib/Rex/Virtualization/LibVirt/info.pm
+++ b/lib/Rex/Virtualization/LibVirt/info.pm
@@ -18,6 +18,8 @@ use Data::Dumper;
 
 sub execute {
    my ($class, $vmname) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($vmname) {
       die("You have to define the vm name!");
@@ -27,7 +29,7 @@ sub execute {
 
    my $xml;
 
-   my @dominfo = i_run "virsh dominfo $vmname";
+   my @dominfo = i_run "virsh -c $uri dominfo $vmname";
   
    if($? != 0) {
       die("Error running virsh dominfo $vmname");

--- a/lib/Rex/Virtualization/LibVirt/list.pm
+++ b/lib/Rex/Virtualization/LibVirt/list.pm
@@ -16,15 +16,18 @@ use Data::Dumper;
 
 sub execute {
    my ($class, $arg1, %opt) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
+
    my @domains;
 
    if($arg1 eq "all") {
-      @domains = i_run "virsh list --all";
+      @domains = i_run "virsh -c $uri list --all";
       if($? != 0) {
          die("Error running virsh list --all");
       }
    } elsif($arg1 eq "running") {
-      @domains = i_run "virsh list";
+      @domains = i_run "virsh -c $uri list";
       if($? != 0) {
          die("Error running virsh list");
       }

--- a/lib/Rex/Virtualization/LibVirt/option.pm
+++ b/lib/Rex/Virtualization/LibVirt/option.pm
@@ -19,6 +19,8 @@ my $FUNC_MAP = {
 
 sub execute {
    my ($class, $arg1, %opt) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($arg1) {
       die("You have to define the vm name!");
@@ -36,7 +38,7 @@ sub execute {
       }
 
       my $func = $FUNC_MAP->{$opt};
-      i_run "virsh $func $dom $val";
+      i_run "virsh -c $uri $func $dom $val";
       if($? != 0) {
          Rex::Logger::info("Error setting $opt to $val on $dom ($@)", "warn");
       }

--- a/lib/Rex/Virtualization/LibVirt/reboot.pm
+++ b/lib/Rex/Virtualization/LibVirt/reboot.pm
@@ -14,6 +14,8 @@ use Rex::Helper::Run;
 
 sub execute {
    my ($class, $arg1, %opt) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($arg1) {
       die("You have to define the vm name!");
@@ -26,7 +28,7 @@ sub execute {
       die("VM $dom not found.");
    }
 
-   i_run "virsh reboot $dom";
+   i_run "virsh -c $uri reboot $dom";
    if($? != 0) {
       die("Error rebooting vm $dom");
    }

--- a/lib/Rex/Virtualization/LibVirt/shutdown.pm
+++ b/lib/Rex/Virtualization/LibVirt/shutdown.pm
@@ -14,6 +14,8 @@ use Rex::Helper::Run;
 
 sub execute {
    my ($class, $arg1, %opt) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($arg1) {
       die("You have to define the vm name!");
@@ -26,7 +28,7 @@ sub execute {
       die("VM $dom not found.");
    }
 
-   i_run "virsh shutdown $dom";
+   i_run "virsh -c $uri shutdown $dom";
    if($? != 0) {
       die("Error shutdown vm $dom");
    }

--- a/lib/Rex/Virtualization/LibVirt/start.pm
+++ b/lib/Rex/Virtualization/LibVirt/start.pm
@@ -14,6 +14,8 @@ use Rex::Helper::Run;
 
 sub execute {
    my ($class, $arg1, %opt) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($arg1) {
       die("You have to define the vm name!");
@@ -26,7 +28,7 @@ sub execute {
       die("VM $dom not found.");
    }
 
-   i_run "virsh start $dom";
+   i_run "virsh -c $uri start $dom";
    if($? != 0) {
       die("Error starting vm $dom");
    }

--- a/lib/Rex/Virtualization/LibVirt/vncdisplay.pm
+++ b/lib/Rex/Virtualization/LibVirt/vncdisplay.pm
@@ -18,6 +18,8 @@ use Data::Dumper;
 
 sub execute {
    my ($class, $vmname) = @_;
+   my $virt_settings = Rex::Config->get("virtualization");
+   chomp( my $uri = ref($virt_settings) ? $virt_settings->{connect} : i_run "virsh uri" );
 
    unless($vmname) {
       die("You have to define the vm name!");
@@ -27,7 +29,7 @@ sub execute {
 
    my $xml;
 
-   my @vncdisplay = i_run "virsh vncdisplay $vmname";
+   my @vncdisplay = i_run "virsh -c $uri vncdisplay $vmname";
   
    if($? != 0) {
       die("Error running virsh vncdisplay $vmname");

--- a/t/virtualization.t
+++ b/t/virtualization.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 5;
+use Test::More tests => 7;
 
 use_ok 'Rex';
 use_ok 'Rex::Commands';
@@ -11,3 +11,9 @@ use_ok 'Rex::Commands::Virtualization';
 Rex::Commands::set(virtualization => "LibVirt");
 ok(Rex::Config->get("virtualization") eq "LibVirt", "set virtualization handler");
 
+Rex::Commands::set(
+    virtualization => { "type" => "LibVirt", "connect" => "qemu:///system", } );
+is( Rex::Config->get("virtualization")->{type},
+    "LibVirt", "Virtualization type with connection URI" );
+is( Rex::Config->get("virtualization")->{connect},
+    "qemu:///system", "Virtualization URI with connection URI" );


### PR DESCRIPTION
Try to get the value of a connect key from virtualization config options
if it has been specified as a reference, and use that with virsh as
connect URI. Also tries to fall back to use the default LibVirt
connection parameters.
