### PR TITLE
allow multiple tasks to run in tests

### DIFF
--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -169,11 +169,11 @@ sub run_task {
 
     $box->auth( %{ $self->{auth} } );
 
-    if ( ref $task eq 'SCALAR' ) {
-      $box->setup($task);
-    }
-    elsif ( ref $task eq 'ARRAY' ) {
+    if ( ref $task eq 'ARRAY' ) {
       $box->setup(@$task);
+    }
+    else {
+      $box->setup($task);
     }
   };
 


### PR DESCRIPTION
Hello again,

this pull requests enables you to run more than one task with Rex::Test::Base::run_task. it is still compatible to the old way, but it also accepts an ARRAY ref. if there is an ARRAY ref it uses this instead of a single task.
