### PR TITLE
do not call sprintf on undefined values to prevent warnings

### DIFF
--- a/lib/Rex/Hardware/Network/FreeBSD.pm
+++ b/lib/Rex/Hardware/Network/FreeBSD.pm
@@ -34,8 +34,9 @@ sub get_network_configuration {
 
       $device_info->{$dev} = {
          ip          => [ ( $ifconfig =~ m/inet (\d+\.\d+\.\d+\.\d+)/ ) ]->[0],
-         netmask     => sprintf ("%d.%d.%d.%d", unpack "C4", pack "H*",
-            [ ( $ifconfig =~ m/(netmask 0x|netmask )([a-f0-9]+)/ ) ]->[1] ),
+         netmask     => $ifconfig =~ m/(?:netmask 0x|netmask )([a-f0-9]+)/
+            ? sprintf("%d.%d.%d.%d", unpack "C4", pack "H*", $1 )
+            : undef,
          broadcast   => [ ( $ifconfig =~ m/broadcast (\d+\.\d+\.\d+\.\d+)/ ) ]->[0],
          mac         => [ ( $ifconfig =~ m/(ether|address:|lladdr) (..?:..?:..?:..?:..?:..?)/ ) ]->[1],
       };


### PR DESCRIPTION
On FreeBSD (and OpenBSD which inherits from that class) interfaces without assigned ip address lead to a bunch of warnings:

Use of uninitialized value in pack at /home/simon/Code/Rex/lib/Rex/Hardware/Network/FreeBSD.pm line 35, <> line 15.
Missing argument in sprintf at /home/simon/Code/Rex/lib/Rex/Hardware/Network/FreeBSD.pm line 35, <> line 15.
Missing argument in sprintf at /home/simon/Code/Rex/lib/Rex/Hardware/Network/FreeBSD.pm line 35, <> line 15.
Missing argument in sprintf at /home/simon/Code/Rex/lib/Rex/Hardware/Network/FreeBSD.pm line 35, <> line 15.
Missing argument in sprintf at /home/simon/Code/Rex/lib/Rex/Hardware/Network/FreeBSD.pm line 35, <> line 15.

With this commit pack() and sprintf() are only called with actual values and the warnings are gone.

Cheers,
Simon
