### PR TITLE
Rex::Commands::MD5: Make Rex use the /sbin/md5 binary on OS X

### DIFF
--- a/lib/Rex/Commands/MD5.pm
+++ b/lib/Rex/Commands/MD5.pm
@@ -67,7 +67,7 @@ sub md5 {
     my $md5;
 
     my $os = $exec->exec("uname -s");
-    if ( $os =~ /bsd/i ) {
+    if ( $os =~ /bsd|darwin/i ) {
       $md5 = $exec->exec("/sbin/md5 -q '$file'");
     }
     else {


### PR DESCRIPTION
- Mac OS X (uname -s = 'Darwin') also has an MD5 checksum command located at '/sbin/md5', same as the existing check for "uname -s" = "BSD" in Rex::Commands::MD5