### PR TITLE
make apt-listchanges non-interactive

### DIFF
--- a/lib/Rex/Pkg/Debian.pm
+++ b/lib/Rex/Pkg/Debian.pm
@@ -26,10 +26,10 @@ sub new {
 
   $self->{commands} = {
     install =>
-      'DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold --force-yes -y install %s',
+      'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold --force-yes -y install %s',
     install_version =>
-      'DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold --force-yes -y install %s=%s',
-    update_system => 'DEBIAN_FRONTEND=noninteractive apt-get -y -qq upgrade',
+      'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold --force-yes -y install %s=%s',
+    update_system => 'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -y -qq upgrade',
     remove        => 'apt-get -y remove %s',
     purge         => 'dpkg --purge %s',
     update_package_db => 'apt-get -y update',


### PR DESCRIPTION
apt-listchanges prints the last bit of changelog for packages about to be installed and it is interactive by default. With this patch the changes just get written to stdout instead which seems to be a decent compromise.

Alternatively, we could just set it to `none' to disable it completely.
