### PR TITLE
Fixed yaml output for server groups

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -452,9 +452,9 @@ CHECK_OVERWRITE: {
 
     for my $group ( keys %groups ) {
       my @servers = 
-        map { $_->name }
         map { $_->get_servers }
         Rex::Group->get_group_object($group)->get_servers;
+      @servers = map { $_->name } @servers if $opts{'y'} >= 2;
       $real_groups{$group} = \@servers;
     }
 

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -451,7 +451,9 @@ CHECK_OVERWRITE: {
     my %real_groups;
 
     for my $group ( keys %groups ) {
-      my @servers = map { $_->get_servers }
+      my @servers = 
+        map { $_->name }
+        map { $_->get_servers }
         Rex::Group->get_group_object($group)->get_servers;
       $real_groups{$group} = \@servers;
     }


### PR DESCRIPTION
`rex -Ty` was dumping a Perl object Rex::Group::Entry::Server as yaml.  This patch makes it so we are dumping data and its a lot more readable.