### PR TITLE
Include provided modules in META.yml

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -33,3 +33,4 @@ repository.web  = https://github.com/RexOps/Rex
 repository.type = git
 x_twitter       = https://twitter.com/RexOps
 x_IRC           = irc://irc.freenode.net/rex
+[MetaProvides::Package]


### PR DESCRIPTION
I tried previously to enable this, but at the time it was breaking tests on perl-5.8. Now it seems to support it, so let's try again :) Full history below:

This reverts commit 51d4c40775eb38def1254c55aa13b7fa25c10afd.

Since v2.001003, Dist::Zilla::Plugin::MetaProvides::Packages works
with perl-5.8, so we can start using it.

Previous commit history:

Revert "Include provided modules in META.yml"

This reverts commit 86a5f6d9e03c2e1f6f3fcea999cb0622c379e4fc.

Dist::Zilla::Plugin::MetaProvides::Package requires >=perl-5.10.0,
thus breaking the tests for 5.8.9.