### PR TITLE
directory removal using "file XXXX, ensure => 'absent' not working (#381 fix)

### DIFF
--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -471,6 +471,8 @@ sub file {
       #### check and run after_change hook
       Rex::Hook::run_hook( file => "after_change", @_, $__ret );
       ##############################
+      
+      goto FINISH_FILE; # Following tasks are not needed. otherwise a file will be created instead of the removed directory.
 
     }
     elsif ( $option->{ensure} eq "directory" ) {
@@ -490,7 +492,7 @@ sub file {
     }
   }
 
-  if ( !exists $option->{content} && !exists $option->{source} ) {
+  if ( !exists $option->{content} && !exists $option->{source} )  {
 
     # no content and no source, so just verify that the file is present
     if ( !$fs->is_file($file) && !$is_directory ) {
@@ -581,15 +583,15 @@ sub file {
       $__ret = { changed => 1 };
     }
   }
-
-  #### check and run before hook
-  Rex::Hook::run_hook( file => "after", @_, $__ret );
-  ##############################
-
-  Rex::get_current_connection()->{reporter}
-    ->report_resource_end( type => "file", name => $file );
-
-  return $__ret->{changed};
+  FINISH_FILE:
+	  #### check and run before hook
+	  Rex::Hook::run_hook( file => "after", @_, $__ret );
+	  ##############################
+	
+	  Rex::get_current_connection()->{reporter}
+	    ->report_resource_end( type => "file", name => $file );
+	
+	  return $__ret->{changed};
 }
 
 =item file_write($file_name)

--- a/lib/Rex/Interface/Fs/OpenSSH.pm
+++ b/lib/Rex/Interface/Fs/OpenSSH.pm
@@ -1,5 +1,6 @@
 #
 # (c) Jan Gehring <jan.gehring@gmail.com>
+#
 # 
 # vim: set ts=2 sw=2 tw=0:
 # vim: set expandtab:
@@ -13,7 +14,7 @@ use Fcntl;
 use Rex::Interface::Exec;
 use Rex::Interface::Fs::SSH;
 use Net::SFTP::Foreign::Constants qw(:flags);
-use base qw(Rex::Interface::Fs::SSH);
+use base 						  qw(Rex::Interface::Fs::SSH);
 
 require Rex::Commands;
 
@@ -51,40 +52,6 @@ sub ls {
   return @ret;
 }
 
-sub is_dir {
-  my ($self, $path) = @_;
-
-  my $ret = 0;
-
-  Rex::Commands::profiler()->start("is_dir: $path");
-  my $sftp = Rex::get_sftp();
-  if(my $hndl = $sftp->opendir($path)) {
-    # return true if $path can be opened as a directory
-    $sftp->closedir($hndl);
-    $ret = 1;
-  }
-  Rex::Commands::profiler()->end("is_dir: $path");
-
-  return $ret;
-}
-
-sub is_file {
-  my ($self, $file) = @_;
-
-  my $ret;
-
-  my $sftp = Rex::get_sftp();
-  Rex::Commands::profiler()->start("is_file: $file");
-  if(my $hndl = $sftp->open($file, SSH2_FXF_READ) ) {
-    # return true if $file can be opened read only
-    $sftp->close($hndl);
-    $ret = 1;
-  }
-  Rex::Commands::profiler()->end("is_file: $file");
-
-  return $ret;
-}
-
 sub unlink {
   my ($self, @files) = @_;
 
@@ -113,6 +80,7 @@ sub stat {
     gid => $ret->gid,
     atime => $ret->atime,
     mtime => $ret->mtime,
+    perms => $ret->perm
   );
 
   Rex::Commands::profiler()->end("stat: $file");


### PR DESCRIPTION
1) 'open' test in SSH2 was returning true even if the target is a
directory. the "is_file" & "is_dir" were pushed to the base class and
both are using "stat" to get the perms flags (SSH & OpenSSH "stat" were
updated to return these in the stat's hash) and Fcntl call (hopefully
wont break windows stuff...)

2) in file (File.pm) after the ensure absent section is completed, a
file is created, this is no needed. a "dirty" goto was added.

Conflicts:
    lib/Rex/Group/Entry/Server.pm
