### PR TITLE
make ssh probe for the right keys

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -378,7 +378,7 @@ sub get_public_key {
       return $public_key;
    }
 
-   return _home_dir() . '/.ssh/id_rsa.pub';
+   return undef;
 }
 
 sub set_private_key {
@@ -395,7 +395,7 @@ sub get_private_key {
       return $private_key;
    }
 
-   return _home_dir() . '/.ssh/id_rsa';
+   return undef;
 }
 
 sub set_parallelism {


### PR DESCRIPTION
As discussed on IRC the SSH program will probe for local keys anyways and will find what is needed to work, so this commit removes the default.
That also makes ssh work when there are no local keys but a running ssh agent.

Cheers,
Simon
