### PR TITLE
added YAML DeepMerge CMDB - fixes RexOps/Rex#499

### DIFF
--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -597,15 +597,7 @@ sub import {
 
         Rex::Commands::set(
           cmdb => {
-            type => "YAML",
-            path => [
-              "cmdb/{operatingsystem}/{hostname}.yml",
-              "cmdb/{operatingsystem}/default.yml",
-              "cmdb/{environment}/{hostname}.yml",
-              "cmdb/{environment}/default.yml",
-              "cmdb/{hostname}.yml",
-              "cmdb/default.yml",
-            ],
+            type => "Rex::CMDB::YAML::Default",
           }
         );
 

--- a/lib/Rex/CMDB.pm
+++ b/lib/Rex/CMDB.pm
@@ -94,6 +94,10 @@ sub cmdb {
     $klass = "Rex::CMDB::$klass";
   }
 
+  if ( $klass eq "Rex::CMDB::YAML" ) {
+    $klass = "Rex::CMDB::YAML::Default";
+  }
+
   eval "use $klass";
   if ($@) {
     die("CMDB provider ($klass) not found: $@");

--- a/lib/Rex/CMDB/YAML/DeepMerge.pm
+++ b/lib/Rex/CMDB/YAML/DeepMerge.pm
@@ -1,0 +1,89 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::CMDB::YAML::DeepMerge;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use base qw(Rex::CMDB::YAML::Default);
+
+use Rex::Commands -no => [qw/get/];
+use Rex::Logger;
+use YAML;
+use Data::Dumper;
+use Hash::Merge qw/merge/;
+
+sub new {
+  my $that  = shift;
+  my $proto = ref($that) || $that;
+  my $self  = $proto->SUPER::new(@_);
+
+  $self->{merge_behavior} ||= 'LEFT_PRECEDENT';
+
+  bless( $self, $proto );
+  return $self;
+}
+
+sub get {
+  my ( $self, $item, $server ) = @_;
+
+  my (@files);
+
+  my $merge = Hash::Merge->new( $self->{merge_behavior} );
+
+  if ( !ref $self->{path} ) {
+    my $env       = environment;
+    my $yaml_path = $self->{path};
+    @files = (
+      "$yaml_path/$env/$server.yml", "$yaml_path/$env/default.yml",
+      "$yaml_path/$server.yml",      "$yaml_path/default.yml"
+    );
+  }
+  elsif ( ref $self->{path} eq "CODE" ) {
+    @files = $self->{path}->();
+  }
+  elsif ( ref $self->{path} eq "ARRAY" ) {
+    @files = @{ $self->{path} };
+  }
+
+  @files = map { $self->_parse_path($_) } @files;
+
+  my $all = {};
+  Rex::Logger::debug( Dumper( \@files ) );
+
+  my $global_cmdb = {};
+
+  for my $file (@files) {
+    Rex::Logger::debug("CMDB - Opening $file");
+    if ( -f $file ) {
+      my $ref;
+      eval {
+        $ref = YAML::LoadFile($file);
+        1;
+      } or do {
+        die "Error parsing YAML file: $file";
+      };
+
+      $all = $merge->merge( $all, $ref );
+    }
+  }
+
+  if ( !$item ) {
+    return $all;
+  }
+  else {
+    return $all->{$item};
+  }
+
+  Rex::Logger::debug("CMDB - no item ($item) found");
+
+  return;
+}
+
+1;

--- a/lib/Rex/CMDB/YAML/Default.pm
+++ b/lib/Rex/CMDB/YAML/Default.pm
@@ -4,7 +4,7 @@
 # vim: set ts=2 sw=2 tw=0:
 # vim: set expandtab:
 
-package Rex::CMDB::YAML;
+package Rex::CMDB::YAML::Default;
 
 use strict;
 use warnings;
@@ -23,8 +23,18 @@ sub new {
   my $proto = ref($that) || $that;
   my $self  = {@_};
 
-  bless( $self, $proto );
+  if ( !$self->{path} ) {
+    $self->{path} = [
+      "cmdb/{operatingsystem}/{hostname}.yml",
+      "cmdb/{operatingsystem}/default.yml",
+      "cmdb/{environment}/{hostname}.yml",
+      "cmdb/{environment}/default.yml",
+      "cmdb/{hostname}.yml",
+      "cmdb/default.yml",
+    ];
+  }
 
+  bless( $self, $proto );
   return $self;
 }
 
@@ -65,7 +75,13 @@ sub get {
       #my $content = eval { local ( @ARGV, $/ ) = ($file); <>; };
       #$content .= "\n";    # for safety
 
-      my $ref = YAML::LoadFile($file);
+      my $ref;
+      eval {
+        $ref = YAML::LoadFile($file);
+        1;
+      } or do {
+        die "Error parsing YAML file: $file";
+      };
 
       if ( !$item ) {
         for my $key ( keys %{$ref} ) {

--- a/t/cmdb/default.yml
+++ b/t/cmdb/default.yml
@@ -1,4 +1,13 @@
 ntp:
-   - ntp1
-   - ntp2
+  - ntp1
+  - ntp2
 name: defaultname
+
+newntp:
+  - ntp1
+  - ntp2
+
+users:
+  root:
+    id: 0
+    password: proot

--- a/t/cmdb/default/default.yml
+++ b/t/cmdb/default/default.yml
@@ -1,3 +1,15 @@
 dns:
-   - 1.1.1.1
-   - 2.2.2.2
+  - 1.1.1.1
+  - 2.2.2.2
+vhost2:
+  name: defaulthost
+  doc_root: /var/www
+
+
+users:
+  user01:
+    id: 500
+    password: puser01
+  user02:
+    id: 600
+    password: puser02

--- a/t/cmdb/default/foo.yml
+++ b/t/cmdb/default/foo.yml
@@ -1,3 +1,10 @@
 vhost:
-   name: foohost
-   doc_root: /var/www
+  name: foohost
+  doc_root: /var/www
+
+vhost2:
+  name: vhost2foo
+
+newntp:
+  - ntpdefaultfoo01
+  - ntpdefaultfoo02

--- a/t/cmdb_deepmerge.t
+++ b/t/cmdb_deepmerge.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+
+use Test::More tests => 4;
+use Data::Dumper;
+
+use_ok 'Rex::CMDB';
+use_ok 'Rex::Commands';
+use_ok 'Rex::Commands::File';
+
+Rex::Commands->import;
+Rex::CMDB->import;
+
+set(
+  cmdb => {
+    type => "Rex::CMDB::YAML::DeepMerge",
+    path => "t/cmdb",
+  }
+);
+
+my $foo_all = get( cmdb( undef, "foo" ) );
+
+is_deeply(
+  $foo_all,
+  {
+    'ntp'    => [ 'ntp1',            'ntp2' ],
+    'newntp' => [ 'ntpdefaultfoo01', 'ntpdefaultfoo02', 'ntp1', 'ntp2' ],
+    'dns'    => [ '1.1.1.1',         '2.2.2.2' ],
+    'vhost' => {
+      'name'     => 'foohost',
+      'doc_root' => '/var/www'
+    },
+    'name'   => 'foo',
+    'vhost2' => {
+      'name'     => 'vhost2foo',
+      'doc_root' => '/var/www'
+    },
+    'users' => {
+      'root' => {
+        'password' => 'proot',
+        'id'       => '0'
+      },
+      'user02' => {
+        'password' => 'puser02',
+        'id'       => '600'
+      },
+      'user01' => {
+        'password' => 'puser01',
+        'id'       => '500'
+      }
+    }
+  },
+  "DeepMerge CMDB"
+);
+
+


### PR DESCRIPTION
This adds a DeepMerge YAML CMDB.

To load it:

```perl
set cmdb => {
  type => 'Rex::CMDB::YAML::DeepMerge',
};
``` 

To set merge behavior:
```perl
set cmdb => {
  type => 'Rex::CMDB::YAML::DeepMerge',
  merge_behavior => 'SOME-TYPE',
};
```

The merge is done with Hash::Merge (https://metacpan.org/pod/Hash::Merge) so the behavior can also be customized.