### PR TITLE
Speed up connecting to Boxes

### DIFF
--- a/lib/Rex/Interface/Fs/Local.pm
+++ b/lib/Rex/Interface/Fs/Local.pm
@@ -82,12 +82,12 @@ sub rmdir {
 
 sub is_dir {
   my ( $self, $path ) = @_;
-  if ( -d $path ) { return 1; }
+  ( -d $path ) ? return 1 : return 0;
 }
 
 sub is_file {
   my ( $self, $file ) = @_;
-  if ( -f $file ) { return 1; }
+  ( -f $file || -l _ || -b _ || -c _ || -p _ || -S _ ) ? return 1 : return 0;
 }
 
 sub unlink {

--- a/lib/Rex/Interface/Fs/OpenSSH.pm
+++ b/lib/Rex/Interface/Fs/OpenSSH.pm
@@ -70,7 +70,7 @@ sub is_dir {
 
   Rex::Commands::profiler()->end("is_dir: $path");
 
-  defined $attr ? return S_ISDIR( $attr->perm ) : return;
+  defined $attr ? return S_ISDIR( $attr->perm ) : return 0;
 }
 
 sub is_file {
@@ -88,8 +88,9 @@ sub is_file {
       || S_ISLNK( $attr->perm )
       || S_ISBLK( $attr->perm )
       || S_ISCHR( $attr->perm )
-      || S_ISFIFO( $attr->perm ) )
-    : return;
+      || S_ISFIFO( $attr->perm )
+      || S_ISSOCK( $attr->perm ) )
+    : return 0;
 }
 
 sub unlink {

--- a/lib/Rex/Interface/Fs/SSH.pm
+++ b/lib/Rex/Interface/Fs/SSH.pm
@@ -66,7 +66,7 @@ sub is_dir {
 
   Rex::Commands::profiler()->end("is_dir: $path");
 
-  defined $stat ? return S_ISDIR( $stat->{mode} ) : return;
+  defined $stat ? return S_ISDIR( $stat->{mode} ) : return 0;
 }
 
 sub is_file {
@@ -84,8 +84,9 @@ sub is_file {
       || S_ISLNK( $stat->{mode} )
       || S_ISBLK( $stat->{mode} )
       || S_ISCHR( $stat->{mode} )
-      || S_ISFIFO( $stat->{mode} ) )
-    : return;
+      || S_ISFIFO( $attr->perm )
+      || S_ISSOCK( $attr->perm ) )
+    : return 0;
 }
 
 sub unlink {

--- a/lib/Rex/Interface/Fs/Sudo.pm
+++ b/lib/Rex/Interface/Fs/Sudo.pm
@@ -99,7 +99,7 @@ sub is_dir {
   $self->_exec("test -d $path");
   my $ret = $?;
 
-  if ( $ret == 0 ) { return 1; }
+  $ret == 0 ? return 1 : return 0;
 }
 
 sub is_file {
@@ -113,11 +113,7 @@ sub is_file {
   $self->_exec("test -d $file");
   my $is_dir = $?;
 
-  if ( $is_file == 0 && $is_dir != 0 ) {
-    return 1;
-  }
-
-  return;
+  ( $is_file == 0 && $is_dir != 0 ) ? return 1 : return 0;
 }
 
 sub unlink {


### PR DESCRIPTION
@krimdomu: please review and merge/discuss

There was a fixed amount of delay before SSH was considered as up and running for Boxes. During development this could be very annoying by forcing this wait on every `rex Test:run` call, while the Box might already be up and running.

I think the cases when it might have been required to give some time for SSH to settle, e.g. just after startup, should be handled just fine by normal SSH retry attempts (fixme :)