### PR TITLE
added exclude option to sync commands

### DIFF
--- a/lib/Rex/Commands/Sync.pm
+++ b/lib/Rex/Commands/Sync.pm
@@ -133,7 +133,7 @@ sub sync_up {
   #
 
   for my $file (@diff) {
-    next if $file->{name} ~~ @excluded_files;
+    next if grep { $_ eq $file->{name} } @excluded_files;
 
     my ($dir)      = ($file->{path} =~ m/(.*)\/[^\/]+$/);
     my ($remote_dir) = ($file->{name} =~ m/\/(.*)\/[^\/]+$/);
@@ -263,7 +263,7 @@ sub sync_down {
   #
 
   for my $file (@diff) {
-    next if $file->{name} ~~ @excluded_files;
+    next if grep { $_ eq $file->{name} } @excluded_files;
 
     my ($dir)      = ($file->{path} =~ m/(.*)\/[^\/]+$/);
     my ($remote_dir) = ($file->{name} =~ m/\/(.*)\/[^\/]+$/);


### PR DESCRIPTION
Added an exclude argument to Rex::Commands::Sync::sync_up & sync_down. Should be mostly inline with the exclude argument in the Rsync.pm module.

Usage:

``` perl
desc 'Sync test';
task 'sync', sub {
    use Rex::Commands::Sync;

    sync_up '.', '/tmp/test',
    exclude => ['log/*', 'init.d/', '*.conf'];
};
```
