### PR TITLE
modify Rex::Commands::MD5. use /sbin/md5 on *BSD.

### DIFF
--- a/lib/Rex/Commands/MD5.pm
+++ b/lib/Rex/Commands/MD5.pm
@@ -84,7 +84,12 @@ sub md5 {
     }
 
     unless($? == 0) {
-      ($md5) = split(/\s/, $exec->exec("md5sum '$file'"));
+      if($^O =~ /bsd/) {
+        $md5 = $exec->exec("/sbin/md5 -q '$file'");
+      }
+      else {
+        ($md5) = split(/\s/, $exec->exec("md5sum '$file'"));
+      }
     }
 
     unless($? == 0) {


### PR DESCRIPTION
Hello.

*BSD has /sbin/md5 as base system, md5sum is not.
