### PR TITLE
Sort tasklist output

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -485,7 +485,7 @@ CHECK_OVERWRITE: {
     }
     else {
       my $max_task_str = max map { length } @tasks;
-      for my $task (@tasks) {
+      for my $task ( sort @tasks ) {
         my $padding = $max_task_str - length($task);
         print " $task  "
           . ' ' x $padding . " "
@@ -494,14 +494,15 @@ CHECK_OVERWRITE: {
           _print_color(
             "    Servers: "
               . join( ", ",
-              @{ Rex::TaskList->create()->get_task($task)->server } )
+              sort { $a->to_s cmp $b->to_s }
+                @{ Rex::TaskList->create()->get_task($task)->server } )
               . "\n"
           );
         }
       }
     }
     _print_color( "Batches\n", 'yellow' ) if ( Rex::Batch->get_batchs );
-    for my $batch ( Rex::Batch->get_batchs ) {
+    for my $batch ( sort Rex::Batch->get_batchs ) {
       printf "  %-30s %s\n", $batch, Rex::Batch->get_desc($batch);
       if ( $opts{'v'} ) {
         _print_color(
@@ -509,7 +510,7 @@ CHECK_OVERWRITE: {
       }
     }
     my @envs = map { Rex::Commands->get_environment($_) }
-      Rex::Commands->get_environments();
+      sort Rex::Commands->get_environments();
     _print_color( "Environments\n", "yellow" ) if scalar @envs;
     for my $e (@envs) {
       printf "  %-30s %s\n", $e->{name}, $e->{description};
@@ -517,8 +518,9 @@ CHECK_OVERWRITE: {
 
     my %groups = Rex::Group->get_groups;
     _print_color( "Server Groups\n", "yellow" ) if ( keys %groups );
-    for my $group ( keys %groups ) {
-      printf "  %-30s %s\n", $group, join( ", ", @{ $groups{$group} } );
+    for my $group ( sort keys %groups ) {
+      printf "  %-30s %s\n", $group,
+        join( ", ", sort { $a->to_s cmp $b->to_s } @{ $groups{$group} } );
     }
 
     Rex::global_sudo(0);

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -494,8 +494,7 @@ CHECK_OVERWRITE: {
           _print_color(
             "    Servers: "
               . join( ", ",
-              sort { $a->to_s cmp $b->to_s }
-                @{ Rex::TaskList->create()->get_task($task)->server } )
+              sort @{ Rex::TaskList->create()->get_task($task)->server } )
               . "\n"
           );
         }
@@ -519,8 +518,7 @@ CHECK_OVERWRITE: {
     my %groups = Rex::Group->get_groups;
     _print_color( "Server Groups\n", "yellow" ) if ( keys %groups );
     for my $group ( sort keys %groups ) {
-      printf "  %-30s %s\n", $group,
-        join( ", ", sort { $a->to_s cmp $b->to_s } @{ $groups{$group} } );
+      printf "  %-30s %s\n", $group, join( ", ", sort @{ $groups{$group} } );
     }
 
     Rex::global_sudo(0);

--- a/lib/Rex/Group/Entry/Server.pm
+++ b/lib/Rex/Group/Entry/Server.pm
@@ -16,14 +16,16 @@ use Rex::Helper::System;
 use Rex::Config;
 use Rex::Interface::Exec;
 use Data::Dumper;
+use Sort::Naturally;
 require Rex::Helper::Run;
 
 use List::MoreUtils qw(uniq);
 
 use overload
-  'eq' => sub { shift->is_eq(@_); },
-  'ne' => sub { shift->is_ne(@_); },
-  '""' => sub { shift->to_s(@_); };
+  'eq'  => sub { shift->is_eq(@_); },
+  'ne'  => sub { shift->is_ne(@_); },
+  '""'  => sub { shift->to_s(@_); },
+  'cmp' => sub { shift->compare(@_); };
 
 use attributes;
 
@@ -124,6 +126,11 @@ sub is_ne {
   if ( $comp ne $self->to_s ) {
     return 1;
   }
+}
+
+sub compare {
+  my ( $self, $comp ) = @_;
+  return ncmp( $self->to_s, $comp->to_s );
 }
 
 sub has_auth {


### PR DESCRIPTION
@krimdomu: the first commit sorts everything in the tasklist output alphabetically as correctly as possible without adding any new dependencies. However, if we can add `Sort::Naturally` as a dependency, then the second commit allows the output to be sorted, well, "naturally", e.g. server names containing mixed alphabetical and numerical parts would also be sorted in a "natural" way. For example `web-10` comes after `web-2`, and not before. It also works when server names are merely IPs, or if they contain multiple alphabetical and numerical substrings (e.g. `rack10-host-1`, `rack2-host-2`).

Please discuss/merge either only the first commit or both.