### PR TITLE
fixed get_installed and is_installed functions Rex::Pkg::Gentoo

### DIFF
--- a/lib/Rex/Test/Base/has_package.pm
+++ b/lib/Rex/Test/Base/has_package.pm
@@ -27,20 +27,21 @@ sub new {
 
 sub run_test {
   my ( $self, $pkg, $version ) = @_;
-  my @packages = installed_packages;
-
-  for my $p (@packages) {
-    if ( $p->{name} eq $pkg ) {
-      if ($version) {
+  if ($version) {
+    my @packages = installed_packages;
+    for my $p (@packages) {
+      if ( $p->{name} eq $pkg ) {
         if ( $p->{version} eq $version ) {
           $self->ok( 1, "Found package $pkg in version $version." );
           return 1;
         }
       }
-      else {
-        $self->ok( 1, "Found package $pkg" );
-        return 1;
-      }
+    }
+  }
+  else {
+    if ( is_installed($pkg) ) {
+      $self->ok( 1, "Found package $pkg" );
+      return 1;
     }
   }
 


### PR DESCRIPTION
i had an issue with the `get_installed` and `is_installed` function in the Gentoo submodule of Rex::Pkg:

In Gentoo you can define package names with a ambiguous short name (for example `tmux`) and a long well defined name (for example `app-misc/tmux`). this pull request patches the is_installed behaviour in the following way: 
first it checks if the given package name matches the long name and if this fails it tries to compare against the short name (the current behaviour of upstream is to check against the short name).

i also adjusted the `has_package` module of Rex::Test::Base to use is_installed if no `$version` is given.
so in this case it also works now on Gentoo no matter if you try the long or the short package name.
The behaviour if `$version` is set is not fixed.
