### PR TITLE
Gather.pm: add another Red Hat synonym for RHWS version 3

### DIFF
--- a/lib/Rex/Commands/Gather.pm
+++ b/lib/Rex/Commands/Gather.pm
@@ -245,8 +245,8 @@ sub is_redhat {
     "Fedora",                      "Redhat",
     "CentOS",                      "Scientific",
     "RedHatEnterpriseServer",      "RedHatEnterpriseES",
-    "RedHatEnterpriseWorkstation", "Amazon",
-    "ROSAEnterpriseServer"
+    "RedHatEnterpriseWorkstation", "RedHatEnterpriseWS",
+    "Amazon",                      "ROSAEnterpriseServer"
   );
 
   if ( grep { /$os/i } @redhat_clones ) {


### PR DESCRIPTION
There's another operatingsystemtype for Red Hat Workstation version 3; add it to Gather.pm