### PR TITLE
Support df by mountpoint and directory like df(1)

### DIFF
--- a/lib/Rex/Commands/Fs.pm
+++ b/lib/Rex/Commands/Fs.pm
@@ -710,17 +710,10 @@ sub df {
    $ret = _parse_df(@lines);
 
    if($dev) {
-      if ( exists $ret->{$dev} ) {
-         return $ret->{$dev};
+      if ( keys %$ret == 1 ) {
+         ( $dev ) = keys %$ret;
       }
-      my %mounted_on = map +( $_->{mounted_on}, $_ ), values %$ret;
-      if ( exists $mounted_on{$dev} ) {
-         return $mounted_on{$dev};
-      }
-      my @mounted_on = keys %mounted_on;
-      return @mounted_on == 1
-           ? $mounted_on{ $mounted_on[0] }
-           : undef;
+      return $ret->{$dev};
    }
 
    return $ret;


### PR DESCRIPTION
Currently Rex only supports df (disk free) on specific devices but does not allow to query a mount point or directory like the df(1) command.
With this commit Rex first checks for existence of a device and then tries to look up a matching mount point, and in case df(1) returns exactly one match it just passes it along like df(1).

Cheers,
Simon
