### PR TITLE
Fixing a typo in the getops & releasing shared memory segments

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -570,8 +570,9 @@ CHECK_OVERWRITE: {
     &$exit_hook();
   }
 
-  if ( $opts{'o'} ) {
-    Rex::Output->get->write() if ( defined Rex::Output->get );
+  if ( $opts{'o'} && defined(Rex::Output->get) ) {
+    Rex::Output->get->write();
+    IPC::Shareable->clean_up_all();
   }
 
   if ($Rex::WITH_EXIT_STATUS) {

--- a/lib/Rex/Interface/Executor/Default.pm
+++ b/lib/Rex/Interface/Executor/Default.pm
@@ -53,7 +53,7 @@ sub exec {
     }
   }
   else {
-    if ( exists $opts{c} ) {
+    if ( exists $opts{o} ) {
       Rex::Output->get->add( $task->name );
     }
   }


### PR DESCRIPTION
In Default.pm, a wrong key was used, 'c' with the %opts to check for
Output.

In addition, seems like after running several executions with the JUnit,
looking at 'ipcs' some shared memory and semaphore arrays were not being
released back to the system.
