### PR TITLE
Low priority for REX_USER environment variable

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -435,12 +435,12 @@ sub has_user {
 sub get_user {
   my $class = shift;
 
-  if ( exists $ENV{REX_USER} ) {
-    return $ENV{REX_USER};
-  }
-
   if ($user) {
     return $user;
+  }
+
+  if ( exists $ENV{REX_USER} ) {
+    return $ENV{REX_USER};
   }
 
   return getlogin || getpwuid($<) || "Kilroy";


### PR DESCRIPTION
When REX_USER is set globally I get a lot of errors on make test:

    $ export REX_USER=blabla
    $ make test
    PERL_DL_NONLAZY=1 "/opt/perl/5.20/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t t/commands/*.t
    
    #   Failed test 'merge_auth - user'
    #   at t/0.31.t line 53.
    #          got: 'blabla'
    #     expected: 'root3'

    #   Failed test 'merge_auth - user'
    #   at t/0.31.t line 64.
    #          got: 'blabla'
    #     expected: 'root3'
    
    ...

This patch reduce priority for REX_USER environment variable. If you set user in you Rexfile it will be user instead of REX_USER and tests will works properly.

Please review.