### PR TITLE
Die if trying to run augeas without augtool installed

### DIFF
--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -389,6 +389,8 @@ Returns the value of the given item.
 sub _run_augtool {
   my (@commands) = @_;
 
+  die "augtool is not installed or not executable in the path"
+    unless can_run "augtool";
   my $rnd_file = get_tmp_file;
   my $fh       = Rex::Interface::File->create;
   $fh->open( ">", $rnd_file );


### PR DESCRIPTION
If augtool is not installed the command will fail silently and appear to function correctly