### PR TITLE
Add support for CloudLinux (RedHat clone)

### DIFF
--- a/lib/Rex/Commands/Gather.pm
+++ b/lib/Rex/Commands/Gather.pm
@@ -246,7 +246,8 @@ sub is_redhat {
     "CentOS",                      "Scientific",
     "RedHatEnterpriseServer",      "RedHatEnterpriseES",
     "RedHatEnterpriseWorkstation", "RedHatEnterpriseWS",
-    "Amazon",                      "ROSAEnterpriseServer"
+    "Amazon",                      "ROSAEnterpriseServer",
+    "CloudLinuxServer",
   );
 
   if ( grep { /$os/i } @redhat_clones ) {


### PR DESCRIPTION
This adds support for CloudLinux (RedHat clone distro for shared hosting providers: cloudlinux.com).

    $ lsb_release -s -i
    CloudLinuxServer