### PR TITLE
misc/create_pod.sh: add PkgConf.pm to list of files to PODify

### DIFF
--- a/misc/create_pod.sh
+++ b/misc/create_pod.sh
@@ -45,6 +45,7 @@ for x in \
    lib/Rex/Commands/Notify.pm \
    lib/Rex/Commands/Partition.pm \
    lib/Rex/Commands/Pkg.pm \
+   lib/Rex/Commands/PkgConf.pm \
    lib/Rex/Commands/Process.pm \
    lib/Rex/Commands/Rsync.pm \
    lib/Rex/Commands/Run.pm \


### PR DESCRIPTION
The POD needs to be regenerated after applying this patch.  There's also a corresponding change that needs to be applied in rexify-website.git before the Rex::Commands::PkgConf page will be available on the website.