### PR TITLE
only execute testfiles which end on '.t'

### DIFF
--- a/lib/Rex/Test.pm
+++ b/lib/Rex/Test.pm
@@ -15,7 +15,7 @@ task run => make {
 
   my @files;
   LOCAL {
-    @files = list_files "t";
+    @files = grep { $_ =~ /\.t$/ } list_files 't';
   };
 
   for my $file (@files) {


### PR DESCRIPTION
I had the issue, that rex wanted to execute my `*.t.swp` files and failes as these files are not valid test files. this patch filters all files, that dont have a `.t` suffix.
