### PR TITLE
Log STDERR on errors when auto_die is enabled

### DIFF
--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -226,6 +226,7 @@ sub run {
   }
 
   my $out_ret;
+  my ( $out, $err );
 
   if ($changed) {
     my $path;
@@ -234,7 +235,6 @@ sub run {
       $path = join( ":", Rex::Config->get_path() );
     }
 
-    my ( $out, $err );
     my $exec = Rex::Interface::Exec->create;
     if ( exists $option->{timeout} && $option->{timeout} > 0 ) {
       eval {
@@ -301,7 +301,7 @@ sub run {
 
   if ( exists $option->{auto_die} && $option->{auto_die} ) {
     if ( $? != 0 ) {
-      die("Error executing: $cmd.\nOutput:\n$out_ret");
+      die("Error executing: $cmd.\nSTDOUT:\n$out\nSTDERR:\n$err");
     }
   }
 


### PR DESCRIPTION
When executed command fails it usualy writes error message to STDERR. But rex's "run" doesn't put it to the log and you often do not undestand what goes wrong. To analyze the problem you have to run rex again with -d option and it is not useful if your task is not idempotent or executing for a long time.

This patch simply adds STDERR to a log message.