### PR TITLE
Add ROSA systems support

### DIFF
--- a/lib/Rex/Commands/Gather.pm
+++ b/lib/Rex/Commands/Gather.pm
@@ -243,7 +243,8 @@ sub is_redhat {
     "Fedora",                      "Redhat",
     "CentOS",                      "Scientific",
     "RedHatEnterpriseServer",      "RedHatEnterpriseES",
-    "RedHatEnterpriseWorkstation", "Amazon"
+    "RedHatEnterpriseWorkstation", "Amazon",
+    "ROSAEnterpriseServer"
   );
 
   if ( grep { /$os/i } @redhat_clones ) {
@@ -295,7 +296,7 @@ sub is_suse {
 
  task "foo", "server1", sub {
    if(is_mageia) {
-     # do something on a mageia system
+     # do something on a mageia system (or other Mandriva followers)
    }
  };
 
@@ -304,7 +305,9 @@ sub is_suse {
 sub is_mageia {
   my $os = @_ ? shift : get_operating_system();
 
-  if ( $os =~ m/mageia/i ) {
+  my @mdv_clones = ("Mageia", "ROSADesktopFresh");
+
+  if ( grep { /$os/i } @mdv_clones ) {
     return 1;
   }
 }


### PR DESCRIPTION
Let's add support for ROSA Linux variations. ROSA Enterprise Server is based of RHEL with minor editions, ROSA Desktop is based on old Mandriva and is similar to Mageia from Rex point of view.

With the minor improvements from this pull request, I have managed to make most Rex commands work on ROSA Server and ROSA Desktop. I haven't tested the whole functionality, but this is definitely better than nothing.
