### PR TITLE
allow set callback and environment together

### DIFF
--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -112,7 +112,7 @@ sub run {
   if ( ref $_[0] eq "CODE" ) {
     $code = shift;
   }
-  elsif ( scalar @_ > 0 ) {
+  if ( scalar @_ > 0 ) {
     $option = {@_};
   }
 


### PR DESCRIPTION
Example:
run "my_command", sub {
     my ($stdout, $stderr) = @_;
     my $server = Rex::get_current_connection()->{server};
     say "[$server] $stdout\n";
   },
   env => {
     env_var_1 => "the value for 1",
     env_var_2 => "the value for 2",
   };
