### PR TITLE
dist.ini: Add Twitter and IRC links to metaresources block

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -21,8 +21,10 @@ max_target_perl = 5.8.9
 critic_config = ../../.perlcriticrc
 [OurPkgVersion]
 [MetaResources]
-homepage = http://www.rexify.org
-bugtracker.web = https://github.com/RexOps/Rex/issues
-repository.url = https://github.com/RexOps/Rex.git
-repository.web = https://github.com/RexOps/Rex
+homepage        = http://www.rexify.org
+bugtracker.web  = https://github.com/RexOps/Rex/issues
+repository.url  = https://github.com/RexOps/Rex.git
+repository.web  = https://github.com/RexOps/Rex
 repository.type = git
+x_twitter       = https://twitter.com/RexOps
+x_IRC           = irc://irc.freenode.net/rex


### PR DESCRIPTION
The IRC metaresource will get you a pretty red banner on your MetaCPAN page for Rex that is clickable; when clicked in a browser, you are taken to mibbit.org for a web IRC session.  You may not actually want this "feature", but I thought I'd throw it out there in any case.