### PR TITLE
Add PkgConf command to configure packages

### DIFF
--- a/lib/Rex/Commands/PkgConf.pm
+++ b/lib/Rex/Commands/PkgConf.pm
@@ -1,0 +1,137 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Commands::PkgConf - Configure packages
+
+=head1 DESCRIPTION
+
+With this module you can configure packages. Currently it only supports Debian
+(using debconf), but it is designed to be extendable.
+
+=head1 SYNOPSIS
+
+ my %options = get_pkgconf('postfix');
+ say $options{'postfix/relayhost'}->{value};
+
+ # Only obtain one value
+ my %options = get_pkgconf('postfix', 'postfix/relayhost');
+ say $options{'postfix/relayhost'}->{value};
+
+ # Set options
+ set_pkgconf("postfix", [
+    {question => 'chattr', type => 'boolean', value => 'false'},
+    {question => 'relayhost', type => 'string', value => 'relay.example.com'},
+ ]);
+
+ # Don't update if it's already set
+ set_pkgconf("mysql-server-5.5", [
+    {question => 'mysql-server/root_password', type => 'string', value => 'mysecret'},
+    {question => 'mysql-server/root_password_again', type => 'string', value => 'mysecret'},
+ ], no_update => 1);
+
+=head1 EXPORTED FUNCTIONS
+
+=over 4
+
+=cut
+
+package Rex::Commands::PkgConf;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Rex::PkgConf;
+use Rex::Logger;
+
+require Rex::Exporter;
+
+use base qw(Rex::Exporter);
+use vars qw(@EXPORT);
+
+@EXPORT = qw(get_pkgconf set_pkgconf);
+
+=item get_pkgconf($package, [$question])
+
+Use this to query existing package configurations.
+
+Without a question specified, it will return all options for
+the specified package as a hash.
+
+With a question specified, it will return only that option
+
+Each question is returned with the question as the key, and 
+the value as a hashref. The hashref contains the keys: question,
+value and already_set. already_set is true if the question has
+already been answered.
+
+ # Only obtain one value
+ my %options = get_pkgconf('postfix', 'postfix/relayhost');
+ say $options{'postfix/relayhost'}->{question};
+ say $options{'postfix/relayhost'}->{value};
+ say $options{'postfix/relayhost'}->{already_set};
+
+=cut
+
+sub get_pkgconf {
+  my ($package) = @_;
+
+  Rex::get_current_connection()->{reporter}
+    ->report_resource_start( type => "pkgconf", name => $package );
+
+  my $pkgconf = Rex::PkgConf->get;
+
+  $pkgconf->get_options($package);
+}
+
+=item set_pkgconf($package, $values, [%options])
+
+Use this to set package configurations.
+
+At least the package name and values must be specified. Values
+must be an array ref, with each item containing a hashref with
+the attributes specified that are required by the package
+configuration program.
+
+For example, for debconf, this must be the question, the type
+and answer. In this case, the types can be any accetable debconf
+type: string, boolean, select, multiselect, note, text, password.
+
+Optionally the option "no_update" may be true, in which case the
+question will not be updated if it has already been set.
+
+See the synopsis for examples.
+
+=cut
+
+sub set_pkgconf {
+  my ( $package, $values, %options ) = @_;
+
+  Rex::get_current_connection()->{reporter}
+    ->report_resource_start( type => "pkgconf", name => $package );
+
+  my $pkgconf = Rex::PkgConf->get;
+
+  my $return = $pkgconf->set_options( $package, $values, %options );
+
+  if ( $return->{changed} ) {
+    Rex::get_current_connection()->{reporter}->report(
+      changed => 1,
+      message => "Configuration values updated: @{$return->{names}}",
+    );
+  }
+  else {
+    Rex::get_current_connection()->{reporter}->report( changed => 0, );
+  }
+
+  Rex::get_current_connection()->{reporter}
+    ->report_resource_end( type => "pkg", name => $package );
+}
+
+1;

--- a/lib/Rex/PkgConf.pm
+++ b/lib/Rex/PkgConf.pm
@@ -1,0 +1,74 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::PkgConf;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Rex::Config;
+use Rex::Commands::Gather;
+use Rex::Hardware;
+use Rex::Hardware::Host;
+use Rex::Logger;
+
+my %PKG_PROVIDER;
+
+sub register_package_provider {
+  my ( $class, $service_name, $service_class ) = @_;
+  $PKG_PROVIDER{"\L$service_name"} = $service_class;
+  return 1;
+}
+
+sub get {
+
+  my ($self) = @_;
+
+  my %_host = %{ Rex::Hardware::Host->get() };
+  my $host  = {%_host};
+
+  my $pkg_provider_for = Rex::Config->get("package_provider") || {};
+
+  if ( is_redhat() ) {
+    $host->{"operatingsystem"} = "Redhat";
+  }
+
+  my $class = "Rex::PkgConf::" . $host->{"operatingsystem"};
+
+  my $provider;
+  if ( ref($pkg_provider_for)
+    && exists $pkg_provider_for->{ $host->{"operatingsystem"} } )
+  {
+    $provider = $pkg_provider_for->{ $host->{"operatingsystem"} };
+    $class .= "::$provider";
+  }
+  elsif ( exists $PKG_PROVIDER{$pkg_provider_for} ) {
+    $class = $PKG_PROVIDER{$pkg_provider_for};
+  }
+
+  Rex::Logger::debug("Using $class for package management");
+  eval "use $class";
+
+  if ($@) {
+
+    if ($provider) {
+      Rex::Logger::info( "Provider not supported (" . $provider . ")" );
+    }
+    else {
+      Rex::Logger::info(
+        "OS not supported (" . $host->{"operatingsystem"} . ")" );
+    }
+    die("OS/Provider not supported");
+
+  }
+
+  return $class->new;
+
+}
+
+1;

--- a/lib/Rex/PkgConf/Base.pm
+++ b/lib/Rex/PkgConf/Base.pm
@@ -1,0 +1,24 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::PkgConf::Base;
+
+use strict;
+use warnings;
+
+# VERSION
+
+sub new {
+  my $that  = shift;
+  my $proto = ref($that) || $that;
+  my $self  = {@_};
+
+  bless( $self, $proto );
+
+  return $self;
+}
+
+1;

--- a/lib/Rex/PkgConf/Debian.pm
+++ b/lib/Rex/PkgConf/Debian.pm
@@ -1,0 +1,105 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::PkgConf::Debian;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Rex::Helper::Run;
+
+use Rex::PkgConf::Base;
+use base qw(Rex::PkgConf::Base);
+
+sub new {
+  my $that  = shift;
+  my $proto = ref($that) || $that;
+  my $self  = $proto->SUPER::new(@_);
+
+  bless( $self, $proto );
+
+  return $self;
+}
+
+sub get_options {
+  my ( $self, $pkg, $option ) = @_;
+  die "Package name required to configure" unless $pkg;
+  my $conf_cmd = "debconf-show $pkg";
+
+  Rex::Logger::debug("Running command $conf_cmd");
+  my @lines = i_run $conf_cmd;
+
+  my %config;
+  for my $line (@lines) {
+    # Expecting: * postfix/relayhost: smtp.example.com
+    Rex::Logger::debug("Parsing line $line");
+    if ( $line =~ m!^(\*?)\h+(.+):\h*(.*)! ) {
+      my ($already_set, $question, $value) = ($1, $2, $3, $4);
+      Rex::Logger::debug("Found configuration question $question with value $value");
+      next if $option && $option ne $question;
+      $already_set = $already_set ? 1 : 0;
+      $config{$question} = {
+          question    => $question,
+          value       => $value,
+          already_set => $already_set,
+      };
+    }
+  }
+
+  %config;
+}
+
+sub set_options {
+  my ( $self, $pkg, $values, %options ) = @_;
+  die "set_option usage: set_option package, values, options"
+    unless $pkg && $values;
+
+  # Get existing options first, to see if they need setting
+  my %existing = $self->get_options( $pkg );
+
+  my @updated;
+  for my $line (@$values) {
+
+    my ($question, $value, $type)  = ($line->{question}, $line->{value}, $line->{type});
+
+    die "Question and type required for each package configuration option"
+      unless $question && $type;
+
+    if ($existing{$question} && $existing{$question}->{value} eq $value) {
+      Rex::Logger::debug("Option $question already set to $value, ignoring");
+      next;
+    }
+
+    if ($options{no_update} && $existing{$question} && $existing{$question}->{already_set}) {
+      Rex::Logger::debug("Option $question already set, not updating");
+      next;
+    }
+
+    push @updated, $question;
+    Rex::Logger::debug("Will set option $question: $value (type $type)");
+    push @updated, "$pkg $question $type $value";
+  }
+
+  if (@updated)
+  {
+    my $settings = join '\n', @updated;
+    my $conf_cmd = qq(echo -e "$settings"|debconf-set-selections);
+    i_run $conf_cmd;
+    return {
+      changed => 1,
+      names   => \@updated,
+    };
+  }
+  else {
+    return {
+      changed => 0,
+    };
+  }
+}
+
+1;


### PR DESCRIPTION
This patch adds commands ```get_pkgconf``` and ```set_pkgconf``` to configure packages. As it stands, this patch only provides support for Debian (using debconf), but it is designed to be extensible, in the same way that the Pkg commands are.

Let me know if you think this should be approached in a different way, and I'll refactor accordingly.