### PR TITLE
only pass actual option strings to prevent ssh crashes

### DIFF
--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -74,10 +74,10 @@ sub connect {
    my @connection_props = ($server, user => $user, port => $port);
    push @connection_props, master_opts => [
                               -o => $ssh_opts_line,
-                           ];
+                           ] if $ssh_opts_line;
    push @connection_props, default_ssh_opts => [
                               -o => $ssh_opts_line,
-                           ];
+                           ] if $ssh_opts_line;
 
    if($auth_type && $auth_type eq "pass") {
       Rex::Logger::debug("OpenSSH: pass_auth: $server:$port - $user - ******");


### PR DESCRIPTION
Using Net::OpenSSH it is currently possible to pass empty options to the ssh program which makes it crash every once in a while (at least on one of my machines).
Debugging on Net::OpenSSH level I found the following ssh command:
# open_ex: ['ssh','-o','','-S',...]

Note the empty option string - isolated testing confirmed the same crashes with this.

So the changes in this commit make sure only non-zero options are passed along which avoids those types of crashes.

Cheers,
Simon
