### PR TITLE
Speed up connecting to Boxes

### DIFF
--- a/lib/Rex/Box/Base.pm
+++ b/lib/Rex/Box/Base.pm
@@ -290,13 +290,6 @@ sub wait_for_ssh {
     sleep 1;
   }
 
-  my $i = 5;
-  while ( $i != 0 ) {
-    sleep 1;
-    print ".";
-    $i--;
-  }
-
   print "\n";
 }
 


### PR DESCRIPTION
@krimdomu: please review and merge/discuss

There was a fixed amount of delay before SSH was considered as up and running for Boxes. During development this could be very annoying by forcing this wait on every `rex Test:run` call, while the Box might already be up and running.

I think the cases when it might have been required to give some time for SSH to settle, e.g. just after startup, should be handled just fine by normal SSH retry attempts (fixme :)