### PR TITLE
update _parse_ip subroutine. be possible to parse ppp0.

### DIFF
--- a/lib/Rex/Hardware/Network/Linux.pm
+++ b/lib/Rex/Hardware/Network/Linux.pm
@@ -140,6 +140,12 @@ sub _parse_ip {
             $dev->{$cur_dev}->{netmask} = _convert_cidr_prefix($cidr_prefix);
          }
       }
+
+      # ppp
+      if($line =~ m/^\s*inet (\d+\.\d+\.\d+\.\d+) peer (\d+\.\d+\.\d+\.\d+)\/(\d+)/) {
+         $dev->{$cur_dev}->{ip} = $1;
+         $dev->{$cur_dev}->{netmask} = _convert_cidr_prefix($3);
+      }
    }
 
    return $dev;

--- a/t/ifconfig.out7
+++ b/t/ifconfig.out7
@@ -1,0 +1,7 @@
+ppp0      Link encap:Point-to-Point Protocol
+          inet addr:123.117.251.17  P-t-P:234.165.249.179  Mask:255.255.255.255
+          UP POINTOPOINT RUNNING NOARP MULTICAST  MTU:1454  Metric:1
+          RX packets:4143329786 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:754829057 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:3
+          RX bytes:1171440390 (1.0 GiB)  TX bytes:121847007 (116.2 MiB)

--- a/t/ip.out3
+++ b/t/ip.out3
@@ -1,0 +1,3 @@
+4: ppp0: <POINTOPOINT,MULTICAST,NOARP,UP> mtu 1454 qdisc pfifo_fast qlen 3
+    link/ppp
+    inet 123.117.251.17 peer 234.165.249.179/32 scope global ppp0

--- a/t/network_linux.t
+++ b/t/network_linux.t
@@ -1,5 +1,5 @@
 use Data::Dumper;
-use Test::More tests => 38;
+use Test::More tests => 46;
 use_ok 'Rex::Hardware::Network::Linux';
 use_ok 'Rex::Helper::Hash';
 
@@ -70,4 +70,16 @@ ok($info->{"eth0:1"}->{ip} eq "1.2.3.4", "(fc19) eth0:1 / ip");
 ok($info->{"eth0:1"}->{netmask} eq "255.255.0.0", "(fc19) eth0:1 / netmask");
 ok($info->{"eth0:1"}->{mac} eq "52:54:00:37:a8:e1", "(fc19) eth0:1 / mac");
 
+@in = eval { local(@ARGV) = ("t/ifconfig.out7"); <>; };
+$info = Rex::Hardware::Network::Linux::_parse_ifconfig(@in);
+ok($info->{ppp0}->{ip} eq "123.117.251.17", "ppp0 / ip");
+ok($info->{ppp0}->{netmask} eq "255.255.255.255", "ppp0 / netmask");
+ok($info->{ppp0}->{broadcast} eq "", "ppp0 / broadcast");
+ok($info->{ppp0}->{mac} eq "", "ppp0 / mac");
 
+@in = eval { local(@ARGV) = ("t/ip.out3"); <>; };
+$info = Rex::Hardware::Network::Linux::_parse_ip(@in);
+ok($info->{ppp0}->{ip} eq "123.117.251.17", "ppp0 / ip");
+ok($info->{ppp0}->{netmask} eq "255.255.255.255", "ppp0 / netmask");
+ok($info->{ppp0}->{broadcast} eq "", "ppp0 / broadcast");
+ok($info->{ppp0}->{mac} eq "", "ppp0 / mac");


### PR DESCRIPTION
Hello.

I commited https://github.com/krimdomu/Rex/commit/baa6385e4fe176a9099fd82264b5f1e1904f69a0 .

Rex is no longer match ppp0 from _parse_ip subroutine added.

I have changed to match again.

Please merge if it is good.
