### PR TITLE
Multiple test files

### DIFF
--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -54,15 +54,10 @@ Then you can create your test files inside this directory.
 =cut
 
 package Rex::Test::Base;
+use base 'Test::Builder::Module';
 
 use strict;
 use warnings;
-
-#use Rex -base;
-BEGIN {
-  use Rex::Require;
-  Test::More->require;
-}
 
 require Rex::Commands;
 use Rex::Commands::Box;
@@ -185,11 +180,14 @@ sub run_task {
 
 sub ok {
   my ( $self, $test, $msg ) = @_;
-  Test::More::ok( $test, $msg );
+  my $tb = Rex::Test::Base->builder;
+  $tb->ok( $test, $msg );
 }
 
 sub finish {
-  Test::More::done_testing();
+  my $tb = Rex::Test::Base->builder;
+  $tb->done_testing();
+  $tb->reset();
   Rex::pop_connection();
 }
 


### PR DESCRIPTION
i had the following issue:
i have multiple files in `t/`. as `done_testing()` gets executed mulitple times. the current rex version throws errors like `not ok xx - done_testing() was already called a blah`. this pull request fixes this issue. i switched to `Test::Builder` as it is faster this way and it seems like `Rex::Test::Base` was not using any special `Test::More` functionality. the call to `Test::Builder::reset` fixes my original mentioned issue.
