### PR TITLE
added possibility to define parameters multiple times. - #516

### DIFF
--- a/lib/Rex/Args.pm
+++ b/lib/Rex/Args.pm
@@ -84,7 +84,16 @@ sub import {
           $rex_opts{$name_param}++;
         }
         else {
-          $rex_opts{$name_param} = $c->get;
+          # multiple params defined, create an array
+          if ( exists $rex_opts{$name_param} ) {
+            if ( !ref $rex_opts{$name_param} ) {
+              $rex_opts{$name_param} = [ $rex_opts{$name_param} ];
+            }
+            push @{ $rex_opts{$name_param} }, $c->get;
+          }
+          else {
+            $rex_opts{$name_param} = $c->get;
+          }
         }
       }
       else {

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -261,12 +261,17 @@ FORCE_SERVER: {
 
     Rex::Config->set_environment( $opts{"E"} ) if ( $opts{"E"} );
 
-    if ( $opts{'G'} ) {
-      $::FORCE_SERVER = "\0" . $opts{'G'};
-    }
+    if ( $opts{'g'} || $opts{'G'} ) {
 
-    if ( $opts{'g'} ) {
-      $::FORCE_SERVER = "\0" . $opts{'g'};
+      #$::FORCE_SERVER = "\0" . $opts{'g'};
+      $opts{'g'} ||= $opts{'G'};
+
+      if ( ref $opts{'g'} ne "ARRAY" ) {
+        $::FORCE_SERVER = [ $opts{'g'} ];
+      }
+      else {
+        $::FORCE_SERVER = $opts{'g'};
+      }
     }
 
     if ( -f "vars.db" ) {

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -61,29 +61,31 @@ sub create_task {
 
   if ($::FORCE_SERVER) {
 
-    if ( $::FORCE_SERVER =~ m/^\0/ ) {
-      my $group_name = substr( $::FORCE_SERVER, 1 );
+    if ( ref $::FORCE_SERVER eq "ARRAY" ) {
+      my $group_name_arr = $::FORCE_SERVER;
 
-      if ( !Rex::Group->is_group($group_name) ) {
-        Rex::Logger::debug("Using late group-lookup");
+      for my $group_name ( @{$group_name_arr} ) {
+        if ( !Rex::Group->is_group($group_name) ) {
+          Rex::Logger::debug("Using late group-lookup");
 
-        push @server, sub {
-          if ( !Rex::Group->is_group($group_name) ) {
-            Rex::Logger::info( "No group $group_name defined.", "error" );
-            exit 1;
-          }
+          push @server, sub {
+            if ( !Rex::Group->is_group($group_name) ) {
+              Rex::Logger::info( "No group $group_name defined.", "error" );
+              exit 1;
+            }
 
-          return
-            map { Rex::Group::Entry::Server->new( name => $_ )->get_servers; }
-            Rex::Group->get_group($group_name);
-        };
-      }
-      else {
+            return
+              map { Rex::Group::Entry::Server->new( name => $_ )->get_servers; }
+              Rex::Group->get_group($group_name);
+          };
+        }
+        else {
 
-        push( @server,
-          map { Rex::Group::Entry::Server->new( name => $_ ); }
-            Rex::Group->get_group($group_name) );
+          push( @server,
+            map { Rex::Group::Entry::Server->new( name => $_ ); }
+              Rex::Group->get_group($group_name) );
 
+        }
       }
     }
     else {

--- a/t/args.t
+++ b/t/args.t
@@ -1,12 +1,14 @@
 use strict;
 use warnings;
 
-use Test::More tests => 13;
+use Test::More tests => 14;
 use Data::Dumper;
 
 use_ok 'Rex::Args';
 
-push( @ARGV, qw(-h -T -dv -u user -p pass -t 5 foo --name=thename --num=5) );
+push( @ARGV,
+  qw(-h -g test1 -g test2 -T -dv -u user -p pass -t 5 foo --name=thename --num=5)
+);
 
 Rex::Args->import(
   C => {},
@@ -32,10 +34,14 @@ Rex::Args->import(
   P => { type => "string" },
   K => { type => "string" },
   G => { type => "string" },
+  g => { type => "string" },
   t => { type => "integer" },
 );
 
-my %opts = Rex::Args->getopts;
+my %opts   = Rex::Args->getopts;
+my $groups = $opts{g};
+
+is_deeply( $groups, [qw/test1 test2/], "Got array for groups" );
 
 ok( exists $opts{h} && $opts{h}, "single parameter" );
 ok( exists $opts{T} && $opts{T}, "single parameter (2)" );


### PR DESCRIPTION
Hi,

this is a patch allowing to define command lines switches multiple times.

so it would be possible to do the following:

```
rex -g group1 -g group2 mytask
```

This patch won't filter out duplicate servers. I think implementing this would result in a rewrite of the TaskList/Base.pm module.

But i think this is an acceptable approach until we rewrite the cli arg parser.

What do you ppl think?  