### PR TITLE
Describe platform-specific dependencies

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,8 +8,12 @@ copyright_holder = Jan Gehring
 
 [ManifestSkip]
 [Prereqs]
-Net::SSH2 = 0
 perl = 5.008008
+[OSPrereqs / !~MSWin]
+Net::OpenSSH = 0
+Net::SFTP::Foreign = 0
+[OSPrereqs / ~MSWin]
+Net::SSH2 = 0
 [Prereqs / BuildRequires]
 Test::Pod = 0
 [AutoPrereqs]


### PR DESCRIPTION
Let's depend on Net::SSH2 only on Windows systems, and on Net::OpenSSH + Net::SFTP::Foreign on anything else. Rex defaults to this latter pair of modules already if they are installed.