### PR TITLE
allow multiple tasks to run in tests

### DIFF
--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -168,7 +168,14 @@ sub run_task {
     $box->forward_port( ssh => [ $self->{redirect_port}, 22 ] );
 
     $box->auth( %{ $self->{auth} } );
-    $box->setup($task);
+    if ( ref $task eq 'SCALAR' ) {
+      $box->setup($task);
+    }
+    elsif ( ref $task eq 'ARRAY' ) {
+      for my $_task (@$task) {
+        $box->setup($_task);
+      }
+    }
   };
 
   $self->{box} = $box;


### PR DESCRIPTION
Hello again,

this pull requests enables you to run more than one task with Rex::Test::Base::run_task. it is still compatible to the old way, but it also accepts an ARRAY ref. if there is an ARRAY ref it runs all the tasks one after another after connect.
