### PR TITLE
Refactor can_run

### DIFF
--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -327,24 +327,8 @@ specify multiple commands, the first command found will be returned.
 
 sub can_run {
   my @cmds = @_;
-
-  if ( !Rex::is_ssh() && $^O =~ m/^MSWin/ ) {
-    return 1;
-  }
-
-  for my $cmd (@cmds) {
-    my @ret = i_run "which $cmd";
-    next if ( $? != 0 );
-
-    if ( grep { /^no.*in/ } @ret ) {
-      next;
-    }
-    else {
-      return $ret[0];
-    }
-  }
-
-  return 0;
+  my $exec = Rex::Interface::Exec->create;
+  $exec->can_run(@cmds);
 }
 
 =item sudo

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -326,9 +326,9 @@ specify multiple commands, the first command found will be returned.
 =cut
 
 sub can_run {
-  my @cmds = @_;
-  my $exec = Rex::Interface::Exec->create;
-  $exec->can_run(@cmds);
+  my @commands = @_;
+  my $exec     = Rex::Interface::Exec->create;
+  $exec->can_run(@commands);
 }
 
 =item sudo

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -328,7 +328,7 @@ specify multiple commands, the first command found will be returned.
 sub can_run {
   my @commands = @_;
   my $exec     = Rex::Interface::Exec->create;
-  $exec->can_run(@commands);
+  $exec->can_run( [@commands] ); # use a new anon ref, so that we don't have drawbacks if some lower layers will manipulate things.
 }
 
 =item sudo

--- a/lib/Rex/Interface/Exec/Base.pm
+++ b/lib/Rex/Interface/Exec/Base.pm
@@ -48,4 +48,27 @@ sub execute_line_based_operation {
   $self->_continuous_read( $line, $option );
   return $self->_end_if_matched( $line, $option );
 }
+
+sub can_run {
+  my ( $self, @cmds ) = @_;
+
+  if ( !Rex::is_ssh() && $^O =~ m/^MSWin/ ) {
+    return 1;
+  }
+
+  for my $cmd (@cmds) {
+    my @ret = Rex::Helper::Run::i_run "which $cmd";
+    next if ( $? != 0 );
+
+    if ( grep { /^no.*in/ } @ret ) {
+      next;
+    }
+    else {
+      return $ret[0];
+    }
+  }
+
+  return 0;
+}
+
 1;

--- a/lib/Rex/Interface/Exec/Base.pm
+++ b/lib/Rex/Interface/Exec/Base.pm
@@ -8,6 +8,7 @@ package Rex::Interface::Exec::Base;
 
 use strict;
 use warnings;
+use Carp;
 
 # VERSION
 
@@ -50,10 +51,11 @@ sub execute_line_based_operation {
 }
 
 sub can_run {
-  my ( $self, @commands_to_check ) = @_;
-  my $check_with_command = $^O =~ /^MSWin/ ? 'where' : 'which';
+  my ( $self, $commands_to_check, $check_with_command ) = @_;
 
-  for my $command (@commands_to_check) {
+  $check_with_command ||= "which";
+
+  for my $command ( @{$commands_to_check} ) {
     my @output = Rex::Helper::Run::i_run "$check_with_command $command";
 
     next if ( $? != 0 );

--- a/lib/Rex/Interface/Exec/Base.pm
+++ b/lib/Rex/Interface/Exec/Base.pm
@@ -50,22 +50,19 @@ sub execute_line_based_operation {
 }
 
 sub can_run {
-  my ( $self, @cmds ) = @_;
+  my ( $self, @commands_to_check ) = @_;
   my $check_with_command = $^O =~ /^MSWin/ ? 'where' : 'which';
 
-  for my $cmd (@cmds) {
-    my @ret = Rex::Helper::Run::i_run "$check_with_command $cmd";
-    next if ( $? != 0 );
+  for my $command (@commands_to_check) {
+    my @output = Rex::Helper::Run::i_run "$check_with_command $command";
 
-    if ( grep { /^no.*in/ } @ret ) {
-      next;
-    }
-    else {
-      return $ret[0];
-    }
+    next if ( $? != 0 );
+    next if ( grep { /^no $command in/ } @output ); # for solaris
+
+    return $output[0];
   }
 
-  return 0;
+  return undef;
 }
 
 1;

--- a/lib/Rex/Interface/Exec/Base.pm
+++ b/lib/Rex/Interface/Exec/Base.pm
@@ -51,13 +51,10 @@ sub execute_line_based_operation {
 
 sub can_run {
   my ( $self, @cmds ) = @_;
-
-  if ( !Rex::is_ssh() && $^O =~ m/^MSWin/ ) {
-    return 1;
-  }
+  my $check_with_command = $^O =~ /^MSWin/ ? 'where' : 'which';
 
   for my $cmd (@cmds) {
-    my @ret = Rex::Helper::Run::i_run "which $cmd";
+    my @ret = Rex::Helper::Run::i_run "$check_with_command $cmd";
     next if ( $? != 0 );
 
     if ( grep { /^no.*in/ } @ret ) {

--- a/lib/Rex/Interface/Exec/Local.pm
+++ b/lib/Rex/Interface/Exec/Local.pm
@@ -135,4 +135,12 @@ sub exec {
   return $out;
 }
 
+sub can_run {
+  my ( $self, $commands_to_check, $check_with_command ) = @_;
+
+  $check_with_command ||= $^O =~ /^MSWin/i ? 'where' : 'which';
+
+  return $self->SUPER::can_run($commands_to_check, $check_with_command);
+}
+
 1;

--- a/lib/Rex/Interface/Fs/Base.pm
+++ b/lib/Rex/Interface/Fs/Base.pm
@@ -89,12 +89,18 @@ sub chown {
   }
 
   my $exec = Rex::Interface::Exec->create;
-  $exec->exec("chown $recursive $user $file");
 
-  if ( $? == 0 ) { return 1; }
+  if ( $exec->can_run('chown') ) {
+    $exec->exec("chown $recursive $user $file");
 
-  die("Error running chown $recursive $user $file")
-    if ( Rex::Config->get_autodie );
+    if ( $? == 0 ) { return 1; }
+
+    die("Error running chown $recursive $user $file")
+      if ( Rex::Config->get_autodie );
+  }
+  else {
+    Rex::Logger::debug("Can't find `chown`.");
+  }
 }
 
 sub chgrp {
@@ -108,12 +114,18 @@ sub chgrp {
   }
 
   my $exec = Rex::Interface::Exec->create;
-  $exec->exec("chgrp $recursive $group $file");
 
-  if ( $? == 0 ) { return 1; }
+  if ( $exec->can_run('chgrp') ) {
+    $exec->exec("chgrp $recursive $group $file");
 
-  die("Error running chgrp $recursive $group $file")
-    if ( Rex::Config->get_autodie );
+    if ( $? == 0 ) { return 1; }
+
+    die("Error running chgrp $recursive $group $file")
+      if ( Rex::Config->get_autodie );
+  }
+  else {
+    Rex::Logger::debug("Can't find `chgrp`.");
+  }
 }
 
 sub chmod {
@@ -127,12 +139,18 @@ sub chmod {
   }
 
   my $exec = Rex::Interface::Exec->create;
-  $exec->exec("chmod $recursive $mode $file");
 
-  if ( $? == 0 ) { return 1; }
+  if ( $exec->can_run('chmod') ) {
+    $exec->exec("chmod $recursive $mode $file");
 
-  die("Error running chmod $recursive $mode $file")
-    if ( Rex::Config->get_autodie );
+    if ( $? == 0 ) { return 1; }
+
+    die("Error running chmod $recursive $mode $file")
+      if ( Rex::Config->get_autodie );
+  }
+  else {
+    Rex::Logger::debug("Can't find `chmod`.");
+  }
 }
 
 sub cp {

--- a/lib/Rex/Interface/Fs/Base.pm
+++ b/lib/Rex/Interface/Fs/Base.pm
@@ -90,7 +90,7 @@ sub chown {
 
   my $exec = Rex::Interface::Exec->create;
 
-  if ( $exec->can_run('chown') ) {
+  if ( $exec->can_run( ['chown'] ) ) {
     $exec->exec("chown $recursive $user $file");
 
     if ( $? == 0 ) { return 1; }
@@ -100,6 +100,7 @@ sub chown {
   }
   else {
     Rex::Logger::debug("Can't find `chown`.");
+    return 1; # fake success for windows
   }
 }
 
@@ -115,7 +116,7 @@ sub chgrp {
 
   my $exec = Rex::Interface::Exec->create;
 
-  if ( $exec->can_run('chgrp') ) {
+  if ( $exec->can_run( ['chgrp'] ) ) {
     $exec->exec("chgrp $recursive $group $file");
 
     if ( $? == 0 ) { return 1; }
@@ -125,6 +126,7 @@ sub chgrp {
   }
   else {
     Rex::Logger::debug("Can't find `chgrp`.");
+    return 1; # fake success for windows
   }
 }
 
@@ -140,7 +142,7 @@ sub chmod {
 
   my $exec = Rex::Interface::Exec->create;
 
-  if ( $exec->can_run('chmod') ) {
+  if ( $exec->can_run( ['chmod'] ) ) {
     $exec->exec("chmod $recursive $mode $file");
 
     if ( $? == 0 ) { return 1; }
@@ -150,6 +152,7 @@ sub chmod {
   }
   else {
     Rex::Logger::debug("Can't find `chmod`.");
+    return 1; # fake success for windows
   }
 }
 

--- a/t/can_run.t
+++ b/t/can_run.t
@@ -1,0 +1,32 @@
+use strict;
+use warnings;
+
+use Test::More tests => 5;
+
+use_ok 'Rex::Commands::Run';
+
+{
+  my $command_to_check = $^O =~ /^MSWin/ ? 'where' : 'which';
+  my $result = can_run($command_to_check);
+  ok( $result, 'Found checker command' );
+}
+
+{
+  my $command_to_check = "I'm pretty sure this command doesn't exist anywhere";
+  my $result           = can_run($command_to_check);
+  ok( !$result, 'Non-existing command not found' );
+}
+
+{
+  my @commands_to_check = $^O =~ /^MSWin/ ? 'where' : 'which';
+  push @commands_to_check, 'non-existing command';
+  my $result = can_run(@commands_to_check);
+  ok( $result, 'Multiple commands - existing first' );
+}
+
+{
+  my @commands_to_check = $^O =~ /^MSWin/ ? 'where' : 'which';
+  unshift @commands_to_check, 'non-existing command';
+  my $result = can_run(@commands_to_check);
+  ok( $result, 'Multiple commands - non-existing first' );
+}

--- a/t/file.t
+++ b/t/file.t
@@ -5,13 +5,14 @@ use Cwd 'getcwd';
 my $cwd = getcwd;
 
 BEGIN {
-  use Test::More tests => 57;
+  use Test::More tests => 58;
   use Data::Dumper;
 
   use_ok 'Rex';
   use_ok 'Rex::Commands::File';
   use_ok 'Rex::Commands::Fs';
   use_ok 'Rex::Commands::Gather';
+  use_ok 'Rex::Commands::Run';
   use_ok 'Rex::Config';
   Rex::Commands::File->import;
   Rex::Commands::Fs->import;
@@ -50,11 +51,13 @@ file(
   mode    => 777
 );
 
-SKIP: {
-  skip "chmod not for windows", 1 unless ! is_windows();
-  my %stats = Rex::Commands::Fs::stat($filename);
-  is( $stats{mode}, "0777" || is_windows(), "fs chmod ok" );
-};
+my %stats = Rex::Commands::Fs::stat($filename);
+if ( is_windows() && !can_run('chmod') ) {
+  is( $stats{mode}, "0666", "windows without chmod" );
+}
+else {
+  is( $stats{mode}, "0777", "fs chmod ok" );
+}
 
 my $changed = 0;
 my $content = cat($filename);


### PR DESCRIPTION
This is an ongoing work to refactor the `can_run` command. We are trying to push the implementation to the Interface::Exec level and to make it work with Windows (providing a clean way of fixing #514) + possible bugfixes