### PR TITLE
Added possibility to define task auth parameters before task is created (with auth(for => task))

### DIFF
--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -105,7 +105,7 @@ use Rex;
 use Rex::Helper::Misc;
 
 use vars
-  qw(@EXPORT $current_desc $global_no_ssh $environments $dont_register_tasks $profiler);
+  qw(@EXPORT $current_desc $global_no_ssh $environments $dont_register_tasks $profiler %auth_late);
 use base qw(Rex::Exporter);
 
 @EXPORT = qw(task desc group
@@ -648,7 +648,9 @@ sub auth {
   }
 
   if ( !$group ) {
-    Rex::Logger::info("Group or Task $entity not found.");
+    Rex::Logger::info(
+      "Group or Task $entity not found. Assuming late-binding for task.");
+    $auth_late{$entity} = \%data;
     return;
   }
 

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -194,6 +194,10 @@ sub create_task {
     };
   }
 
+  if ( exists $Rex::Commands::auth_late{$task_name} ) {
+    $task_hash{auth} = $Rex::Commands::auth_late{$task_name};
+  }
+
   $self->{tasks}->{$task_name} = Rex::Task->new(%task_hash);
 
 }

--- a/t/auth.t
+++ b/t/auth.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 48;
+use Test::More tests => 52;
 use Data::Dumper;
 
 use_ok 'Rex';
@@ -136,4 +136,24 @@ for my $server ( @{$servers} ) {
   is( $auth->{private_key}, "priv.key2" );
   is( $auth->{public_key},  "pub.key2" );
 }
+
+auth(
+  for         => "testa4",
+  user        => "baruser",
+  password    => "barpass",
+  private_key => "testa4.priv",
+  public_key  => "testa4.pub"
+);
+
+task(
+  "testa4",
+  sub {
+  }
+);
+
+$auth = Rex::TaskList->create()->get_task("testa4")->{auth};
+is( $auth->{user},        "baruser" );
+is( $auth->{password},    "barpass" );
+is( $auth->{private_key}, "testa4.priv" );
+is( $auth->{public_key},  "testa4.pub" );
 


### PR DESCRIPTION
This commit fixes #402 