### PR TITLE
Optimisations and bug fixes for Rex::Commands::Augeas

### DIFF
--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -199,7 +199,7 @@ Insert an item into the file. Here, the order of the options is important. If th
         return 0;
       }
 
-      my @commands = ("ins $label $position " . $opts->{$position} . "\n");
+      my @commands = ("ins $label $position $file$opts->{$position}\n");
       delete $opts->{$position};
 
       for ( my $i = 0 ; $i < @options ; $i += 2 ) {

--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -291,7 +291,7 @@ Check if an item exists.
       my @paths;
       my $result = _run_augtool("match $aug_key");
       for my $line ( @{$result->{return}} ) {
-        $line =~ s/\s=[^=]+$//;
+        $line =~ s/\s=[^=]+$// or next;
         push @paths, $line;
       }
 

--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -109,7 +109,7 @@ This modifies the keys given in @options in $file.
         push @commands, "set $key $config_option->{$key}\n";
       }
       my $result = _run_augtool(@commands);
-      $ret = $result->{return};
+      $ret = "@{$result->{return}}";
       $changed = $result->{changed};
     }
     else {
@@ -155,7 +155,7 @@ Remove an entry.
 
     if ($is_ssh) {
       my $result = _run_augtool(@commands);
-      $ret = $result->{return};
+      $ret = "@{$result->{return}}";
       $changed = $result->{changed};
     }
     else {
@@ -213,7 +213,7 @@ Insert an item into the file. Here, the order of the options is important. If th
         push @commands, "set $_key $val\n";
       }
       my $result = _run_augtool(@commands);
-      $ret = $result->{return};
+      $ret = "@{$result->{return}}";
       $changed = $result->{changed};
     }
     else {


### PR DESCRIPTION
In the case of SSH, this patch groups Augeas commands and runs
them together. Starting augtool is expensive, which is now done
only once for each group of commands.

In addition, the commands are passed via a file, fixing bugs
if the commands have characters that would otherwise need
to be escaped.