### PR TITLE
Allow cron operations without specifying the user

### DIFF
--- a/lib/Rex/Cron/Base.pm
+++ b/lib/Rex/Cron/Base.pm
@@ -159,7 +159,9 @@ sub write_cron {
 
 sub activate_user_cron {
   my ( $self, $file, $user ) = @_;
-  i_run "crontab -u $user $file";
+  my $command = 'crontab';
+  $command .= " -u $user" if defined $user;
+  i_run "$command $file";
   unlink $file;
 }
 

--- a/lib/Rex/Cron/Base.pm
+++ b/lib/Rex/Cron/Base.pm
@@ -165,7 +165,9 @@ sub activate_user_cron {
 
 sub read_user_cron {
   my ( $self, $user ) = @_;
-  my @lines = i_run "crontab -u $user -l";
+  my $command = 'crontab -l';
+  $command .= " -u $user" if defined $user;
+  my @lines = i_run $command;
   $self->parse_cron(@lines);
 }
 


### PR DESCRIPTION
If we don't require the user to be specified for cronjob operations, it would make it possible for users to manage their _own_ crontabs.