### PR TITLE
Ensure update_system always updates package repositories first

### DIFF
--- a/lib/Rex/Pkg/Debian.pm
+++ b/lib/Rex/Pkg/Debian.pm
@@ -32,7 +32,7 @@ sub new {
     install_version =>
       'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold --force-yes -y install %s=%s',
     update_system =>
-      'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -y -qq upgrade',
+      'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -y -qq update && APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -y -qq upgrade',
     remove            => 'apt-get -y remove %s',
     purge             => 'dpkg --purge %s',
     update_package_db => 'apt-get -y update',

--- a/lib/Rex/Pkg/Gentoo.pm
+++ b/lib/Rex/Pkg/Gentoo.pm
@@ -27,7 +27,7 @@ sub new {
   $self->{commands} = {
     install           => 'emerge %s',
     install_version   => 'emerge =%s-%s',
-    update_system     => 'emerge --update --deep --with-bdeps=y --newuse world',
+    update_system     => 'emerge --sync && emerge --update --deep --with-bdeps=y --newuse world',
     remove            => 'emerge -C %s',
     update_package_db => 'emerge --sync',
   };

--- a/lib/Rex/Pkg/SuSE.pm
+++ b/lib/Rex/Pkg/SuSE.pm
@@ -26,7 +26,7 @@ sub new {
   $self->{commands} = {
     install           => 'zypper -n install %s',
     install_version   => 'zypper -n install $pkg-%s',
-    update_system     => 'zypper -n up',
+    update_system     => 'zypper refresh && zypper -n up',
     remove            => 'zypper -n remove %s',
     update_package_db => 'zypper --no-gpg-checks -n ref -fd',
   };


### PR DESCRIPTION
There is a mixture of behaviours with update_system. With some operating systems it will update the package repository cache first, with others it won't. This patch attempts to make the behaviour consistent, and always update repositories first, given that this is most likely what one would want to do when updating a system.

Disclaimer: I have only experience with apt, but have attempted to cover all operating systems.