### PR TITLE
added a Rex::Logger::masq() function that can masq sensitiv data for logging output. (fix for RexOps/Rex#554)

### DIFF
--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -56,7 +56,7 @@ sub connect {
 
   Rex::Logger::debug( "Using user: " . $user );
   Rex::Logger::debug(
-    "Using password: " . ( $pass ? "***********" : "<no password>" ) );
+    Rex::Logger::masq( "Using password: %s", ( $pass || "" ) ) );
 
   $self->{server} = $server;
 
@@ -88,14 +88,19 @@ sub connect {
     push @ssh_opts_line, "-o" => $key . "=" . $ssh_opts{$key};
   }
 
-  my @connection_props = ( $server, user => $user, port => $port );
+  my @connection_props = ( "" . $server ); # stringify server object, so that a dumper don't print out passwords.
+  push @connection_props, ( user => $user, port => $port );
   push @connection_props, master_opts      => \@ssh_opts_line if @ssh_opts_line;
   push @connection_props, default_ssh_opts => \@ssh_opts_line if @ssh_opts_line;
   push @connection_props, proxy_command    => $proxy_command  if $proxy_command;
 
   my @auth_types_to_try;
   if ( $auth_type && $auth_type eq "pass" ) {
-    Rex::Logger::debug("OpenSSH: pass_auth: $server:$port - $user - ******");
+    Rex::Logger::debug(
+      Rex::Logger::masq(
+        "OpenSSH: pass_auth: $server:$port - $user - %s", $pass
+      )
+    );
     push @auth_types_to_try, "pass";
   }
   elsif ( $auth_type && $auth_type eq "krb5" ) {

--- a/lib/Rex/Interface/Connection/SSH.pm
+++ b/lib/Rex/Interface/Connection/SSH.pm
@@ -56,7 +56,7 @@ sub connect {
 
   Rex::Logger::debug( "Using user: " . $user );
   Rex::Logger::debug(
-    "Using password: " . ( $pass ? "***********" : "<no password>" ) );
+    Rex::Logger::masq( "Using password: %s", ( $pass || "" ) ) );
 
   $self->{server} = $server;
 

--- a/lib/Rex/Logger.pm
+++ b/lib/Rex/Logger.pm
@@ -264,6 +264,19 @@ sub format_string {
   return $line;
 }
 
+sub masq {
+  my ( $format, @params ) = @_;
+
+  return $format if scalar @params == 0;
+  return $format if scalar( grep { defined } @params ) == 0;
+
+  if ( exists $ENV{REX_DEBUG_INSECURE} && $ENV{REX_DEBUG_INSECURE} eq "1" ) {
+    return sprintf( $format, @params );
+  }
+
+  return sprintf( $format, ("**********") x @params );
+}
+
 =back
 
 =cut

--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -594,7 +594,17 @@ sub connect {
 
   my $rex_int_conf = Rex::Commands::get("rex_internals");
   Rex::Logger::debug( Dumper($rex_int_conf) );
-  Rex::Logger::debug( Dumper($auth) );
+  Rex::Logger::debug("Auth-Information inside Task:");
+  for my $key ( keys %{$auth} ) {
+    my $data = $auth->{$key};
+    if ( $key eq "password" ) {
+      $data = Rex::Logger::masq( "%s", $data );
+    }
+
+    $data ||= "";
+
+    Rex::Logger::debug("$key => [[$data]]");
+  }
 
   $auth->{public_key} = resolv_path( $auth->{public_key}, 1 )
     if ( $auth->{public_key} );

--- a/t/logger.t
+++ b/t/logger.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 12;
 
 use_ok 'Rex';
 use_ok 'Rex::Logger';
@@ -84,7 +84,8 @@ ok( -e $logfile, 'Logfile still available' );
 unlink $logfile;
 ok( !-e $logfile, 'Logfile unlinked' );
 
-done_testing();
+my $masq_s = Rex::Logger::masq( "This is a password: %s", "pass" );
+is( $masq_s, "This is a password: **********", "Log-Masquerading" );
 
 sub _get_log {
   local $/;


### PR DESCRIPTION
If someone want to print out also the sensitiv data, he can add an environment variable. I don't want to add an cli option for this, because the environment variable rises more attention than a cli option.

```
REX_DEBUG_INSECURE=1 rex ...
```

references: #554 