### PR TITLE
fixed setting of path environment variable - #583

### DIFF
--- a/lib/Rex/Interface/Shell/Bash.pm
+++ b/lib/Rex/Interface/Shell/Bash.pm
@@ -75,7 +75,7 @@ sub exec {
     $complete_cmd = "cd $option->{cwd} && $complete_cmd";
   }
 
-  if ( $self->{path} ) {
+  if ( $self->{path} && !exists $self->{__env__}->{PATH} ) {
     $complete_cmd = "PATH=$self->{path}; export PATH; $complete_cmd ";
   }
 

--- a/lib/Rex/Interface/Shell/Csh.pm
+++ b/lib/Rex/Interface/Shell/Csh.pm
@@ -82,7 +82,7 @@ sub exec {
     $complete_cmd = "cd $option->{cwd} && $complete_cmd";
   }
 
-  if ( $self->{path} ) {
+  if ( $self->{path} && !exists $self->{__env__}->{PATH} ) {
     $complete_cmd = "set PATH=$self->{path}; $complete_cmd ";
   }
 


### PR DESCRIPTION
This is a fix for #583 

This fix checks the options given for the run command if there is a PATH option set. If so, it doesn't overwrite the PATH.