### PR TITLE
get as much output from ps(1) as possible

### DIFF
--- a/lib/Rex/Commands/Process.pm
+++ b/lib/Rex/Commands/Process.pm
@@ -142,18 +142,18 @@ sub ps {
    
    elsif(operating_system_is("SunOS") && operating_system_version() <= 510) {
       if(@custom) {
-         @list = run("/usr/ucb/ps ax -o" . join(",", @custom));
+         @list = run("/usr/ucb/ps awwx -o" . join(",", @custom));
       }
       else {
-         @list = run("/usr/ucb/ps aux");
+         @list = run("/usr/ucb/ps auwwx");
       }
    }
    else {
       if(@custom) {
-         @list = run("ps ax -o" . join(",", @custom));
+         @list = run("ps awwx -o" . join(",", @custom));
       }
       else {
-         @list = run("ps aux");
+         @list = run("ps auwwx");
       }
    }
 


### PR DESCRIPTION
Currently Rex relies on the ps(1) default for the window size, which is probably 80 or so in most cases and does not cover all possible output.
This commit adds the -w flag two times which gives full width lines as output.

Cheers,
Simon
