### PR TITLE
CLI.pm: throw error if -T used with task arg, but no matching task found; Updates to docs

### DIFF
--- a/bin/rex
+++ b/bin/rex
@@ -36,7 +36,9 @@ Rex is a tool to ease the execution of commands on multiple remote servers. You 
 
 =item -H              Execute task on these hosts
 
-=item -G              Execute task on these group
+=item -z              Execute task on hosts from this command's output
+
+=item -G|-g           Execute task on these group
 
 =item -u              Username for the ssh connection
 
@@ -48,9 +50,17 @@ Rex is a tool to ease the execution of commands on multiple remote servers. You 
 
 =item -T              List all known tasks.
 
+=item -Tm             List all known tasks in "machine readable" format
+
+=item -Ty             List all known tasks in YAML format
+
+=item -Tv             List all known tasks with all information
+
 =item -f              Use this file instead of Rexfile
 
 =item -h              Display this help
+
+=item -m              Monochrome output. No colors
 
 =item -M              Load Module instead of Rexfile
 
@@ -71,6 +81,14 @@ Rex is a tool to ease the execution of commands on multiple remote servers. You 
 =item -C              Turn cache OFF
 
 =item -c              Turn cache ON
+
+=item -q              Quiet mode. No Logging output
+
+=item -qw             Quiet mode. Only output warnings and errors
+
+=item -Q              Really quiet. Output nothing.
+
+=item -t              Number of threads to use ('parallelism' parameter)
 
 =back
 

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -469,18 +469,26 @@ CHECK_OVERWRITE: {
     if ( defined $ARGV[0] ) {
       @tasks = map { Rex::TaskList->create()->is_task($_) ? $_ : () } @ARGV;
     }
-    my $max_task_str = max map { length } @tasks;
-    for my $task (@tasks) {
-      my $padding = $max_task_str - length($task);
-      print " $task  "
-        . ' ' x $padding . " "
-        . Rex::TaskList->create()->get_desc($task) . "\n";
-      if ( $opts{'v'} ) {
-        _print_color( "    Servers: "
-            . join( ", ",
-            @{ Rex::TaskList->create()->get_task($task)->server } )
-            . "\n" );
-      }
+    # Warn the user if they pass in arguments to '-T' and no task names
+    # were found that match those arguments
+    if ( scalar(@tasks) == 0 ) {
+        foreach my $task_warn ( @ARGV ) {
+            Rex::Logger::info("No task matching '$task_warn' found.", "error");
+        }
+    } else {
+        my $max_task_str = max map { length } @tasks;
+        for my $task (@tasks) {
+          my $padding = $max_task_str - length($task);
+          print " $task  "
+            . ' ' x $padding . " "
+            . Rex::TaskList->create()->get_desc($task) . "\n";
+          if ( $opts{'v'} ) {
+            _print_color( "    Servers: "
+                . join( ", ",
+                @{ Rex::TaskList->create()->get_task($task)->server } )
+                . "\n" );
+          }
+        }
     }
     _print_color( "Batches\n", 'yellow' ) if ( Rex::Batch->get_batchs );
     for my $batch ( Rex::Batch->get_batchs ) {

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -702,6 +702,9 @@ sub __help__ {
   printf "  %-15s %s\n", "-P",    "Private Keyfile for the ssh connection";
   printf "  %-15s %s\n", "-K",    "Public Keyfile for the ssh connection";
   printf "  %-15s %s\n", "-T",    "List all known tasks.";
+  printf "  %-15s %s\n", "-Tm",
+    "List all known tasks, in machine-readable format.";
+  printf "  %-15s %s\n", "-Ty",   "List all known tasks, in YAML format.";
   printf "  %-15s %s\n", "-Tv",   "List all known tasks with all information.";
   printf "  %-15s %s\n", "-f",    "Use this file instead of Rexfile";
   printf "  %-15s %s\n", "-h",    "Display this help";
@@ -719,7 +722,8 @@ sub __help__ {
   printf "  %-15s %s\n", "-q",    "Quiet mode. No Logging output";
   printf "  %-15s %s\n", "-qw",   "Quiet mode. Only output warnings and errors";
   printf "  %-15s %s\n", "-Q",    "Really quiet. Output nothing.";
-  printf "  %-15s %s\n", "-t",    "Number of threads to use.";
+  printf "  %-15s %s\n", "-t",
+    "Number of threads to use (aka 'parallelism' param)";
   print "\n";
 
   for my $code (@help) {


### PR DESCRIPTION
- If the user passes in the -T switch with argument(s), Rex will search the task list in the Rexfile for a matching task(s) and print only those tasks; no error is given to the user if there are no matches between the user's arguments and the task list

Note that the -Tv and -Tm switches have their own block that handles arguments that don't have matching task names; the plain -T switch does not, currently