### PR TITLE
close last used ssh connection after test

### DIFF
--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -190,6 +190,7 @@ sub ok {
 
 sub finish {
   Test::More::done_testing();
+  Rex::pop_connection();
 }
 
 =back


### PR DESCRIPTION
This fixes an issue i had with multiple test files in `t/`.
If you have multiple test files, the existing connections are not closed in Rex::Test::Base finish(). That causes Rex to run the following `virsh list --all` commands on the existing SSH connection and the tests after the first file are failing silently, as Rex is unable to get the list of the virtual machines.
