### PR TITLE
use ssh agent when environment indicates it and no key was configured

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -377,6 +377,9 @@ sub get_public_key {
    if($public_key) {
       return $public_key;
    }
+   elsif($ENV{SSH_AUTH_SOCK}) {
+      return undef;
+   }
 
    return _home_dir() . '/.ssh/id_rsa.pub';
 }
@@ -393,6 +396,9 @@ sub has_private_key {
 sub get_private_key {
    if($private_key) {
       return $private_key;
+   }
+   elsif($ENV{SSH_AUTH_SOCK}) {
+      return undef;
    }
 
    return _home_dir() . '/.ssh/id_rsa';


### PR DESCRIPTION
Using Rex only with an ssh agent but no local keys always gives this warning for every host:

Warning: Identity file $HOME/.ssh/id_rsa not accessible: No such file or directory.

This commit just prevents default file locations when SSH_AUTH_SOCK is set,
maybe a better fix would be a file check. But then again the full list of possible
keys would have to be checked and I wonder if an empty default would not simply
do the trick instead.
Any thoughts on that?

Cheers,
Simon
