### PR TITLE
Test failure without Net::SSH2

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -725,6 +725,21 @@ sub get_connection_type {
       Rex::Logger::debug(
         "Found Net::OpenSSH and Net::SFTP::Foreign - using it as default");
       $connection_type = "OpenSSH";
+      return "OpenSSH";
+    }
+  }
+
+  if ( !$connection_type ) {
+    my $has_net_ssh2 = 0;
+    eval {
+      Net::SSH2->require;
+      $has_net_ssh2 = 1;
+      1;
+    };
+
+    if ($has_net_ssh2) {
+      $connection_type = "SSH";
+      return "SSH";
     }
   }
 

--- a/lib/Rex/Interface/Connection.pm
+++ b/lib/Rex/Interface/Connection.pm
@@ -15,7 +15,7 @@ sub create {
   my ( $class, $type ) = @_;
 
   unless ($type) {
-    $type = "SSH";
+    $type = Rex::Config->get_connection_type();
   }
 
   my $class_name = "Rex::Interface::Connection::$type";

--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -115,7 +115,6 @@ Returns the current connection object.
 
 sub connection {
   my ($self) = @_;
-
   if ( !exists $self->{connection} || !$self->{connection} ) {
     $self->{connection} =
       Rex::Interface::Connection->create( $self->get_connection_type );
@@ -356,7 +355,7 @@ sub get_connection_type {
     return "OpenSSH";
   }
   elsif ( $self->is_remote && $self->want_connect ) {
-    return "SSH";
+    return Rex::Config->get_connection_type();
   }
   elsif ( $self->is_remote ) {
     return "Fake";

--- a/t/base.t
+++ b/t/base.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 167;
+use Test::More tests => 168;
 
 my %have_mods = (
   'Net::SSH2'             => 1,
@@ -38,14 +38,19 @@ SKIP: {
 }
 
 SKIP: {
-  diag
-    "SSH module not found. You need Net::SSH2 or Net::OpenSSH module to connect to servers via SSH."
-    unless ( $have_mods{'Net::SSH2'} or $have_mods{'Net::OpenSSH'} );
   skip
-    "SSH module not found. You need Net::SSH2 or Net::OpenSSH module to connect to servers via SSH.",
+    "Net::SSH2 module not found. You need Net::SSH2 or Net::OpenSSH module to connect to servers via SSH.",
     1
-    unless ( $have_mods{'Net::SSH2'} or $have_mods{'Net::OpenSSH'} );
+    unless $have_mods{'Net::SSH2'};
   use_ok 'Rex::Interface::Connection::SSH';
+}
+
+SKIP: {
+  skip
+    "Net::OpenSSH module not found. You need Net::SSH2 or Net::OpenSSH module to connect to servers via SSH.",
+    1
+    unless $have_mods{'Net::OpenSSH'};
+  use_ok 'Rex::Interface::Connection::OpenSSH';
 }
 
 SKIP: {

--- a/t/task.t
+++ b/t/task.t
@@ -20,7 +20,7 @@ unless ( $have_mods{'Net::SSH2'} or $have_mods{'Net::OpenSSH'} ) {
     'SSH module not found. You need Net::SSH2 or Net::OpenSSH to connect to servers via SSH.';
 }
 else {
-  plan tests => 33;
+  plan tests => 35;
 }
 
 use_ok 'Rex::Task';
@@ -48,14 +48,28 @@ is( $t1->is_local, 0, "is task not local" );
 $t1->set_desc("Description");
 is( $t1->desc, "Description", "get/set description" );
 
-is( $t1->get_connection_type, "SSH", "get connection type for ssh" );
-is( $t1->want_connect,        1,     "want a connection?" );
+is(
+  $t1->get_connection_type,
+  ( $have_mods{"Net::OpenSSH"} ? "OpenSSH" : "SSH" ),
+  "get connection type for ssh"
+);
+is( $t1->want_connect, 1, "want a connection?" );
 $t1->modify( "no_ssh", 1 );
 is( $t1->want_connect,        0,      "want no connection?" );
 is( $t1->get_connection_type, "Fake", "get connection type for fake" );
 $t1->modify( "no_ssh", 0 );
-is( $t1->want_connect,        1,     "want a connection?" );
+is( $t1->want_connect, 1, "want a connection?" );
+is(
+  $t1->get_connection_type,
+  ( $have_mods{"Net::OpenSSH"} ? "OpenSSH" : "SSH" ),
+  "get connection type for ssh"
+);
+
+Rex::Config->set( "connection" => "SSH" );
 is( $t1->get_connection_type, "SSH", "get connection type for ssh" );
+
+Rex::Config->set( "connection" => "OpenSSH" );
+is( $t1->get_connection_type, "OpenSSH", "get connection type for ssh" );
 
 $t1->set_user("root");
 is( $t1->user, "root", "get/set the user" );


### PR DESCRIPTION
If Net::SSH2 is not installed, `t/base.t` and `t/task.t` fails, e.g. preventing installation from CPAN or from source with `dzil install`.

I modified `t/base.t` to recognize SSH modules separately, but I couldn't fix `t/task.t` easily yet. The problem happens at [t/task.t#L56](https://github.com/RexOps/Rex/blob/master/t/task.t#L56).

@krimdomu: could you please take a look at it and push a fix or turn me in the right direction?