### PR TITLE
Fix SCM documentation

### DIFF
--- a/lib/Rex/Commands/SCM.pm
+++ b/lib/Rex/Commands/SCM.pm
@@ -21,7 +21,7 @@ All these functions are not idempotent.
  use Rex::Commands::SCM;
  
  set repository => "myrepo",
-    url => "git@foo.bar:myrepo.git";
+    url => 'git@foo.bar:myrepo.git';
  
  set repository => "myrepo2",
     url => "https://foo.bar/myrepo",


### PR DESCRIPTION
Within double quotes, perl tries to expand `@foo` in the example which leads to an error. The `@` can be escaped, but I think it's cleaner to express the intention that the quoted string does not need to be expanded.