### PR TITLE
Rex::Output to persist across different processes (forks)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -18,6 +18,7 @@ my %deps = (
   'List::MoreUtils'       => 0,
   'XML::LibXML'           => 0,
   'Parallel::ForkManager' => 0,
+  'IPC::Shareable'        => 0
 );
 
 if ( $^O =~ m/^MSWin/ ) {

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -570,7 +570,7 @@ CHECK_OVERWRITE: {
   for my $exit_hook (@exit) {
     &$exit_hook();
   }
-
+  Rex::Output->get->write() if ( defined Rex::Output->get );
   if ($Rex::WITH_EXIT_STATUS) {
     for my $exit_code (@exit_codes) {
       if ( $exit_code != 0 ) {

--- a/lib/Rex/Output/Base.pm
+++ b/lib/Rex/Output/Base.pm
@@ -1,0 +1,13 @@
+#
+# (c) Nathan Abu <aloha2004@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Output::Base;
+
+sub write { die "Must be implemented by inheriting class" }
+sub add   { die "Must be implemented by inheriting class" }
+sub error { die "Must be implemented by inheriting class" }
+
+1;


### PR DESCRIPTION
It does not persist. for instance, creating a batch of tasks and
running:
rex -o JUnit -b batch_name

junit xml file will include _only_ the very first task and not an
aggregation of all the tasks executed during the batch, this is because
the JUnit destructor will be called after the first task's process is
completed, the junit file will be written and any subsequent call wont
do what it needs to.

Using IPC::Shareable to share the object across different processes in
addition to some design changes.
