### PR TITLE
Rex::Command::Run: separate POD =item(s) with newline

### DIFF
--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -59,6 +59,7 @@ use base qw(Rex::Exporter);
 @EXPORT = qw(run can_run sudo);
 
 =item run($command [, $callback])
+
 =item run($command_description, command => $command, %options)
 
 This function will execute the given command and returns the output. In


### PR DESCRIPTION
- The POD parser built into MetaCPAN, as well as the 'perlpod'
  command, need blank lines before and after POD commands (lines that
  start with '='), or they won't format the POD correctly; you can see
  the second '=item' POD command in the output of 'perlpod Run.pm' or
  in the current MetaCPAN page for Rex::Command::Run.  This is noted
  in the 'perlpod' POD page, in the "Hints for Writing Pod" section
