### PR TITLE
stat() should return a hash or undef.

### DIFF
--- a/lib/Rex/Commands/Fs.pm
+++ b/lib/Rex/Commands/Fs.pm
@@ -522,7 +522,11 @@ sub stat {
   Rex::Logger::debug("Getting fs stat from $file");
 
   my $fs = Rex::Interface::Fs->create;
-  %ret = $fs->stat($file) or die("Can't stat $file");
+
+  # may return undef, so capture into a list first.
+  my @stat = $fs->stat($file);
+  die("Can't stat $file") if !defined $stat[0];
+  %ret = @stat;
 
   return %ret;
 }

--- a/lib/Rex/Interface/Fs/HTTP.pm
+++ b/lib/Rex/Interface/Fs/HTTP.pm
@@ -77,6 +77,8 @@ sub stat {
   if ( $resp->{ok} ) {
     return %{ $resp->{stat} };
   }
+
+  return undef;
 }
 
 sub is_readable {

--- a/lib/Rex/Interface/Fs/Local.pm
+++ b/lib/Rex/Interface/Fs/Local.pm
@@ -131,6 +131,7 @@ sub stat {
     return %ret;
   }
 
+  return undef;
 }
 
 sub is_readable {

--- a/lib/Rex/Interface/Fs/OpenSSH.pm
+++ b/lib/Rex/Interface/Fs/OpenSSH.pm
@@ -117,7 +117,7 @@ sub stat {
   my $sftp = Rex::get_sftp();
   my $ret  = $sftp->stat($file);
 
-  if ( !$ret ) { return; }
+  if ( !$ret ) { return undef; }
 
   my %ret = (
     mode  => sprintf( "%04o", $ret->perm & 07777 ),

--- a/lib/Rex/Interface/Fs/SSH.pm
+++ b/lib/Rex/Interface/Fs/SSH.pm
@@ -134,7 +134,7 @@ sub stat {
   my $sftp = Rex::get_sftp();
   my %ret  = $sftp->stat($file);
 
-  if ( !%ret ) { return; }
+  if ( !%ret ) { return undef; }
 
   $ret{'mode'} = sprintf( "%04o", $ret{'mode'} & 07777 );
 

--- a/lib/Rex/Interface/Fs/Sudo.pm
+++ b/lib/Rex/Interface/Fs/Sudo.pm
@@ -167,7 +167,7 @@ sub stat {
   );
 
   if ( !$out ) {
-    return ();
+    return undef;
   }
 
   my $tmp = decode_json($out);

--- a/t/fs.t
+++ b/t/fs.t
@@ -1,8 +1,16 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More tests => 2;
 use Data::Dumper;
 
 use_ok 'Rex::Commands::Fs';
 
+my $fake_file = "file_that_does_not_exist";
+eval { Rex::Commands::Fs::stat($fake_file); };
+my $err = $@;
+like(
+  $err,
+  qr/^Can't stat $fake_file/,
+  "Trying to stat a non-existent file throws an exception"
+);

--- a/t/interface_fs_local.t
+++ b/t/interface_fs_local.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 8;
 use Data::Dumper;
 
 use_ok 'Rex::Interface::Fs';
@@ -22,3 +22,5 @@ is( $fs->is_dir("foo"), 1, "mkdir" );
 $fs->rmdir("foo");
 is( $fs->is_dir("foo"), undef, "rmdir" );
 
+is( $fs->stat("some_file_that_does_not_exist"),
+  undef, "stat should return undef for non-existent files" );


### PR DESCRIPTION
This previously would return 0 for non-existing files. When called like 'my %stat = $fs->stat("foo")', you would get 'Odd number of elements in hash assignment' perl warnings.