### PR TITLE
Rex::Commands::MD5: Make Rex use the /sbin/md5 binary on OS X

### DIFF
--- a/lib/Rex/Commands/MD5.pm
+++ b/lib/Rex/Commands/MD5.pm
@@ -67,7 +67,7 @@ sub md5 {
     my $md5;
 
     my $os = $exec->exec("uname -s");
-    if ( $os =~ /bsd/i ) {
+    if ( $os =~ /bsd|darwin/i ) {
       $md5 = $exec->exec("/sbin/md5 -q '$file'");
     }
     else {


### PR DESCRIPTION
- Mac OS X (uname -s = 'Darwin') also has an MD5 checksum command located at '/sbin/md5', same as the existing check for "uname -s" = "BSD" in Rex::Commands::MD5.  No need to set up a Perl script to run locally in order to get MD5 checksums if the local system is a Mac

Tested on local system under OS X Mavericks (10.9.x), Perl 5.20.1, latest version of Rex from Git

Has not (yet) been tested on remote systems where remote system is OS X