### PR TITLE
Stop append_or_amend_line inserting extra blank lines

### DIFF
--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -1050,13 +1050,13 @@ sub _append_or_update {
       }
       if ( $content->[$line] =~ $match ) {
         return 0 if $action eq 'append_if_no_such_line';
-        $content->[$line] = "$new_line\n";
+        $content->[$line] = "$new_line";
         $found = 1;
       }
     }
   }
 
-  push @$content, "$new_line\n" unless $found;
+  push @$content, "$new_line" unless $found;
 
   eval {
     my $fh = file_write $file;
@@ -1064,6 +1064,7 @@ sub _append_or_update {
       die("can't open file for writing");
     }
     $fh->write( join( "\n", @$content ) );
+    $fh->write( "\n" );
     $fh->close;
     $ret = 0;
     1;


### PR DESCRIPTION
This patch fixes append_or_amend_line inserting extra blank lines. It also ensures that if an amended line is at the end of a file that the newline is not removed.