### PR TITLE
Switch off command echoing in SSH shell

### DIFF
--- a/lib/Rex/Helper/SSH2/Expect.pm
+++ b/lib/Rex/Helper/SSH2/Expect.pm
@@ -78,6 +78,7 @@ sub new {
   $self->{"__shell"} = $_[0]->channel();
   $self->{"__shell"}->pty("vt100");
   $self->{"__shell"}->shell;
+  $self->{"__shell"}->write("stty -echo\n");
 
   $self->{"__log_stdout"} = $Rex::Helper::SSH2::Expect::Log_Stdout;
   $self->{"__log_to"} = sub {};
@@ -224,4 +225,3 @@ sub _log {
 =cut
 
 1;
-


### PR DESCRIPTION
When using Rex::Helper::SSH2::Expect, commands sent to an SSH shell might be echoed, then match a pattern and trigger the assigned commands. To prevent this, command echoing of the SSH shell is now switched off.
