### PR TITLE
add ksh to shells

### DIFF
--- a/lib/Rex/Interface/Shell/Ksh.pm
+++ b/lib/Rex/Interface/Shell/Ksh.pm
@@ -1,0 +1,26 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+# 
+# vim: set ts=3 sw=3 tw=0:
+# vim: set expandtab:
+   
+package Rex::Interface::Shell::Ksh;
+
+use strict;
+use warnings;
+
+use Rex::Interface::Shell::Bash;
+
+use base qw(Rex::Interface::Shell::Bash);
+
+sub new {
+    my $class = shift;
+    my $proto = ref($class) || $class;
+    my $self = $proto->SUPER::new(@_);
+
+    bless($self, $class);
+    
+    return $self;
+}
+
+1;


### PR DESCRIPTION
Got warnings about ksh not being recognized on some boxes:

[2014-02-13 19:11:29] WARN - Can't load wanted shell: ksh. Using default shell.
[2014-02-13 19:11:29] WARN - If you want to help the development of Rex please report this issue in our Github issue tracker.

The commit makes it a bash based one as that seems closest and just works.

Cheers,
Simon
