### PR TITLE
Rex::FS::File accepts filenames now

### DIFF
--- a/lib/Rex/FS/File.pm
+++ b/lib/Rex/FS/File.pm
@@ -14,6 +14,10 @@ This is the File Class used by I<file_write> and I<file_read>.
 
 =head1 SYNOPSIS
 
+ use Rex::Interface::File;
+ my $fh = Rex::Interface::File->create('Local');
+ $fh->open( '<', 'filename' );
+
  my $file = Rex::FS::File->new(fh => $fh);
  $file->read($len);
  $file->read_all;
@@ -31,14 +35,49 @@ use strict;
 package Rex::FS::File;
 
 use warnings;
+use Rex::Interface::File;
 
 use constant DEFAULT_READ_LEN => 64;
 
 =item new
 
-This is the constructor. You need to set the filehandle which the object should work on.
+This is the constructor. You need to set the filehandle which the object should work on
+or pass a filename. If you pass a filehandle, it has to be a C<Rex::Interface::File::*>
+object
 
+ my $fh = Rex::Interface::File->create('Local');
+ $fh->open( '<', 'filename' );
+ 
  my $file = Rex::FS::File->new(fh => $fh);
+
+Create a C<Rex::FS::File> object with a filename
+
+ # open a local file in read mode
+ my $file = Rex::FS::File->new(
+   filename => 'filename',
+   mode     => 'r', # or '<'
+   type     => 'Local',
+ );
+ 
+ # or shorter
+ my $file = Rex::FS::File->new( filename => 'filename' );
+ 
+ # open a local file in write mode
+ my $file = Rex::FS::File->new(
+   filename => 'filename',
+   mode     => 'w', # or '>'
+ );
+
+Allowed modes:
+
+ <  read
+ r  read
+ >  write
+ w  write
+ >> append
+ a  append
+
+For allowed C<types> see documentation of L<Rex::Interface::File>.
 
 =cut
 
@@ -47,7 +86,28 @@ sub new {
   my $proto = ref($that) || $that;
   my $self  = {@_};
 
+  my %modes = (
+    'w'  => '>',
+    'r'  => '<',
+    'a'  => '>>',
+    '<'  => '<',
+    '>'  => '>',
+    '>>' => '>>',
+  );
+
+  if ( $self->{filename} ) {
+      $self->{mode} ||= '<';
+
+      my $mode = $modes{ $self->{mode} } || '<';
+      $self->{fh} = Rex::Interface::File->create( $self->{type} || 'Local' );
+      $self->{fh}->open( $mode, $self->{filename} );
+  }
+
   bless( $self, $proto );
+
+  if ( ref $self->{fh} !~ m{Rex::Interface::File} ) {
+    die "Need an Rex::Interface::File object";
+  }
 
   return $self;
 }

--- a/t/fs_files.t
+++ b/t/fs_files.t
@@ -1,0 +1,102 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use_ok 'Rex::Helper::Path';
+use_ok 'Rex::Commands::File';
+use_ok 'Rex::Interface::File';
+use_ok 'Rex::FS::File';
+
+my @lines = ( "first line", "second line", "test" );
+
+my $filename = Rex::Helper::Path::get_tmp_file();
+file( $filename, content => join "\n", @lines );
+
+ok -e $filename, 'file was created';
+
+{
+  # standard Rex::FS::File usage - read file
+  my $fh = Rex::Interface::File->create('Local');
+  $fh->open( '<', $filename );
+  my $file_object = Rex::FS::File->new( fh => $fh );
+
+  isa_ok $file_object, 'Rex::FS::File', 'new with fh was successful';
+
+  my @read_lines = $file_object->read_all;
+  is_deeply \@read_lines, \@lines, 'read lines from fh';
+}
+
+{
+  # standard Rex::FS::File usage - write file
+  my $fh = Rex::Interface::File->create('Local');
+  $fh->open( '>', $filename );
+  my $file_object = Rex::FS::File->new( fh => $fh );
+
+  isa_ok $file_object, 'Rex::FS::File', 'new with fh (write mode) was successful';
+
+  $file_object->write( qw/this is a test/ );
+  $file_object->close;
+
+  my $read_fh = Rex::Interface::File->create('Local');
+  $read_fh->open( '<', $filename );
+  my $read_object = Rex::FS::File->new( fh => $read_fh );
+  my @read_lines = $read_object->read_all;
+  is_deeply \@read_lines, [qw/this is a test/], 'read lines from fh';
+}
+
+{
+  # new Rex::FS::File usage - read file
+  file( $filename, content => join "\n", @lines );
+  my $file_object = Rex::FS::File->new( filename => $filename );
+
+  isa_ok $file_object, 'Rex::FS::File', 'new with filename was successful';
+
+  my @read_lines = $file_object->read_all;
+  is_deeply \@read_lines, \@lines, 'read lines from filename';
+}
+
+{
+  # new Rex::FS::File usage - write file
+  my $file_object = Rex::FS::File->new( filename => $filename, mode => '>' );
+
+  isa_ok $file_object, 'Rex::FS::File', 'new with filename with mode ">" was successful';
+
+  $file_object->write( qw/this is a test/ );
+  $file_object->close;
+
+  my $read_fh = Rex::Interface::File->create('Local');
+  $read_fh->open( '<', $filename );
+  my $read_object = Rex::FS::File->new( fh => $read_fh );
+  my @read_lines = $read_object->read_all;
+  is_deeply \@read_lines, [qw/this is a test/], 'read lines from fh';
+}
+
+{
+  # new Rex::FS::File usage - read file - explicit read mode
+  file( $filename, content => join "\n", @lines );
+  my $file_object = Rex::FS::File->new( filename => $filename, mode => '<' );
+
+  isa_ok $file_object, 'Rex::FS::File', 'new with filename and explicit read mode was successful';
+
+  my @read_lines = $file_object->read_all;
+  is_deeply \@read_lines, \@lines, 'read lines from filename (explicit read mode)';
+}
+
+{
+  # new Rex::FS::File usage - write file - mode "w"
+  my $file_object = Rex::FS::File->new( filename => $filename, mode => 'w' );
+
+  isa_ok $file_object, 'Rex::FS::File', 'new with filename with mode "w" was successful';
+
+  $file_object->write( qw/this is a test/ );
+  $file_object->close;
+
+  my $read_object = Rex::FS::File->new( filename => $filename, mode => 'r' );
+  my @read_lines = $read_object->read_all;
+  is_deeply \@read_lines, [qw/this is a test/], 'read lines from fh';
+}
+
+done_testing();


### PR DESCRIPTION
This would help to unify code. There is no need to create filehandle objects via Rex::Interface::File and pass the filehandle...