### PR TITLE
A jiffybox can be started after creation automatically (with preferences...

### DIFF
--- a/lib/Rex/Cloud/Jiffybox.pm
+++ b/lib/Rex/Cloud/Jiffybox.pm
@@ -152,7 +152,7 @@ sub run_instance {
 
   ($data) = grep { $_->{"id"} eq $instance_id } $self->list_instances();
 
-  while($data->{"state"} ne "STOPPED") {
+  while($data->{"state"} ne "STOPPED" && $data->{"state"} ne "RUNNING") {
     Rex::Logger::debug("Waiting for instance to be created...");
     ($data) = grep { $_->{"id"} eq $instance_id } $self->list_instances();
 


### PR DESCRIPTION
... in JiffyBox), so that Rex might miss the state 'STOPPED'. Rex ended in an endless loop then...
