### PR TITLE
Summarize success/failure at the end of a run

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -538,6 +538,7 @@ CHECK_OVERWRITE: {
   }
 
   Rex::Logger::info($_) for summarize();
+
   #print ">> $$\n";
   #print Dumper(\@exit_codes);
   # lock loeschen
@@ -777,7 +778,7 @@ sub summarize {
   my @msgs    = ("SUMMARY");
 
   my @failures = grep { $_->{exit_code} != 0 } @summary;
-  if (! @failures) {
+  if ( !@failures ) {
     push @msgs, "All tasks successful on all hosts";
     return @msgs;
   }

--- a/lib/Rex/Fork/Manager.pm
+++ b/lib/Rex/Fork/Manager.pm
@@ -27,18 +27,20 @@ sub new {
 }
 
 sub add {
-  my ( $self, $task, $start ) = @_;
-  my $f = Rex::Fork::Task->new( task => $task );
+  my ( $self, $coderef, $task, $server ) = @_;
+  my $f = Rex::Fork::Task->new(
+    coderef => $coderef,
+    task    => $task,
+    server  => $server,
+  );
 
   push( @{ $self->{'forks'} }, $f );
 
-  if ($start) {
-    $f->start;
-    ++$self->{'running'};
+  $f->start;
+  ++$self->{'running'};
 
-    if ( $self->{'running'} >= $self->{'max'} ) {
-      $self->wait_for_one;
-    }
+  if ( $self->{'running'} >= $self->{'max'} ) {
+    $self->wait_for_one;
   }
 }
 

--- a/lib/Rex/Fork/Task.pm
+++ b/lib/Rex/Fork/Task.pm
@@ -37,7 +37,7 @@ sub start {
     $self->{chld} = 1;
 
     eval { $self->{coderef}->($self) };
-    my $exit_code = $@ ? ($? || 1) : 0;
+    my $exit_code = $@ ? (($? >> 8) || 1) : 0;
     push @SUMMARY, {
       task      => $self->{task}->name,
       server    => $self->{server},

--- a/lib/Rex/Fork/Task.pm
+++ b/lib/Rex/Fork/Task.pm
@@ -37,12 +37,13 @@ sub start {
     $self->{chld} = 1;
 
     eval { $self->{coderef}->($self) };
-    my $exit_code = $@ ? (($? >> 8) || 1) : 0;
-    push @SUMMARY, {
+    my $exit_code = $@ ? ( ( $? >> 8 ) || 1 ) : 0;
+    push @SUMMARY,
+      {
       task      => $self->{task}->name,
       server    => $self->{server},
       exit_code => $exit_code,
-    };
+      };
 
     $self->{'running'} = 0;
     exit();

--- a/lib/Rex/Interface/Exec/Local.pm
+++ b/lib/Rex/Interface/Exec/Local.pm
@@ -119,8 +119,6 @@ sub exec {
 
   }
 
-  $? >>= 8;
-
   Rex::Logger::debug($out) if ($out);
   if ($err) {
     Rex::Logger::debug("========= ERR ============");

--- a/lib/Rex/Interface/Exec/OpenSSH.pm
+++ b/lib/Rex/Interface/Exec/OpenSSH.pm
@@ -51,10 +51,6 @@ sub _exec {
 
 END_OPEN:
   waitpid( $pid, 0 ) or die($!);
-  if ( $ssh->error || $? ) {
-    $? = $? >> 8;
-  }
-
   return ( $out, $err );
 }
 1;

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -288,7 +288,7 @@ sub is_task {
 sub run {
   my ( $self, $task, %options ) = @_;
 
-  my $fm = Rex::Fork::Manager->new(max => $self->get_thread_count($task));
+  my $fm = Rex::Fork::Manager->new( max => $self->get_thread_count($task) );
   my $task_name   = $task->name;
   my $all_servers = $task->server;
 
@@ -311,7 +311,8 @@ sub run {
       return $return_value;
     };
 
-    if ($self->{IN_TRANSACTION}) {
+    if ( $self->{IN_TRANSACTION} ) {
+
       # Inside a transaction -- no forking and no chance to get zombies.
       # This only happens if someone calls do_task() from inside a transaction.
       # Note the result is not appended to @SUMMARY.

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -288,52 +288,44 @@ sub is_task {
 sub run {
   my ( $self, $task, %options ) = @_;
 
-  my $task_name  = $task->name;
-  my @all_server = @{ $task->server };
+  my $fm = Rex::Fork::Manager->new(max => $self->get_thread_count($task));
+  my $task_name   = $task->name;
+  my $all_servers = $task->server;
 
-  my $fm = Rex::Fork::Manager->new( max => $self->get_thread_count($task) );
-
-  for my $server (@all_server) {
-
+  for my $server (@$all_servers) {
     my $forked_sub = sub {
-
       Rex::Logger::init();
-
-      # create a single task object for the run on $server
-
       Rex::Logger::info("Running task $task_name on $server");
-      my $run_task = $task->clone;
 
-      $run_task->run(
+      my $run_task     = $task->clone;
+      my $return_value = $run_task->run(
         $server,
         in_transaction => $self->{IN_TRANSACTION},
         params         => $options{params},
         args           => $options{args},
       );
 
-      # destroy cached os info
       Rex::Logger::debug("Destroying all cached os information");
-
       Rex::Logger::shutdown();
 
+      return $return_value;
     };
 
-    # add the worker (forked_sub) to the fork queue
-    unless ( $self->{IN_TRANSACTION} ) {
-
-      # not inside a transaction, so lets fork happyly...
-      $fm->add( $forked_sub, 1 );
+    if ($self->{IN_TRANSACTION}) {
+      # Inside a transaction -- no forking and no chance to get zombies.
+      # This only happens if someone calls do_task() from inside a transaction.
+      # Note the result is not appended to @SUMMARY.
+      $forked_sub->();
     }
     else {
-# inside a transaction, no little small funny kids, ... and no chance to get zombies :(
-      &$forked_sub();
+      # Not inside a transaction, so lets fork
+      # Add $forked_sub to the fork queue
+      $fm->add( $forked_sub, $task, $server->to_s );
     }
-
   }
 
   Rex::Logger::debug("Waiting for children to finish");
   my $ret = $fm->wait_for_all;
-
   Rex::reconnect_lost_connections();
 
   return $ret;
@@ -395,7 +387,7 @@ sub is_transaction {
 
 sub get_exit_codes {
   my ($self) = @_;
-  return @Rex::Fork::Task::PROCESS_LIST;
+  return map { $_->{exit_code} } @Rex::Fork::Task::SUMMARY;
 }
 
 sub get_thread_count {
@@ -414,5 +406,7 @@ sub get_thread_count {
   );
   return 1;
 }
+
+sub get_summary { @Rex::Fork::Task::SUMMARY }
 
 1;

--- a/lib/Rex/TaskList/Parallel_ForkManager.pm
+++ b/lib/Rex/TaskList/Parallel_ForkManager.pm
@@ -84,7 +84,7 @@ sub run {
       $fm->start and next;
 
       eval { $forked_sub->() };
-      my $exit_code = $@ ? ($? || 1) : 0;
+      my $exit_code = $@ ? (($? >> 8) || 1) : 0;
       push @SUMMARY, {
         task      => $task_name,
         server    => $server->to_s,

--- a/lib/Rex/TaskList/Parallel_ForkManager.pm
+++ b/lib/Rex/TaskList/Parallel_ForkManager.pm
@@ -21,13 +21,14 @@ use Rex::Report;
 use Time::HiRes qw(time);
 
 BEGIN {
+  use Rex::Shared::Var;
+  share qw(@SUMMARY);
+
   use Rex::Require;
   Parallel::ForkManager->require;
 }
 
 use base qw(Rex::TaskList::Base);
-
-my @PROCESS_LIST;
 
 sub new {
   my $that  = shift;
@@ -40,74 +41,62 @@ sub new {
 }
 
 sub run {
-  my ( $self, $task, %option ) = @_;
+  my ( $self, $task, %options ) = @_;
 
-  my $task_name  = $task->name;
-  my @all_server = @{ $task->server };
-
-  my $fm = Parallel::ForkManager->new( $self->get_thread_count($task) );
+  my $fm = Parallel::ForkManager->new($self->get_thread_count($task));
+  my $task_name   = $task->name;
+  my $all_servers = $task->server;
 
   $fm->run_on_finish(
     sub {
       my ( $pid, $exit_code ) = @_;
       Rex::Logger::debug("Fork exited: $pid -> $exit_code");
-      push @PROCESS_LIST, $exit_code;
     }
   );
 
-  for my $server (@all_server) {
-
+  for my $server (@$all_servers) {
     my $forked_sub = sub {
-
       Rex::Logger::init();
-
-      # create a single task object for the run on $server
-
       Rex::Logger::info("Running task $task_name on $server");
-      my $run_task = $task->clone;
 
-      $run_task->run(
+      my $run_task     = $task->clone;
+      my $return_value = $run_task->run(
         $server,
         in_transaction => $self->{IN_TRANSACTION},
-        params         => $option{params},
-        args           => $option{args},
+        params         => $options{params},
+        args           => $options{args},
       );
 
-      # destroy cached os info
       Rex::Logger::debug("Destroying all cached os information");
-
       Rex::Logger::shutdown();
 
+      return $return_value;
     };
 
-    # add the worker (forked_sub) to the fork queue
-    unless ( $self->{IN_TRANSACTION} ) {
-
-      # not inside a transaction, so lets fork happyly...
-      $fm->start and next;
-      eval {
-        $forked_sub->();
-        1;
-      } or do {
-        my $errcode = $?;
-
-        # exit with error
-        $errcode = 255 if !$errcode;         # unknown error
-        $errcode = 254 if ( $errcode > 255 );
-        exit $errcode;
-      };
-      $fm->finish;
+    if ($self->{IN_TRANSACTION}) {
+      # Inside a transaction -- no forking and no chance to get zombies.
+      # This only happens if someone calls do_task() from inside a transaction.
+      # Note the result is not appended to @SUMMARY.
+      $forked_sub->();
     }
     else {
-# inside a transaction, no little small funny kids, ... and no chance to get zombies :(
-      &$forked_sub();
-    }
+      # Not inside a transaction, so lets fork
+      $fm->start and next;
 
+      eval { $forked_sub->() };
+      my $exit_code = $@ ? ($? || 1) : 0;
+      push @SUMMARY, {
+        task      => $task_name,
+        server    => $server->to_s,
+        exit_code => $exit_code,
+      };
+
+      $fm->finish;
+    }
   }
 
   Rex::Logger::debug("Waiting for children to finish");
   my $ret = $fm->wait_all_children;
-
   Rex::reconnect_lost_connections();
 
   return $ret;
@@ -115,7 +104,19 @@ sub run {
 
 sub get_exit_codes {
   my ($self) = @_;
-  return @PROCESS_LIST;
+  return map { $_->{exit_code} } @SUMMARY;
+}
+
+sub get_summary { @SUMMARY }
+
+sub set_in_transaction {
+  my ( $self, $val ) = @_;
+  $self->{IN_TRANSACTION} = $val;
+}
+
+sub is_transaction {
+  my ($self) = @_;
+  return $self->{IN_TRANSACTION};
 }
 
 1;

--- a/lib/Rex/TaskList/Parallel_ForkManager.pm
+++ b/lib/Rex/TaskList/Parallel_ForkManager.pm
@@ -43,8 +43,8 @@ sub new {
 sub run {
   my ( $self, $task, %options ) = @_;
 
-  my $fm = Parallel::ForkManager->new($self->get_thread_count($task));
-  my $task_name   = $task->name;
+  my $fm        = Parallel::ForkManager->new( $self->get_thread_count($task) );
+  my $task_name = $task->name;
   my $all_servers = $task->server;
 
   $fm->run_on_finish(
@@ -73,7 +73,8 @@ sub run {
       return $return_value;
     };
 
-    if ($self->{IN_TRANSACTION}) {
+    if ( $self->{IN_TRANSACTION} ) {
+
       # Inside a transaction -- no forking and no chance to get zombies.
       # This only happens if someone calls do_task() from inside a transaction.
       # Note the result is not appended to @SUMMARY.
@@ -84,12 +85,13 @@ sub run {
       $fm->start and next;
 
       eval { $forked_sub->() };
-      my $exit_code = $@ ? (($? >> 8) || 1) : 0;
-      push @SUMMARY, {
+      my $exit_code = $@ ? ( ( $? >> 8 ) || 1 ) : 0;
+      push @SUMMARY,
+        {
         task      => $task_name,
         server    => $server->to_s,
         exit_code => $exit_code,
-      };
+        };
 
       $fm->finish;
     }

--- a/t/summary.t
+++ b/t/summary.t
@@ -1,0 +1,133 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Test::Deep;
+
+use Rex::Config;
+use Rex::Commands;
+use Rex::Commands::Run;
+use Rex::Transaction;
+
+$::QUIET = 1;
+
+subtest "distributor => 'Base'" => sub {
+
+  subtest 'exec_autodie => 0' => sub {
+    Rex::Config->set_exec_autodie(0);
+    Rex::Config->set_distributor('Base');
+    test_summary(
+      task0 => { server => '<local>', task => 'task0', exit_code => 1 },
+      task1 => { server => '<local>', task => 'task1', exit_code => 0 },
+      task2 => { server => '<local>', task => 'task2', exit_code => 0 },
+      task3 => { server => '<local>', task => 'task3', exit_code => 1 },
+    );
+  };
+
+  subtest 'exec_autodie => 1' => sub {
+    Rex::Config->set_exec_autodie(1);
+    Rex::Config->set_distributor('Base');
+    test_summary(
+      task0 => { server => '<local>', task => 'task0', exit_code => 1 },
+      task1 => { server => '<local>', task => 'task1', exit_code => 2 },
+      task2 => { server => '<local>', task => 'task2', exit_code => 0 },
+      task3 => { server => '<local>', task => 'task3', exit_code => 1 },
+    );
+  };
+};
+
+SKIP: {
+  skip "Parallel::ForkManager is not installed", 1
+    if parallel_forkmanager_not_installed();
+
+  subtest "distributor => 'Parallel_ForkManager'" => sub {
+    subtest 'exec_autodie => 0' => sub {
+      Rex::Config->set_exec_autodie(0);
+      Rex::Config->set_distributor('Parallel_ForkManager');
+      test_summary(
+        task0 => { server => '<local>', task => 'task0', exit_code => 1 },
+        task1 => { server => '<local>', task => 'task1', exit_code => 0 },
+        task2 => { server => '<local>', task => 'task2', exit_code => 0 },
+        task3 => { server => '<local>', task => 'task3', exit_code => 1 },
+      );
+    };
+
+    subtest 'exec_autodie => 1' => sub {
+      Rex::Config->set_exec_autodie(1);
+      Rex::Config->set_distributor('Parallel_ForkManager');
+      test_summary(
+        task0 => { server => '<local>', task => 'task0', exit_code => 1 },
+        task1 => { server => '<local>', task => 'task1', exit_code => 2 },
+        task2 => { server => '<local>', task => 'task2', exit_code => 0 },
+        task3 => { server => '<local>', task => 'task3', exit_code => 1 },
+      );
+    };
+  };
+}
+
+sub create_tasks {
+  desc "desc 0";
+  task "task0" => sub {
+    die "bork0";
+  };
+
+  desc "desc 1";
+  task "task1" => sub {
+    run "ls asdfxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+  };
+
+  desc "desc 2";
+  task "task2" => sub {
+    my $cmd = "ls";
+    $cmd = "dir" if $^O =~ /MSWin32/;
+    run $cmd;
+  };
+
+  desc "desc 3";
+  task "task3" => sub {
+    transaction {
+      do_task qw/task0/;
+    };
+  };
+}
+
+sub test_summary {
+  my (%expected) = @_;
+
+  $Rex::TaskList::task_list = undef;
+
+  create_tasks();
+
+  my @summary;
+  my @expected_summary;
+  my $test_description;
+
+  for my $task_name ( Rex::TaskList->create->get_tasks ) {
+    Rex::TaskList->run($task_name);
+    @summary = Rex::TaskList->create->get_summary;
+
+    push @expected_summary, $expected{$task_name};
+
+    $test_description =
+      $expected{$task_name}->{exit_code} == 0
+      ? "$task_name succeeded"
+      : "$task_name failed";
+
+    cmp_deeply \@summary, \@expected_summary, $test_description;
+  }
+
+  my $distributor = Rex::Config->get_distributor;
+  no warnings;
+
+  @Rex::Fork::Task::SUMMARY = ()
+    if $distributor eq 'Base';
+
+  @Rex::TaskList::Parallel_ForkManager::SUMMARY = ()
+    if $distributor eq 'Parallel_ForkManager';
+}
+
+sub parallel_forkmanager_not_installed {
+  eval { require Parallel::ForkManager };
+  return 1 if $@;
+  return 0;
+}


### PR DESCRIPTION
# What this pr does

This pr logs a summary of successes/failures at the end of a run so the user doesn't have to scroll up through the logs to see if anything failed which can be a chore when deploying to many servers.

It also answers a fundamental question about rex: what defines success or failure of a task.  This pr defines a failed task as one that has died.  This is a simple solution for people who use the `exec_autodie` feature.  See [this comment](https://github.com/RexOps/Rex/issues/706#issuecomment-127365886) for more discussion on this design decision.

The summary looks like this if everything was successful:
```
SUMMARY
2015-08-04 08:16:19 <local> INFO : SUMMARY
2015-08-04 08:16:19 <local> INFO : All tasks successful on all hosts
```

The summary looks like this if there were failures:
```
SUMMARY
2015-07-31 17:04:37 <local> INFO : SUMMARY
2015-07-31 17:04:37 <local> INFO :  - deploy:test failed on eric
2015-07-31 17:04:37 <local> INFO :  - deploy:test failed on caine
2015-07-31 17:04:37 <local> INFO :  - deploy:test failed on jaryd
2015-07-31 17:04:37 <local> INFO : 3/3 task execution failures
```

See also: https://github.com/RexOps/Rex/issues/691

# Testing
 - [x] `t/summary.t` - Without the `exec_autodie` feature 
 - [x] `t/summary.t` - With the `exec_autodie` feature
 - [x] `t/summary.t` - With `Rex::TaskList::Base` and `Rex::Task::Manager`
 - [x] `t/summary.t` - With `Rex::TaskList::Parallel_ForkManager` and `Parallel::ForkManager`
 - [x] `t/summary.t` - With transactions
 - [x] `t/shared.t` - Parallel execution (handled via new tests added in https://github.com/RexOps/Rex/pull/774)