### PR TITLE
Add initial version of changelog generator

### DIFF
--- a/misc/changelogger.sh
+++ b/misc/changelogger.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+changelog="ChangeLog"
+tmp_file="changelog.tmp"
+lasttag=`git tag --sort=-v:refname | head -n1`
+date=`date +%Y-%m-%d`
+
+release_manager=$1
+email=$2
+version=$3
+
+firstline="$date $release_manager <$email> ($version)"
+
+git checkout $changelog
+
+echo $firstline > $tmp_file
+git log --format='  * %s - %an' $lasttag..HEAD >> $tmp_file
+echo >> $tmp_file
+cat $changelog >> $tmp_file
+mv $tmp_file $changelog
+
+$EDITOR $changelog


### PR DESCRIPTION
This very basic scripts takes three arguments: release manager, email address and version number. It compiles the release header line based on those inputs and prepends current date to it. Then it finds the last git tag, and from that point to HEAD, it converts git log entries to Rex's ChangeLog format. When finished, it opens the generated file in the default editor for manual cleanup steps if needed (like perltidy entries, or multiple `Fix typos`, or commit-revert pairs, etc.). Most of it can be automated later by making the script smarter over time.

@krimdomu: please review and discuss/merge.