### PR TITLE
return array as other list function

### DIFF
--- a/lib/Rex/Cloud/OpenStack.pm
+++ b/lib/Rex/Cloud/OpenStack.pm
@@ -283,7 +283,9 @@ sub list_flavors {
 
   Rex::Logger::debug('Listing flavors');
 
-  $self->_request( GET => $nova_url . '/flavors' );
+  my $flavors = $self->_request( GET => $nova_url . '/flavors' );
+  confess "Error getting cloud flavors." if ( !exists $flavors->{flavors} );
+  return @{ $flavors->{flavors} };
 }
 
 sub list_plans { return shift->list_flavors; }


### PR DESCRIPTION
Hi,

fix list_flavor to return array of hash like other list functions.
Not sure of the impact on other part of Rex.
