### PR TITLE
Iptables.pm: show error from iptables on non-zero exit status

### DIFF
--- a/lib/Rex/Commands/Iptables.pm
+++ b/lib/Rex/Commands/Iptables.pm
@@ -280,11 +280,11 @@ sub iptables {
   }
 
   if ( can_run("iptables") ) {
-    run "iptables $cmd";
+    my $output = run "iptables $cmd";
 
     if ( $? != 0 ) {
       Rex::Logger::info( "Error setting iptable rule: $cmd", "warn" );
-      die("Error setting iptable rule: $cmd");
+      die("Error setting iptable rule: $cmd; command output: $output");
     }
   }
   else {


### PR DESCRIPTION
If there's something wrong with an IPTables rule you try to add to a host via the `iptables` DSL function, Rex should capture the output from `iptables` and display it, so that you can try and fix the offending `iptables` command(s).