### PR TITLE
Issue #685; convert POD =item to =head2 for methods/DSL functions

### DIFF
--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -49,8 +49,6 @@ See L<Rex::Commands> for a list of all commands you can use.
 
 =head1 CLASS METHODS
 
-=over 4
-
 =cut
 
 package Rex;
@@ -228,7 +226,7 @@ sub modified_caller {
   }
 }
 
-=item get_current_connection
+=head2 get_current_connection
 
 This function is deprecated since 0.28! See Rex::Commands::connection.
 
@@ -272,7 +270,7 @@ sub get_current_connection_object {
   return Rex::get_current_connection()->{conn};
 }
 
-=item is_ssh
+=head2 is_ssh
 
 Returns 1 if the current connection is a ssh connection. 0 if not.
 
@@ -289,7 +287,7 @@ sub is_ssh {
   return 0;
 }
 
-=item is_local
+=head2 is_local
 
 Returns 1 if the current connection is local. Otherwise 0.
 
@@ -306,7 +304,7 @@ sub is_local {
   return 0;
 }
 
-=item is_sudo
+=head2 is_sudo
 
 Returns 1 if the current operation is executed within sudo.
 
@@ -336,7 +334,7 @@ sub global_sudo {
   Rex::Config->set_use_cache(1);
 }
 
-=item get_sftp
+=head2 get_sftp
 
 Returns the sftp object for the current ssh connection.
 
@@ -358,7 +356,7 @@ sub get_cache {
   return Rex::Interface::Cache->create();
 }
 
-=item connect
+=head2 connect
 
 Use this function to create a connection if you use Rex as a library.
 
@@ -810,8 +808,6 @@ sub import {
   # we are always strict
   strict->import;
 }
-
-=back
 
 =head1 CONTRIBUTORS
 

--- a/lib/Rex/Box/Amazon.pm
+++ b/lib/Rex/Box/Amazon.pm
@@ -73,8 +73,6 @@ And then you can use it the following way in your Rexfile.
 
 See also the Methods of Rex::Box::Base. This module inherits all methods of it.
 
-=over 4
-
 =cut
 
 package Rex::Box::Amazon;
@@ -105,7 +103,7 @@ $|++;
 # BEGIN of class methods
 ################################################################################
 
-=item new(name => $vmname)
+=head2 new(name => $vmname)
 
 Constructor if used in OO mode.
 
@@ -169,7 +167,7 @@ sub import_vm {
   $self->{info} = $vminfo;
 }
 
-=item ami($ami_id)
+=head2 ami($ami_id)
 
 Set the AMI ID for the box.
 
@@ -180,7 +178,7 @@ sub ami {
   $self->{ami} = $ami;
 }
 
-=item type($type)
+=head2 type($type)
 
 Set the type of the Instance. For example "m1.large".
 
@@ -191,7 +189,7 @@ sub type {
   $self->{type} = $type;
 }
 
-=item security_group($sec_group)
+=head2 security_group($sec_group)
 
 Set the Amazon security group for this Instance.
 
@@ -217,7 +215,7 @@ sub provision_vm {
   }
 }
 
-=item forward_port(%option)
+=head2 forward_port(%option)
 
 Not available for Amazon Boxes.
 
@@ -225,7 +223,7 @@ Not available for Amazon Boxes.
 
 sub forward_port { Rex::Logger::debug("Not available for Amazon Boxes."); }
 
-=item share_folder(%option)
+=head2 share_folder(%option)
 
 Not available for Amazon Boxes.
 
@@ -280,7 +278,7 @@ sub stop {
   cloud_instance stop => $self->{info}->{id};
 }
 
-=item info
+=head2 info
 
 Returns a hashRef of vm information.
 
@@ -300,9 +298,5 @@ sub ip {
 
   return $self->{info}->{ip};
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Box/Base.pm
+++ b/lib/Rex/Box/Base.pm
@@ -16,8 +16,6 @@ This is a Rex/Boxes base module.
 
 These methods are shared across all other Rex::Box modules.
 
-=over 4
-
 =cut
 
 package Rex::Box::Base;
@@ -66,7 +64,7 @@ sub new {
   return $self;
 }
 
-=item info
+=head2 info
 
 Returns a hashRef of vm information.
 
@@ -77,7 +75,7 @@ sub info {
   return $self->{info};
 }
 
-=item name($vmname)
+=head2 name($vmname)
 
 Sets the name of the virtual machine.
 
@@ -88,7 +86,7 @@ sub name {
   $self->{name} = $name;
 }
 
-=item setup(@tasks)
+=head2 setup(@tasks)
 
 Sets the tasks that should be executed as soon as the VM is available through SSH.
 
@@ -99,7 +97,7 @@ sub setup {
   $self->{__tasks} = \@tasks;
 }
 
-=item import_vm()
+=head2 import_vm()
 
 This method must be overwritten by the implementing class.
 
@@ -110,7 +108,7 @@ sub import_vm {
   die("This method must be overwritten.");
 }
 
-=item stop()
+=head2 stop()
 
 Stops the VM.
 
@@ -122,7 +120,7 @@ sub stop {
   vm shutdown => $self->{name};
 }
 
-=item start()
+=head2 start()
 
 Starts the VM.
 
@@ -135,7 +133,7 @@ sub start {
 
 }
 
-=item ip()
+=head2 ip()
 
 Return the ip:port to which rex will connect to.
 
@@ -143,7 +141,7 @@ Return the ip:port to which rex will connect to.
 
 sub ip { die("Must be implemented by box class.") }
 
-=item status()
+=head2 status()
 
 Returns the status of a VM.
 
@@ -156,7 +154,7 @@ sub status {
   return vm status => $self->{name};
 }
 
-=item provision_vm([@tasks])
+=head2 provision_vm([@tasks])
 
 Executes the given tasks on the VM.
 
@@ -167,7 +165,7 @@ sub provision_vm {
   die("This method must be overwritten.");
 }
 
-=item cpus($count)
+=head2 cpus($count)
 
 Set the amount of CPUs for the VM.
 
@@ -178,7 +176,7 @@ sub cpus {
   $self->{cpus} = $cpus;
 }
 
-=item memory($memory_size)
+=head2 memory($memory_size)
 
 Sets the memory of a VM in megabyte.
 
@@ -189,7 +187,7 @@ sub memory {
   $self->{memory} = $mem;
 }
 
-=item network(%option)
+=head2 network(%option)
 
 Configure the network for a VM.
 
@@ -215,7 +213,7 @@ sub network {
   $self->{__network} = \%option;
 }
 
-=item forward_port(%option)
+=head2 forward_port(%option)
 
 Set ports to be forwarded to the VM. This is not supported by all Box providers.
 
@@ -232,7 +230,7 @@ sub forward_port {
   $self->{__forward_port} = \%option;
 }
 
-=item list_boxes
+=head2 list_boxes
 
 List all available boxes.
 
@@ -246,7 +244,7 @@ sub list_boxes {
   return @{$vms};
 }
 
-=item url($url)
+=head2 url($url)
 
 The URL where to download the Base VM Image. You can use self-made images or prebuild images from http://box.rexify.org/.
 
@@ -258,7 +256,7 @@ sub url {
   $self->{force} = $force;
 }
 
-=item auth(%option)
+=head2 auth(%option)
 
 Configure the authentication to the VM.
 
@@ -388,9 +386,5 @@ sub _download {
     }
   }
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Box/KVM.pm
+++ b/lib/Rex/Box/KVM.pm
@@ -59,8 +59,6 @@ And then you can use it the following way in your Rexfile.
 
 See also the Methods of Rex::Box::Base. This module inherits all methods of it.
 
-=over 4
-
 =cut
 
 package Rex::Box::KVM;
@@ -94,7 +92,7 @@ $|++;
 # BEGIN of class methods
 ################################################################################
 
-=item new(name => $vmname)
+=head2 new(name => $vmname)
 
 Constructor if used in OO mode.
 
@@ -194,7 +192,7 @@ sub list_boxes {
   return @{$vms};
 }
 
-=item info
+=head2 info
 
 Returns a hashRef of vm information.
 
@@ -206,7 +204,7 @@ sub info {
   return $self->{info};
 }
 
-=item ip
+=head2 ip
 
 This method return the ip of a vm on which the ssh daemon is listening.
 
@@ -217,9 +215,5 @@ sub ip {
   $self->{info} = vm guestinfo => $self->{name};
   return $self->{info}->{network}->[0]->{ip};
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Box/VBox.pm
+++ b/lib/Rex/Box/VBox.pm
@@ -80,8 +80,6 @@ It is also possible to run VirtualBox in headless mode. This only works on Linux
 
 See also the Methods of Rex::Box::Base. This module inherits all methods of it.
 
-=over 4
-
 =cut
 
 package Rex::Box::VBox;
@@ -115,7 +113,7 @@ $|++;
 # BEGIN of class methods
 ################################################################################
 
-=item new(name => $vmname)
+=head2 new(name => $vmname)
 
 Constructor if used in OO mode.
 
@@ -273,7 +271,7 @@ sub select_bridge {
   return $ifname;
 }
 
-=item share_folder(%option)
+=head2 share_folder(%option)
 
 Creates a shared folder inside the VM with the content from a folder from the Host machine. This only works with VirtualBox.
 
@@ -289,7 +287,7 @@ sub share_folder {
   $self->{__shared_folder} = \%option;
 }
 
-=item info
+=head2 info
 
 Returns a hashRef of vm information.
 
@@ -315,7 +313,7 @@ sub info {
   return $self->{info};
 }
 
-=item ip
+=head2 ip
 
 This method return the ip of a vm on which the ssh daemon is listening.
 
@@ -361,9 +359,5 @@ sub ip {
 
   return $server;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/CMDB.pm
+++ b/lib/Rex/CMDB.pm
@@ -32,8 +32,6 @@ This module exports a function to access a CMDB via a common interface.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::CMDB;
@@ -112,7 +110,7 @@ Rex::Config->register_set_handler(
   }
 );
 
-=item cmdb([$item, $server])
+=head2 cmdb([$item, $server])
 
 Function to query a CMDB. If this function is called without $item it should return a hash containing all the information for the requested server. If $item is given it should return only the value for $item.
 
@@ -151,9 +149,5 @@ sub cmdb {
 sub cmdb_active {
   return ( $CMDB_PROVIDER ? 1 : 0 );
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -104,8 +104,6 @@ This module is the core commands module.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands;
@@ -163,7 +161,7 @@ use base qw(Rex::Exporter);
 
 our $REGISTER_SUB_HASH_PARAMETER = 0;
 
-=item no_ssh([$task])
+=head2 no_ssh([$task])
 
 Disable ssh for all tasks or a specified task.
 
@@ -188,7 +186,7 @@ sub no_ssh {
   }
 }
 
-=item task($name [, @servers], $funcref)
+=head2 task($name [, @servers], $funcref)
 
 This function will create a new task.
 
@@ -430,7 +428,7 @@ sub task {
   Rex::TaskList->create()->create_task( $task_name, @_, $options );
 }
 
-=item desc($description)
+=head2 desc($description)
 
 Set the description of a task.
 
@@ -445,7 +443,7 @@ sub desc {
   $current_desc = shift;
 }
 
-=item group($name, @servers)
+=head2 group($name, @servers)
 
 With this function you can group servers, so that you don't need to write too much ;-)
 
@@ -553,7 +551,7 @@ Rex::Config->register_set_handler(
   }
 );
 
-=item batch($name, @tasks)
+=head2 batch($name, @tasks)
 
 With the batch function you can call tasks in a batch.
 
@@ -575,7 +573,7 @@ sub batch {
   Rex::Batch->create_batch(@_);
 }
 
-=item user($user)
+=head2 user($user)
 
 Set the user for the ssh connection.
 
@@ -585,7 +583,7 @@ sub user {
   Rex::Config->set_user(@_);
 }
 
-=item password($password)
+=head2 password($password)
 
 Set the password for the ssh connection (or for the private key file).
 
@@ -595,7 +593,7 @@ sub password {
   Rex::Config->set_password(@_);
 }
 
-=item auth(for => $entity, %data)
+=head2 auth(for => $entity, %data)
 
 With this function you can modify/set special authentication parameters for tasks and groups. If you want to modify a task's or group's authentication you first have to create it.
 
@@ -700,7 +698,7 @@ sub auth {
   $group->set_auth(%data);
 }
 
-=item port($port)
+=head2 port($port)
 
 Set the port where the ssh server is listening.
 
@@ -710,7 +708,7 @@ sub port {
   Rex::Config->set_port(@_);
 }
 
-=item sudo_password($password)
+=head2 sudo_password($password)
 
 Set the password for the sudo command.
 
@@ -720,7 +718,7 @@ sub sudo_password {
   Rex::Config->set_sudo_password(@_);
 }
 
-=item timeout($seconds)
+=head2 timeout($seconds)
 
 Set the timeout for the ssh connection and other network related stuff.
 
@@ -730,7 +728,7 @@ sub timeout {
   Rex::Config->set_timeout(@_);
 }
 
-=item max_connect_retries($count)
+=head2 max_connect_retries($count)
 
 Set the maximum number of connection retries.
 
@@ -740,7 +738,7 @@ sub max_connect_retries {
   Rex::Config->set_max_connect_fails(@_);
 }
 
-=item get_random($count, @chars)
+=head2 get_random($count, @chars)
 
 Returns a random string of $count characters on the basis of @chars.
 
@@ -752,7 +750,7 @@ sub get_random {
   return Rex::Helper::Misc::get_random(@_);
 }
 
-=item do_task($task)
+=head2 do_task($task)
 
 Call $task from another task. It will establish a new connection to the server defined in $task and then execute $task there.
 
@@ -784,7 +782,7 @@ sub do_task {
   }
 }
 
-=item run_task($task_name, %option)
+=head2 run_task($task_name, %option)
 
 Run a task on a given host.
 
@@ -848,7 +846,7 @@ sub run_task {
 
 }
 
-=item run_batch($batch_name, %option)
+=head2 run_batch($batch_name, %option)
 
 Run a batch on a given host.
 
@@ -871,7 +869,7 @@ sub run_batch {
   return @results;
 }
 
-=item public_key($key)
+=head2 public_key($key)
 
 Set the public key.
 
@@ -881,7 +879,7 @@ sub public_key {
   Rex::Config->set_public_key(@_);
 }
 
-=item private_key($key)
+=head2 private_key($key)
 
 Set the private key.
 
@@ -891,7 +889,7 @@ sub private_key {
   Rex::Config->set_private_key(@_);
 }
 
-=item pass_auth
+=head2 pass_auth
 
 If you want to use password authentication, then you need to call I<pass_auth>.
 
@@ -907,7 +905,7 @@ sub pass_auth {
   Rex::Config->set_password_auth(1);
 }
 
-=item key_auth
+=head2 key_auth
 
 If you want to use pubkey authentication, then you need to call I<key_auth>.
 
@@ -924,7 +922,7 @@ sub key_auth {
   Rex::Config->set_key_auth(1);
 }
 
-=item krb5_auth
+=head2 krb5_auth
 
 If you want to use kerberos authentication, then you need to call I<krb5_auth>.
 This authentication mechanism is only available if you use Net::OpenSSH.
@@ -940,7 +938,7 @@ sub krb5_auth {
   Rex::Config->set_krb5_auth(1);
 }
 
-=item parallelism($count)
+=head2 parallelism($count)
 
 Will execute the tasks in parallel on the given servers. $count is the thread count to be used. Alternatively, the following notation can be used:
 
@@ -956,7 +954,7 @@ sub parallelism {
   Rex::Config->set_parallelism( $_[0] );
 }
 
-=item proxy_command($cmd)
+=head2 proxy_command($cmd)
 
 Set a proxy command to use for the connection. This is only possible with OpenSSH connection method.
 
@@ -969,7 +967,7 @@ sub proxy_command {
   Rex::Config->set_proxy_command( $_[0] );
 }
 
-=item set_distributor($distributor)
+=head2 set_distributor($distributor)
 
 This sets the task distribution module. Default is "Base".
 
@@ -981,7 +979,7 @@ sub set_distributor {
   Rex::Config->set_distributor( $_[0] );
 }
 
-=item template_function(sub { ... })
+=head2 template_function(sub { ... })
 
 This function sets the template processing function. So it is possible to change the template engine. For example to Template::Toolkit.
 
@@ -991,7 +989,7 @@ sub template_function {
   Rex::Config->set_template_function( $_[0] );
 }
 
-=item logging
+=head2 logging
 
 With this function you can define the logging behaviour of (R)?ex.
 
@@ -1031,7 +1029,7 @@ sub logging {
   }
 }
 
-=item needs($package [, @tasks])
+=head2 needs($package [, @tasks])
 
 With I<needs> you can define dependencies between tasks. The "needed" tasks will be called with the same server configuration as the calling task.
 
@@ -1124,7 +1122,7 @@ sub needs {
   }
 };
 
-=item include Module::Name
+=head2 include Module::Name
 
 Include a module without registering its tasks.
 
@@ -1147,7 +1145,7 @@ sub include {
   $dont_register_tasks = $old_val;
 }
 
-=item environment($name => $code)
+=head2 environment($name => $code)
 
 Define an environment. With environments one can use the same task for different hosts. For example if you want to use the same task on your integration-, test- and production servers.
 
@@ -1217,7 +1215,7 @@ sub environment {
   }
 }
 
-=item LOCAL(&)
+=head2 LOCAL(&)
 
 With the LOCAL function you can do local commands within a task that is defined to work on remote servers.
 
@@ -1256,7 +1254,7 @@ sub LOCAL (&) {
   return $ret;
 }
 
-=item path(@path)
+=head2 path(@path)
 
 Set the execution path for all commands.
 
@@ -1268,7 +1266,7 @@ sub path {
   Rex::Config->set_path( [@_] );
 }
 
-=item set($key, $value)
+=head2 set($key, $value)
 
 Set a configuration parameter. These variables can be used in templates as well.
 
@@ -1296,7 +1294,7 @@ sub set {
   Rex::Config->set( $key, @value );
 }
 
-=item get($key, $value)
+=head2 get($key, $value)
 
 Get a configuration parameter.
 
@@ -1322,7 +1320,7 @@ sub get {
   return Rex::Config->get($key);
 }
 
-=item before($task => sub {})
+=head2 before($task => sub {})
 
 Run code before executing the specified task. The special taskname 'ALL' can be used to run code before all tasks.
 If called repeatedly, each sub will be appended to a list of 'before' functions.
@@ -1351,7 +1349,7 @@ sub before {
     ->modify( 'before', $task, $code, $package, $file, $line );
 }
 
-=item after($task => sub {})
+=head2 after($task => sub {})
 
 Run code after the task is finished. The special taskname 'ALL' can be used to run code after all tasks.
 If called repeatedly, each sub will be appended to a list of 'after' functions.
@@ -1380,7 +1378,7 @@ sub after {
     ->modify( 'after', $task, $code, $package, $file, $line );
 }
 
-=item around($task => sub {})
+=head2 around($task => sub {})
 
 Run code before and after the task is finished. The special taskname 'ALL' can be used to run code around all tasks.
 If called repeatedly, each sub will be appended to a list of 'around' functions.
@@ -1416,7 +1414,7 @@ sub around {
     ->modify( 'around', $task, $code, $package, $file, $line );
 }
 
-=item before_task_start($task => sub {})
+=head2 before_task_start($task => sub {})
 
 Run code before executing the specified task. This gets executed only once for a task. The special taskname 'ALL' can be used to run code before all tasks.
 If called repeatedly, each sub will be appended to a list of 'before' functions.
@@ -1441,7 +1439,7 @@ sub before_task_start {
     ->modify( 'before_task_start', $task, $code, $package, $file, $line );
 }
 
-=item after_task_finished($task => sub {})
+=head2 after_task_finished($task => sub {})
 
 Run code after the task is finished (and after the ssh connection is terminated). This gets executed only once for a task. The special taskname 'ALL' can be used to run code before all tasks.
 If called repeatedly, each sub will be appended to a list of 'before' functions.
@@ -1466,7 +1464,7 @@ sub after_task_finished {
     ->modify( 'after_task_finished', $task, $code, $package, $file, $line );
 }
 
-=item logformat($format)
+=head2 logformat($format)
 
 You can define the logging format with the following parameters.
 
@@ -1491,7 +1489,7 @@ sub logformat {
 
 sub log_format { logformat(@_); }
 
-=item connection
+=head2 connection
 
 This function returns the current connection object.
 
@@ -1505,7 +1503,7 @@ sub connection {
   return Rex::get_current_connection()->{conn};
 }
 
-=item cache
+=head2 cache
 
 This function returns the current cache object.
 
@@ -1521,7 +1519,7 @@ sub cache {
   Rex::Config->set_cache_type($type);
 }
 
-=item profiler
+=head2 profiler
 
 Returns the profiler object for the current connection.
 
@@ -1537,7 +1535,7 @@ sub profiler {
   return $c_profiler;
 }
 
-=item report($switch, $type)
+=head2 report($switch, $type)
 
 This function will initialize the reporting.
 
@@ -1563,7 +1561,7 @@ sub report {
   return Rex::get_current_connection()->{reporter};
 }
 
-=item source_global_profile(0|1)
+=head2 source_global_profile(0|1)
 
 If this option is set, every run() command will first source /etc/profile before getting executed.
 
@@ -1574,7 +1572,7 @@ sub source_global_profile {
   Rex::Config->set_source_global_profile($source);
 }
 
-=item last_command_output
+=head2 last_command_output
 
 This function returns the output of the last "run" command.
 
@@ -1591,7 +1589,7 @@ sub last_command_output {
   return $Rex::Commands::Run::LAST_OUTPUT->[0];
 }
 
-=item case($compare, $option)
+=head2 case($compare, $option)
 
 This is a function to compare a string with some given options.
 
@@ -1642,7 +1640,7 @@ sub case {
   return $to_return;
 }
 
-=item set_executor_for($type, $executor)
+=head2 set_executor_for($type, $executor)
 
 Set the executor for a special type. This is primary used for the upload_and_run helper function.
 
@@ -1654,7 +1652,7 @@ sub set_executor_for {
   Rex::Config->set_executor_for(@_);
 }
 
-=item tmp_dir($tmp_dir)
+=head2 tmp_dir($tmp_dir)
 
 Set the tmp directory on the remote host to store temporary files.
 
@@ -1664,7 +1662,7 @@ sub tmp_dir {
   Rex::Config->set_tmp_dir(@_);
 }
 
-=item inspect($varRef)
+=head2 inspect($varRef)
 
 This function dumps the contents of a variable to STDOUT.
 
@@ -1871,7 +1869,7 @@ sub get_environments {
   return @ret;
 }
 
-=item sayformat($format)
+=head2 sayformat($format)
 
 You can define the format of the say() function.
 
@@ -1967,9 +1965,5 @@ sub FALSE {
 sub make(&) {
   return $_[0];
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -32,8 +32,6 @@ This is a simple module to manipulate configuration files with the help of augea
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Augeas;
@@ -69,7 +67,7 @@ BEGIN {
 
 @EXPORT = qw(augeas);
 
-=item augeas($action, @options)
+=head2 augeas($action, @options)
 
 It returns 1 on success and 0 on failure.
 
@@ -380,8 +378,6 @@ Returns the value of the given item.
 
   return $ret;
 }
-
-=back
 
 =back
 

--- a/lib/Rex/Commands/Box.pm
+++ b/lib/Rex/Commands/Box.pm
@@ -55,8 +55,6 @@ Version <= 1.0: All these functions will not be reported.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Box;
@@ -104,7 +102,7 @@ Rex::Config->register_set_handler(
   }
 );
 
-=item new(name => $box_name)
+=head2 new(name => $box_name)
 
 Constructor if used in OO mode.
 
@@ -117,7 +115,7 @@ sub new {
   return Rex::Box->create(@_);
 }
 
-=item box(sub {})
+=head2 box(sub {})
 
 With this function you can create a new Rex/Box. The first parameter of this function is the Box object. With this object you can define your box.
 
@@ -176,7 +174,7 @@ sub box(&) {
   return $self->ip;
 }
 
-=item list_boxes
+=head2 list_boxes
 
 This function returns an array of hashes containing all information that can be gathered from the hypervisor about the Rex/Box. This function doesn't start a Rex/Box.
 
@@ -221,7 +219,7 @@ sub list_boxes {
   return @{$ref};
 }
 
-=item get_box($box_name)
+=head2 get_box($box_name)
 
 This function tries to gather all information of a Rex/Box. This function also starts a Rex/Box to gather all information of the running system.
 
@@ -309,7 +307,7 @@ sub get_box {
 
 }
 
-=item boxes($action, @data)
+=head2 boxes($action, @data)
 
 With this function you can control your boxes. Currently there are 3 actions.
 
@@ -454,9 +452,5 @@ sub import {
 
   __PACKAGE__->export_to_level( 1, @_ );
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Cloud.pm
+++ b/lib/Rex/Commands/Cloud.pm
@@ -48,8 +48,6 @@ Version <= 1.0: All these functions will not be reported.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Cloud;
@@ -98,7 +96,7 @@ Rex::Config->register_set_handler(
   }
 );
 
-=item cloud_service($cloud_service)
+=head2 cloud_service($cloud_service)
 
 Define which cloud service to use.
 
@@ -130,7 +128,7 @@ sub cloud_service {
   }
 }
 
-=item cloud_auth($param1, $param2, ...)
+=head2 cloud_auth($param1, $param2, ...)
 
 Set the authentication for the cloudservice.
 
@@ -156,7 +154,7 @@ sub cloud_auth {
   @cloud_auth = @_;
 }
 
-=item cloud_region($region)
+=head2 cloud_region($region)
 
 Set the cloud region.
 
@@ -166,7 +164,7 @@ sub cloud_region {
   ($cloud_region) = @_;
 }
 
-=item cloud_instance_list
+=head2 cloud_instance_list
 
 Get all instances of a cloud service.
 
@@ -195,7 +193,7 @@ sub cloud_instance_list {
   return cloud_object()->list_instances(@_);
 }
 
-=item cloud_volume_list
+=head2 cloud_volume_list
 
 Get all volumes of a cloud service.
 
@@ -214,7 +212,7 @@ sub cloud_volume_list {
   return cloud_object()->list_volumes();
 }
 
-=item cloud_network_list
+=head2 cloud_network_list
 
 Get all networks of a cloud service.
 
@@ -232,7 +230,7 @@ sub cloud_network_list {
   return cloud_object()->list_networks();
 }
 
-=item cloud_image_list
+=head2 cloud_image_list
 
 Get a list of all available cloud images.
 
@@ -242,7 +240,7 @@ sub cloud_image_list {
   return cloud_object()->list_images();
 }
 
-=item cloud_upload_key
+=head2 cloud_upload_key
 
 Upload public SSH key to cloud provider
 
@@ -263,7 +261,7 @@ sub cloud_upload_key {
   return cloud_object()->upload_key();
 }
 
-=item get_cloud_instances_as_group
+=head2 get_cloud_instances_as_group
 
 Get a list of all running instances of a cloud service. This can be used for a I<group> definition.
 
@@ -289,7 +287,7 @@ sub get_cloud_instances_as_group {
 
 }
 
-=item cloud_instance($action, $data)
+=head2 cloud_instance($action, $data)
 
 This function controls all aspects of a cloud instance.
 
@@ -304,7 +302,7 @@ sub cloud_instance {
     return $cloud->list_running_instances();
   }
 
-=item create
+=head2 create
 
 Create a new instance.
 
@@ -337,7 +335,7 @@ Create a new instance.
     $cloud->run_instance(%data_hash);
   }
 
-=item start
+=head2 start
 
 Start an existing instance
 
@@ -349,7 +347,7 @@ Start an existing instance
     $cloud->start_instance( instance_id => $data );
   }
 
-=item stop
+=head2 stop
 
 Stop an existing instance
 
@@ -361,7 +359,7 @@ Stop an existing instance
     $cloud->stop_instance( instance_id => $data );
   }
 
-=item terminate
+=head2 terminate
 
 Terminate an instance. This will destroy all data and remove the instance.
 
@@ -375,7 +373,7 @@ Terminate an instance. This will destroy all data and remove the instance.
 
 }
 
-=item get_cloud_regions
+=head2 get_cloud_regions
 
 Returns all regions as an array.
 
@@ -385,7 +383,7 @@ sub get_cloud_regions {
   return cloud_object()->get_regions;
 }
 
-=item cloud_volume($action , $data)
+=head2 cloud_volume($action , $data)
 
 This function controlls all aspects of a cloud volume.
 
@@ -409,7 +407,7 @@ sub cloud_volume {
 
   my $cloud = cloud_object();
 
-=item create
+=head2 create
 
 Create a new volume. Size is in Gigabytes.
 
@@ -426,7 +424,7 @@ Create a new volume. Size is in Gigabytes.
     );
   }
 
-=item attach
+=head2 attach
 
 Attach a volume to an instance.
 
@@ -447,7 +445,7 @@ Attach a volume to an instance.
     );
   }
 
-=item detach
+=head2 detach
 
 Detach a volume from an instance.
 
@@ -468,7 +466,7 @@ Detach a volume from an instance.
     );
   }
 
-=item delete
+=head2 delete
 
 Delete a volume. This will destroy all data.
 
@@ -488,7 +486,7 @@ Delete a volume. This will destroy all data.
 
 }
 
-=item get_cloud_floating_ip
+=head2 get_cloud_floating_ip
 
 Returns first available floating IP
 
@@ -510,7 +508,7 @@ sub get_cloud_floating_ip {
   return cloud_object()->get_floating_ip;
 }
 
-=item cloud_network
+=head2 cloud_network
 
 =cut
 
@@ -519,7 +517,7 @@ sub cloud_network {
   my ( $action, $data ) = @_;
   my $cloud = cloud_object();
 
-=item create
+=head2 create
 
 Create a new network.
 
@@ -533,7 +531,7 @@ Create a new network.
     $cloud->create_network( %{$data} );
   }
 
-=item delete
+=head2 delete
 
 Delete a network.
 
@@ -548,7 +546,7 @@ Delete a network.
   }
 }
 
-=item get_cloud_availability_zones
+=head2 get_cloud_availability_zones
 
 Returns all availability zones of a cloud services. If available.
 
@@ -562,7 +560,7 @@ sub get_cloud_availability_zones {
   return cloud_object()->get_availability_zones();
 }
 
-=item get_cloud_plans
+=head2 get_cloud_plans
 
 Retrieve information of the available cloud plans. If supported.
 
@@ -572,7 +570,7 @@ sub get_cloud_plans {
   return cloud_object()->list_plans;
 }
 
-=item get_cloud_operating_systems
+=head2 get_cloud_operating_systems
 
 Retrieve information of the available cloud plans. If supported.
 
@@ -582,7 +580,7 @@ sub get_cloud_operating_systems {
   return cloud_object()->list_operating_systems;
 }
 
-=item cloud_object
+=head2 cloud_object
 
 Returns the cloud object itself.
 
@@ -596,9 +594,5 @@ sub cloud_object {
 
   return $cloud;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Cron.pm
+++ b/lib/Rex/Commands/Cron.pm
@@ -31,8 +31,6 @@ With this Module you can manage your cronjobs.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Cron;
@@ -52,7 +50,7 @@ use Data::Dumper;
 
 @EXPORT = qw(cron cron_entry);
 
-=item cron_entry($name, %option)
+=head2 cron_entry($name, %option)
 
 Manage cron entries.
 
@@ -156,7 +154,7 @@ sub cron_entry {
     ->report_resource_end( type => "cron_entry", name => $name );
 }
 
-=item cron($action => $user, ...)
+=head2 cron($action => $user, ...)
 
 With this function you can manage cronjobs.
 
@@ -276,9 +274,5 @@ sub cron {
   }
 
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/DB.pm
+++ b/lib/Rex/Commands/DB.pm
@@ -52,8 +52,6 @@ Version <= 1.0: All these functions will not be reported.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::DB;
@@ -75,7 +73,7 @@ use vars qw(@EXPORT $dbh);
 
 @EXPORT = qw(db);
 
-=item db
+=head2 db
 
 Do a database action.
 
@@ -198,8 +196,6 @@ sub db {
   }
 
 }
-
-=back
 
 =cut
 

--- a/lib/Rex/Commands/Download.pm
+++ b/lib/Rex/Commands/Download.pm
@@ -29,8 +29,6 @@ Version <= 1.0: All these functions will not be reported.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Download;
@@ -78,7 +76,7 @@ use File::Basename qw(basename);
 
 @EXPORT = qw(download);
 
-=item download($remote, [$local])
+=head2 download($remote, [$local])
 
 Perform a download. If no local file is specified it will download the file to the current directory.
 
@@ -189,9 +187,5 @@ sub _get_http {
 
   return $html;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -54,8 +54,6 @@ With this module you can manipulate files.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::File;
@@ -98,7 +96,7 @@ use base qw(Rex::Exporter);
 
 use vars qw(%file_handles);
 
-=item template($file, @params)
+=head2 template($file, @params)
 
 Parse a template and return the content.
 
@@ -256,7 +254,7 @@ sub _get_std_template_vars {
   return %template_vars;
 }
 
-=item file($file_name, %options)
+=head2 file($file_name, %options)
 
 This function is the successor of I<install file>. Please use this function to upload files to your server.
 
@@ -696,7 +694,7 @@ sub file {
   return $__ret->{changed};
 }
 
-=item file_write($file_name)
+=head2 file_write($file_name)
 
 This function opens a file for writing (it will truncate the file if it already exists). It returns a Rex::FS::File object on success.
 
@@ -733,7 +731,7 @@ sub file_write {
   return Rex::FS::File->new( fh => $fh );
 }
 
-=item file_append($file_name)
+=head2 file_append($file_name)
 
 =cut
 
@@ -753,7 +751,7 @@ sub file_append {
   return Rex::FS::File->new( fh => $fh );
 }
 
-=item file_read($file_name)
+=head2 file_read($file_name)
 
 This function opens a file for reading. It returns a Rex::FS::File object on success.
 
@@ -791,7 +789,7 @@ sub file_read {
   return Rex::FS::File->new( fh => $fh );
 }
 
-=item cat($file_name)
+=head2 cat($file_name)
 
 This function returns the complete content of $file_name as a string.
 
@@ -813,7 +811,7 @@ sub cat {
   return $content;
 }
 
-=item delete_lines_matching($file, $regexp)
+=head2 delete_lines_matching($file, $regexp)
 
 Delete lines that match $regexp in $file.
 
@@ -889,7 +887,7 @@ OUT:
     ->report_resource_end( type => "delete_lines_matching", name => $file );
 }
 
-=item delete_lines_according_to($search, $file, @options)
+=head2 delete_lines_according_to($search, $file, @options)
 
 This is the successor of the delete_lines_matching() function. This function also allows the usage of an on_change hook.
 
@@ -929,7 +927,7 @@ sub delete_lines_according_to {
 
 }
 
-=item append_if_no_such_line($file, $new_line, @regexp)
+=head2 append_if_no_such_line($file, $new_line, @regexp)
 
 Append $new_line to $file if none in @regexp is found. If no regexp is
 supplied, the line is appended unless there is already an identical line
@@ -960,7 +958,7 @@ sub append_if_no_such_line {
   _append_or_update( 'append_if_no_such_line', @_ );
 }
 
-=item append_or_amend_line($file, $line, @regexp)
+=head2 append_or_amend_line($file, $line, @regexp)
 
 Similar to L<append_if_no_such_line>, but if the line in the regexp is
 found, it will be updated. Otherwise, it will be appended.
@@ -1110,7 +1108,7 @@ sub _append_or_update {
     ->report_resource_end( type => $action, name => $file );
 }
 
-=item extract($file [, %options])
+=head2 extract($file [, %options])
 
 This function extracts a file. The target directory optionally specified with the `to` option will be created automatically.
 
@@ -1202,7 +1200,7 @@ sub extract {
 
 }
 
-=item sed($search, $replace, $file)
+=head2 sed($search, $replace, $file)
 
 Search some string in a file and replace it.
 
@@ -1264,9 +1262,5 @@ sub sed {
 
   return $ret;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Fs.pm
+++ b/lib/Rex/Commands/Fs.pm
@@ -42,8 +42,6 @@ With this module you can do file system tasks like creating a directory, deletin
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Fs;
@@ -78,7 +76,7 @@ use base qw(Rex::Exporter);
 
 use vars qw(%file_handles);
 
-=item list_files("/path");
+=head2 list_files("/path");
 
 This function list all entries (files, directories, ...) in a given directory and returns a array.
 
@@ -100,7 +98,7 @@ sub list_files {
   return @ret;
 }
 
-=item ls($path)
+=head2 ls($path)
 
 Just an alias for I<list_files>
 
@@ -110,7 +108,7 @@ sub ls {
   return list_files(@_);
 }
 
-=item symlink($from, $to)
+=head2 symlink($from, $to)
 
 This function will create a symlink from $from to $to.
 
@@ -144,7 +142,7 @@ sub symlink {
   return 1;
 }
 
-=item ln($from, $to)
+=head2 ln($from, $to)
 
 ln is an alias for I<symlink>
 
@@ -154,7 +152,7 @@ sub ln {
   &symlink(@_);
 }
 
-=item unlink($file)
+=head2 unlink($file)
 
 This function will remove the given file.
 
@@ -207,7 +205,7 @@ sub unlink {
 
 }
 
-=item rm($file)
+=head2 rm($file)
 
 This is an alias for unlink.
 
@@ -217,7 +215,7 @@ sub rm {
   &unlink(@_);
 }
 
-=item rmdir($dir)
+=head2 rmdir($dir)
 
 This function will remove the given directory.
 
@@ -274,7 +272,7 @@ sub rmdir {
   }
 }
 
-=item mkdir($newdir)
+=head2 mkdir($newdir)
 
 This function will create a new directory.
 
@@ -413,7 +411,7 @@ sub mkdir {
   return 1;
 }
 
-=item chown($owner, $file)
+=head2 chown($owner, $file)
 
 Change the owner of a file or a directory.
 
@@ -437,7 +435,7 @@ sub chown {
   $fs->chown( $user, $file, @opts ) or die("Can't chown $file");
 }
 
-=item chgrp($group, $file)
+=head2 chgrp($group, $file)
 
 Change the group of a file or a directory.
 
@@ -461,7 +459,7 @@ sub chgrp {
   $fs->chgrp( $group, $file, @opts ) or die("Can't chgrp $file");
 }
 
-=item chmod($mode, $file)
+=head2 chmod($mode, $file)
 
 Change the permissions of a file or a directory.
 
@@ -485,7 +483,7 @@ sub chmod {
   $fs->chmod( $mode, $file, @opts ) or die("Can't chmod $file");
 }
 
-=item stat($file)
+=head2 stat($file)
 
 This function will return a hash with the following information about a file or directory.
 
@@ -537,7 +535,7 @@ sub stat {
   return %ret;
 }
 
-=item is_file($file)
+=head2 is_file($file)
 
 This function tests if $file is a file. Returns 1 if true. 0 if false.
 
@@ -562,7 +560,7 @@ sub is_file {
   return $fs->is_file($file);
 }
 
-=item is_dir($dir)
+=head2 is_dir($dir)
 
 This function tests if $dir is a directory. Returns 1 if true. 0 if false.
 
@@ -588,7 +586,7 @@ sub is_dir {
 
 }
 
-=item is_symlink($file)
+=head2 is_symlink($file)
 
 This function tests if $file is a symlink. Returns 1 if true. 0 if false.
 
@@ -613,7 +611,7 @@ sub is_symlink {
   return $fs->is_symlink($path);
 }
 
-=item is_readable($file)
+=head2 is_readable($file)
 
 This function tests if $file is readable. It returns 1 if true. 0 if false.
 
@@ -639,7 +637,7 @@ sub is_readable {
   return $fs->is_readable($file);
 }
 
-=item is_writable($file)
+=head2 is_writable($file)
 
 This function tests if $file is writable. It returns 1 if true. 0 if false.
 
@@ -665,7 +663,7 @@ sub is_writable {
   return $fs->is_writable($file);
 }
 
-=item is_writeable($file)
+=head2 is_writeable($file)
 
 This is only an alias for I<is_writable>.
 
@@ -677,7 +675,7 @@ sub is_writeable {
   is_writable(@_);
 }
 
-=item readlink($link)
+=head2 readlink($link)
 
 This function returns the link endpoint if $link is a symlink. If $link is not a symlink it will die.
 
@@ -711,7 +709,7 @@ sub readlink {
   return $link;
 }
 
-=item rename($old, $new)
+=head2 rename($old, $new)
 
 This function will rename $old to $new. Will return 1 on success and 0 on failure.
 
@@ -764,7 +762,7 @@ sub rename {
     ->report_resource_end( type => "rename", name => "$old -> $new" );
 }
 
-=item mv($old, $new)
+=head2 mv($old, $new)
 
 mv is an alias for I<rename>.
 
@@ -774,7 +772,7 @@ sub mv {
   return &rename(@_);
 }
 
-=item chdir($newdir)
+=head2 chdir($newdir)
 
 This function will change the current workdirectory to $newdir. This function currently only works local.
 
@@ -791,7 +789,7 @@ sub chdir {
   CORE::chdir( $_[0] );
 }
 
-=item cd($newdir)
+=head2 cd($newdir)
 
 This is an alias of I<chdir>.
 
@@ -801,7 +799,7 @@ sub cd {
   &chdir( $_[0] );
 }
 
-=item df([$device])
+=head2 df([$device])
 
 This function returns a hashRef reflecting the output of I<df>
 
@@ -868,7 +866,7 @@ sub _parse_df {
   return $ret;
 }
 
-=item du($path)
+=head2 du($path)
 
 Returns the disk usage of $path.
 
@@ -891,7 +889,7 @@ sub du {
   return $du;
 }
 
-=item cp($source, $destination)
+=head2 cp($source, $destination)
 
 cp will copy $source to $destination (it is recursive)
 
@@ -936,7 +934,7 @@ sub cp {
     ->report_resource_end( type => "cp", name => "$source -> $dest" );
 }
 
-=item mount($device, $mount_point, @options)
+=head2 mount($device, $mount_point, @options)
 
 Mount devices.
 
@@ -1127,7 +1125,7 @@ sub mount {
     ->report_resource_end( type => "mount", name => "$mount_point" );
 }
 
-=item umount($mount_point)
+=head2 umount($mount_point)
 
 Unmount device.
 
@@ -1181,7 +1179,7 @@ sub umount {
     ->report_resource_end( type => "umount", name => "$mount_point" );
 }
 
-=item glob($glob)
+=head2 glob($glob)
 
  task "glob", "server1", sub {
    my @files_with_p = grep { is_file($_) } glob("/etc/p*");
@@ -1198,9 +1196,5 @@ sub glob {
   my $fs = Rex::Interface::Fs->create;
   return $fs->glob($glob);
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Gather.pm
+++ b/lib/Rex/Commands/Gather.pm
@@ -21,8 +21,6 @@ All these functions will not be reported. These functions don't modify anything.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Gather;
@@ -50,7 +48,7 @@ use vars qw(@EXPORT);
   is_freebsd is_netbsd is_openbsd is_redhat is_linux is_bsd is_solaris is_suse is_debian is_mageia is_windows is_alt is_openwrt is_gentoo is_fedora
   get_system_information dump_system_information);
 
-=item get_operating_system
+=head2 get_operating_system
 
 Will return the current operating system name.
 
@@ -72,7 +70,7 @@ sub operating_system {
   return get_operating_system();
 }
 
-=item get_system_information
+=head2 get_system_information
 
 Will return a hash of all system information. These Information will be also used by the template function.
 
@@ -82,7 +80,7 @@ sub get_system_information {
   return Rex::Helper::System::info();
 }
 
-=item dump_system_information
+=head2 dump_system_information
 
 This function dumps all known system information on stdout.
 
@@ -96,7 +94,7 @@ sub dump_system_information {
     { prepend_key => '$', key_value_sep => " = ", no_root => 1 } );
 }
 
-=item operating_system_is($string)
+=head2 operating_system_is($string)
 
 Will return 1 if the operating system is $string.
 
@@ -122,7 +120,7 @@ sub operating_system_is {
 
 }
 
-=item operating_system_version()
+=head2 operating_system_version()
 
 Will return the os release number as an integer. For example, it will convert 5.10 to 510, 10.04 to 1004 or 6.0.3 to 603.
 
@@ -146,7 +144,7 @@ sub operating_system_version {
 
 }
 
-=item operating_system_release()
+=head2 operating_system_release()
 
 Will return the os release number as is.
 
@@ -157,7 +155,7 @@ sub operating_system_release {
   return Rex::Hardware::Host->get_operating_system_version();
 }
 
-=item network_interfaces
+=head2 network_interfaces
 
 Return an HashRef of all the networkinterfaces and their configuration.
 
@@ -182,7 +180,7 @@ sub network_interfaces {
 
 }
 
-=item memory
+=head2 memory
 
 Return an HashRef of all memory information.
 
@@ -206,7 +204,7 @@ sub memory {
 
 }
 
-=item is_freebsd
+=head2 is_freebsd
 
 Returns true if the target system is a FreeBSD.
 
@@ -228,7 +226,7 @@ sub is_freebsd {
   }
 }
 
-=item is_redhat
+=head2 is_redhat
 
  task "foo", "server1", sub {
    if(is_redhat) {
@@ -255,7 +253,7 @@ sub is_redhat {
   }
 }
 
-=item is_fedora
+=head2 is_fedora
 
  task "foo", "server1", sub {
    if(is_fedora) {
@@ -275,7 +273,7 @@ sub is_fedora {
   }
 }
 
-=item is_suse
+=head2 is_suse
 
  task "foo", "server1", sub {
    if(is_suse) {
@@ -295,7 +293,7 @@ sub is_suse {
   }
 }
 
-=item is_mageia
+=head2 is_mageia
 
  task "foo", "server1", sub {
    if(is_mageia) {
@@ -315,7 +313,7 @@ sub is_mageia {
   }
 }
 
-=item is_debian
+=head2 is_debian
 
  task "foo", "server1", sub {
    if(is_debian) {
@@ -335,7 +333,7 @@ sub is_debian {
   }
 }
 
-=item is_alt
+=head2 is_alt
 
  task "foo", "server1", sub {
    if(is_alt) {
@@ -355,7 +353,7 @@ sub is_alt {
   }
 }
 
-=item is_netbsd
+=head2 is_netbsd
 
 Returns true if the target system is a NetBSD.
 
@@ -377,7 +375,7 @@ sub is_netbsd {
   }
 }
 
-=item is_openbsd
+=head2 is_openbsd
 
 Returns true if the target system is an OpenBSD.
 
@@ -399,7 +397,7 @@ sub is_openbsd {
   }
 }
 
-=item is_linux
+=head2 is_linux
 
 Returns true if the target system is a Linux System.
 
@@ -425,7 +423,7 @@ sub is_linux {
   }
 }
 
-=item is_bsd
+=head2 is_bsd
 
 Returns true if the target system is a BSD System.
 
@@ -448,7 +446,7 @@ sub is_bsd {
   }
 }
 
-=item is_solaris
+=head2 is_solaris
 
 Returns true if the target system is a Solaris System.
 
@@ -474,7 +472,7 @@ sub is_solaris {
   }
 }
 
-=item is_windows
+=head2 is_windows
 
 Returns true if the target system is a Windows System.
 
@@ -491,7 +489,7 @@ sub is_windows {
 
 }
 
-=item is_openwrt
+=head2 is_openwrt
 
 Returns true if the target system is an OpenWrt System.
 
@@ -505,7 +503,7 @@ sub is_openwrt {
 
 }
 
-=item is_gentoo
+=head2 is_gentoo
 
 Returns true if the target system is a Gentoo System.
 
@@ -518,9 +516,5 @@ sub is_gentoo {
   }
 
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Host.pm
+++ b/lib/Rex/Commands/Host.pm
@@ -23,8 +23,6 @@ With this module you can manage the host entries in /etc/hosts.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Host;
@@ -47,7 +45,7 @@ use base qw(Rex::Exporter);
 
 @EXPORT = qw(create_host get_host delete_host host_entry);
 
-=item host_entry($name, %option)
+=head2 host_entry($name, %option)
 
 Manages the entries in /etc/hosts.
 
@@ -106,7 +104,7 @@ sub host_entry {
     ->report_resource_end( type => "host_entry", name => $res_name );
 }
 
-=item create_host($)
+=head2 create_host($)
 
 Update or create a /etc/hosts entry.
 
@@ -157,7 +155,7 @@ sub create_host {
   }
 }
 
-=item delete_host($host)
+=head2 delete_host($host)
 
 Delete a host from /etc/hosts.
 
@@ -187,7 +185,7 @@ sub delete_host {
   }
 }
 
-=item get_host($host)
+=head2 get_host($host)
 
 Returns the information of $host in /etc/hosts.
 
@@ -254,9 +252,5 @@ sub _parse_hosts {
 
   return @ret;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Inventory.pm
+++ b/lib/Rex/Commands/Inventory.pm
@@ -24,8 +24,6 @@ All these functions will not be reported. These functions don't modify anything.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Inventory;
@@ -44,7 +42,7 @@ use base qw(Rex::Exporter);
 
 @EXPORT = qw(inventor inventory);
 
-=item inventory
+=head2 inventory
 
 This function returns a hashRef of all gathered hardware. Use the Data::Dumper module to see its structure.
 
@@ -64,9 +62,5 @@ sub inventory {
 sub inventor {
   return inventory();
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Iptables.pm
+++ b/lib/Rex/Commands/Iptables.pm
@@ -60,8 +60,6 @@ Only I<open_port> and I<close_port> are idempotent.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Iptables;
@@ -90,7 +88,7 @@ use Rex::Logger;
 
 sub iptables;
 
-=item open_port($port, $option)
+=head2 open_port($port, $option)
 
 Open a port for inbound connections.
 
@@ -132,7 +130,7 @@ sub open_port {
 
 }
 
-=item close_port($port, $option)
+=head2 close_port($port, $option)
 
 Close a port for inbound connections.
 
@@ -169,7 +167,7 @@ sub close_port {
 
 }
 
-=item redirect_port($in_port, $option)
+=head2 redirect_port($in_port, $option)
 
 Redirect $in_port to another local port.
 
@@ -238,7 +236,7 @@ sub redirect_port {
   iptables @opts;
 }
 
-=item iptables(@params)
+=head2 iptables(@params)
 
 Write standard iptable comands.
 
@@ -322,7 +320,7 @@ sub iptables {
   }
 }
 
-=item is_nat_gateway
+=head2 is_nat_gateway
 
 This function creates a NAT gateway for the device the default route points to.
 
@@ -356,7 +354,7 @@ sub is_nat_gateway {
 
 }
 
-=item default_state_rule(%option)
+=head2 default_state_rule(%option)
 
 Set the default state rules for the given device.
 
@@ -389,7 +387,7 @@ sub default_state_rule {
     j     => "ACCEPT";
 }
 
-=item iptables_list
+=head2 iptables_list
 
 List all iptables rules.
 
@@ -440,7 +438,7 @@ sub _iptables_list {
   return $ret;
 }
 
-=item iptables_clear
+=head2 iptables_clear
 
 Remove all iptables rules.
 
@@ -549,9 +547,5 @@ sub _rule_exists {
 
   return 0;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Kernel.pm
+++ b/lib/Rex/Commands/Kernel.pm
@@ -24,8 +24,6 @@ All these functions are not idempotent.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Kernel;
@@ -48,7 +46,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(kmod);
 
-=item kmod($action => $module)
+=head2 kmod($action => $module)
 
 This function loads or unloads a kernel module.
 
@@ -148,9 +146,5 @@ sub kmod {
     die("Unknown action $action");
   }
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/LVM.pm
+++ b/lib/Rex/Commands/LVM.pm
@@ -28,8 +28,6 @@ All these functions are not idempotent.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::LVM;
@@ -47,7 +45,7 @@ use vars qw(@EXPORT);
 
 use Rex::Commands::Run;
 
-=item pvs
+=head2 pvs
 
 Get Information for all your physical volumes.
 
@@ -97,7 +95,7 @@ sub pvs {
 
 }
 
-=item vgs
+=head2 vgs
 
 Get Information for all your volume groups.
 
@@ -154,7 +152,7 @@ sub vgs {
 
 }
 
-=item lvs
+=head2 lvs
 
 Get Information for all your logical volumes.
 
@@ -279,9 +277,5 @@ sub vgextend {
 
   return 1;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/MD5.pm
+++ b/lib/Rex/Commands/MD5.pm
@@ -20,8 +20,6 @@ This is just a helper function and will not be reported.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::MD5;
@@ -45,7 +43,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(md5);
 
-=item md5($file)
+=head2 md5($file)
 
 This function will return the md5 sum (hexadecimal) for the given file.
 
@@ -131,9 +129,5 @@ sub md5 {
 
   }
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Network.pm
+++ b/lib/Rex/Commands/Network.pm
@@ -27,8 +27,6 @@ With this module you can get information of the routing table, current network c
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Network;
@@ -49,7 +47,7 @@ use base qw(Rex::Exporter);
 
 @EXPORT = qw(route default_gateway netstat);
 
-=item route
+=head2 route
 
 Get routing information
 
@@ -59,7 +57,7 @@ sub route {
   return Rex::Hardware::Network::route();
 }
 
-=item default_gateway([$default_gw])
+=head2 default_gateway([$default_gw])
 
 Get or set the default gateway.
 
@@ -90,7 +88,7 @@ sub default_gateway {
   return Rex::Hardware::Network::default_gateway();
 }
 
-=item netstat
+=head2 netstat
 
 Get network connection information
 
@@ -99,9 +97,5 @@ Get network connection information
 sub netstat {
   return Rex::Hardware::Network::netstat();
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Notify.pm
+++ b/lib/Rex/Commands/Notify.pm
@@ -19,8 +19,6 @@ This module exports the notify() function.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Notify;
@@ -37,7 +35,7 @@ use base qw(Rex::Exporter);
 
 @EXPORT = qw(notify);
 
-=item notify($resource_type, $resource_name)
+=head2 notify($resource_type, $resource_name)
 
 This function will notify the given $resource_name of the given $resource_type to execute.
 
@@ -51,9 +49,5 @@ sub notify {
     name => $resource_name,
   );
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Partition.pm
+++ b/lib/Rex/Commands/Partition.pm
@@ -25,8 +25,6 @@ All these functions are not idempotent.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Partition;
@@ -50,7 +48,7 @@ use Rex::Commands qw(TRUE FALSE);
 
 @EXPORT = qw(clearpart partition);
 
-=item clearpart($drive)
+=head2 clearpart($drive)
 
 Clear partitions on drive `sda`:
 
@@ -105,7 +103,7 @@ sub clearpart {
   }
 }
 
-=item partition($mountpoint, %option)
+=head2 partition($mountpoint, %option)
 
 Create a partition with mountpoint $mountpoint.
 
@@ -276,9 +274,5 @@ sub partition {
 
   return "$disk$part_num";
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -22,8 +22,6 @@ With this module you can install packages and files.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Pkg;
@@ -57,7 +55,7 @@ use vars qw(@EXPORT);
 @EXPORT =
   qw(install update remove update_system installed_packages is_installed update_package_db repository package_provider_for pkg);
 
-=item pkg($package, %options)
+=head2 pkg($package, %options)
 
 Since: 0.45
 
@@ -158,7 +156,7 @@ sub pkg {
     ->report_resource_end( type => "pkg", name => $res_package );
 }
 
-=item install($type, $data, $options)
+=head2 install($type, $data, $options)
 
 The install function can install packages (for CentOS, OpenSuSE and Debian) and files.
 
@@ -483,7 +481,7 @@ sub update {
 
 }
 
-=item remove($type, $package, $options)
+=head2 remove($type, $package, $options)
 
 This function will remove the given package from a system.
 
@@ -528,7 +526,7 @@ sub remove {
 
 }
 
-=item update_system
+=head2 update_system
 
 This function does a complete system update.
 
@@ -582,7 +580,7 @@ sub update_system {
   }
 }
 
-=item installed_packages
+=head2 installed_packages
 
 This function returns all installed packages and their version.
 
@@ -602,7 +600,7 @@ sub installed_packages {
   return $pkg->get_installed;
 }
 
-=item is_installed
+=head2 is_installed
 
 This function tests if $package is installed. Returns 1 if true. 0 if false.
 
@@ -623,7 +621,7 @@ sub is_installed {
   return $pkg->is_installed($package);
 }
 
-=item update_package_db
+=head2 update_package_db
 
 This function updates the local package database. For example, on CentOS it will execute I<yum makecache>.
 
@@ -639,7 +637,7 @@ sub update_package_db {
   $pkg->update_pkg_db();
 }
 
-=item repository($action, %data)
+=head2 repository($action, %data)
 
 Add or remove a repository from the package manager.
 
@@ -742,7 +740,7 @@ sub repository {
   return $ret;
 }
 
-=item package_provider_for $os => $type;
+=head2 package_provider_for $os => $type;
 
 To set another package provider as the default, use this function.
 
@@ -763,9 +761,5 @@ sub package_provider_for {
   my ( $os, $provider ) = @_;
   Rex::Config->set( "package_provider", { $os => $provider } );
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/PkgConf.pm
+++ b/lib/Rex/Commands/PkgConf.pm
@@ -36,8 +36,6 @@ With this module you can configure packages. Currently it only supports Debian
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::PkgConf;
@@ -57,7 +55,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(get_pkgconf set_pkgconf);
 
-=item get_pkgconf($package, [$question])
+=head2 get_pkgconf($package, [$question])
 
 Use this to query existing package configurations.
 
@@ -90,7 +88,7 @@ sub get_pkgconf {
   $pkgconf->get_options($package);
 }
 
-=item set_pkgconf($package, $values, [%options])
+=head2 set_pkgconf($package, $values, [%options])
 
 Use this to set package configurations.
 
@@ -107,8 +105,6 @@ Optionally the option "no_update" may be true, in which case the
 question will not be updated if it has already been set.
 
 See the synopsis for examples.
-
-=back
 
 =cut
 

--- a/lib/Rex/Commands/Process.pm
+++ b/lib/Rex/Commands/Process.pm
@@ -24,8 +24,6 @@ All these functions are not idempotent.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Process;
@@ -47,7 +45,7 @@ use base qw(Rex::Exporter);
   ps
   nice);
 
-=item kill($pid, $sig)
+=head2 kill($pid, $sig)
 
 Will kill the given process id. If $sig is specified it will kill with the given signal.
 
@@ -68,7 +66,7 @@ sub kill {
   }
 }
 
-=item killall($name, $sig)
+=head2 killall($name, $sig)
 
 Will kill the given process. If $sig is specified it will kill with the given signal.
 
@@ -94,7 +92,7 @@ sub killall {
   }
 }
 
-=item ps
+=head2 ps
 
 List all processes on a system. Will return all fields of a I<ps aux>.
 
@@ -225,7 +223,7 @@ sub ps {
 #  run "nohup $cmd &";
 #}
 
-=item nice($pid, $level)
+=head2 nice($pid, $level)
 
 Renice a process identified by $pid with the priority $level.
 
@@ -242,9 +240,5 @@ sub nice {
     die("Error renicing $pid");
   }
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -40,8 +40,6 @@ the execution of the rsync task.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Rsync;
@@ -64,7 +62,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(sync);
 
-=item sync($source, $dest, $opts)
+=head2 sync($source, $dest, $opts)
 
 This function executes rsync to sync $source and $dest.
 
@@ -337,9 +335,5 @@ sub sync {
   }
 
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -20,8 +20,6 @@ With this module you can run a command.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Run;
@@ -59,9 +57,9 @@ use base qw(Rex::Exporter);
 
 @EXPORT = qw(run can_run sudo);
 
-=item run($command [, $callback])
+=head2 run($command [, $callback])
 
-=item run($command_description, command => $command, %options)
+=head2 run($command_description, command => $command, %options)
 
 This function will execute the given command and returns the output. In
 scalar context it returns the raw output as is, and in list context it
@@ -312,7 +310,7 @@ sub run {
   return $out_ret;
 }
 
-=item can_run($command)
+=head2 can_run($command)
 
 This function checks if a command is in the path or is available. You can
 specify multiple commands, the first command found will be returned.
@@ -331,7 +329,7 @@ sub can_run {
   $exec->can_run( [@commands] ); # use a new anon ref, so that we don't have drawbacks if some lower layers will manipulate things.
 }
 
-=item sudo
+=head2 sudo
 
 Run a command with I<sudo>. Define the password for sudo with I<sudo_password>.
 
@@ -409,9 +407,5 @@ sub sudo {
 
   return $ret;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/SCM.pm
+++ b/lib/Rex/Commands/SCM.pm
@@ -45,8 +45,6 @@ All these functions are not idempotent.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::SCM;
@@ -71,7 +69,7 @@ Rex::Config->register_set_handler(
   }
 );
 
-=item checkout($name, %data);
+=head2 checkout($name, %data);
 
 With this function you can checkout a repository defined with I<set repository>. See Synopsis.
 
@@ -102,9 +100,5 @@ sub checkout {
   Rex::Logger::debug("Checking out $repo -> $co_to");
   $scm->checkout( $REPOS{$name}, $co_to, \%data );
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Service.pm
+++ b/lib/Rex/Commands/Service.pm
@@ -32,8 +32,6 @@ With this module you can manage Linux services.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Service;
@@ -56,7 +54,7 @@ use Carp;
 
 @EXPORT = qw(service service_provider_for);
 
-=item service($service, $action, [$option])
+=head2 service($service, $action, [$option])
 
 The service function accepts 2 parameters. The first is the service name and the second the action you want to perform.
 
@@ -390,7 +388,7 @@ sub old_service {
   return $return;
 }
 
-=item service_provider_for $os => $type;
+=head2 service_provider_for $os => $type;
 
 To set another service provider as the default, use this function.
 
@@ -412,8 +410,6 @@ sub service_provider_for {
   Rex::Logger::debug("setting service provider for $os to $provider");
   Rex::Config->set( "service_provider", { $os => $provider } );
 }
-
-=back
 
 =cut
 

--- a/lib/Rex/Commands/SimpleCheck.pm
+++ b/lib/Rex/Commands/SimpleCheck.pm
@@ -24,8 +24,6 @@ All these functions are not idempotent.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::SimpleCheck;
@@ -43,7 +41,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(is_port_open);
 
-=item is_port_open($ip, $port)
+=head2 is_port_open($ip, $port)
 
 Check if something is listening on port $port of $ip.
 
@@ -71,9 +69,5 @@ sub is_port_open {
   return 0;
 
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Sysctl.pm
+++ b/lib/Rex/Commands/Sysctl.pm
@@ -27,8 +27,6 @@ This function doesn't persist the entries in /etc/sysctl.conf.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Sysctl;
@@ -48,7 +46,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(sysctl);
 
-=item sysctl($key [, $val])
+=head2 sysctl($key [, $val])
 
 This function will read the sysctl key $key.
 
@@ -96,9 +94,5 @@ sub sysctl {
   }
 
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Tail.pm
+++ b/lib/Rex/Commands/Tail.pm
@@ -23,8 +23,6 @@ With this module you can tail a file.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Tail;
@@ -47,7 +45,7 @@ use base qw(Rex::Exporter);
 
 @EXPORT = qw(tail);
 
-=item tail($file)
+=head2 tail($file)
 
 This function will tail the given file.
 
@@ -102,9 +100,5 @@ sub tail {
   Rex::Commands::set( "rex_internals", $int );
 
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Upload.pm
+++ b/lib/Rex/Commands/Upload.pm
@@ -20,8 +20,6 @@ With this module you can upload a local file via sftp to a remote host.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::Upload;
@@ -46,7 +44,7 @@ use base qw(Rex::Exporter);
 
 @EXPORT = qw(upload);
 
-=item upload($local, $remote)
+=head2 upload($local, $remote)
 
 Perform an upload. If $remote is a directory the file will be uploaded to that directory.
 
@@ -194,9 +192,5 @@ sub upload {
 
   return $__ret;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/User.pm
+++ b/lib/Rex/Commands/User.pm
@@ -31,8 +31,6 @@ With this module you can manage user and groups.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Commands::User;
@@ -58,7 +56,7 @@ use base qw(Rex::Exporter);
   account lock_password unlock_password
 );
 
-=item account($name, %option)
+=head2 account($name, %option)
 
 Manage user account.
 
@@ -122,7 +120,7 @@ sub account {
   }
 }
 
-=item create_user($user => {})
+=head2 create_user($user => {})
 
 Create or update a user.
 
@@ -199,7 +197,7 @@ sub create_user {
   return $uid->{ret};
 }
 
-=item get_uid($user)
+=head2 get_uid($user)
 
 Returns the uid of $user.
 
@@ -209,7 +207,7 @@ sub get_uid {
   Rex::User->get()->get_uid(@_);
 }
 
-=item get_user($user)
+=head2 get_user($user)
 
 Returns all information about $user.
 
@@ -219,7 +217,7 @@ sub get_user {
   Rex::User->get()->get_user(@_);
 }
 
-=item user_groups($user)
+=head2 user_groups($user)
 
 Returns group membership about $user.
 
@@ -229,7 +227,7 @@ sub user_groups {
   Rex::User->get()->user_groups(@_);
 }
 
-=item user_list()
+=head2 user_list()
 
 Returns user list via getent passwd.
 
@@ -245,7 +243,7 @@ sub user_list {
   Rex::User->get()->user_list(@_);
 }
 
-=item delete_user($user)
+=head2 delete_user($user)
 
 Delete a user from the system.
 
@@ -271,7 +269,7 @@ sub delete_user {
   Rex::User->get()->rm_user( $user, $data );
 }
 
-=item lock_password($user)
+=head2 lock_password($user)
 
 Lock the password of a user account. Currently this is only
 available on Linux (see passwd --lock).
@@ -282,7 +280,7 @@ sub lock_password {
   Rex::User->get()->lock_password(@_);
 }
 
-=item unlock_password($user)
+=head2 unlock_password($user)
 
 Unlock the password of a user account. Currently this is only
 available on Linux (see passwd --unlock).
@@ -326,7 +324,7 @@ sub group_resource {
   }
 }
 
-=item create_group($group, {})
+=head2 create_group($group, {})
 
 Create or update a group.
 
@@ -351,7 +349,7 @@ sub create_group {
   Rex::User->get()->create_group( $group, @params );
 }
 
-=item get_gid($group)
+=head2 get_gid($group)
 
 Return the group id of $group.
 
@@ -361,7 +359,7 @@ sub get_gid {
   Rex::User->get()->get_gid(@_);
 }
 
-=item get_group($group)
+=head2 get_group($group)
 
 Return information of $group.
 
@@ -373,7 +371,7 @@ sub get_group {
   Rex::User->get()->get_group(@_);
 }
 
-=item delete_group($group)
+=head2 delete_group($group)
 
 Delete a group.
 
@@ -382,9 +380,5 @@ Delete a group.
 sub delete_group {
   Rex::User->get()->rm_group(@_);
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Commands/Virtualization.pm
+++ b/lib/Rex/Commands/Virtualization.pm
@@ -80,13 +80,9 @@ All these functions are not idempotent.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
-=item vm($action => $name, %option)
+=head2 vm($action => $name, %option)
 
 This module only exports the I<vm> function. You can manage everything with this function.
-
-=back
 
 =head1 EXAMPLES
 

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -16,8 +16,6 @@ With this module you can specify own configuration parameters for your modules.
 
 =head1 EXPORTED METHODS
 
-=over 4
-
 =cut
 
 package Rex::Config;
@@ -809,7 +807,7 @@ sub get_no_tty {
   return $no_tty;
 }
 
-=item register_set_handler($handler_name, $code)
+=head2 register_set_handler($handler_name, $code)
 
 Register a handler that gets called by I<set>.
 
@@ -877,7 +875,7 @@ sub get_all {
   return $set_param;
 }
 
-=item register_config_handler($topic, $code)
+=head2 register_config_handler($topic, $code)
 
 With this function it is possible to register own sections in the users config file ($HOME/.rex/config.yml).
 
@@ -1084,9 +1082,5 @@ sub _home_dir {
 
   return $ENV{'HOME'} || "";
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/FS/File.pm
+++ b/lib/Rex/FS/File.pm
@@ -26,8 +26,6 @@ This is the File Class used by I<file_write> and I<file_read>.
 
 =head1 CLASS METHODS
 
-=over 4
-
 =cut
 
 package Rex::FS::File;
@@ -40,7 +38,7 @@ use Rex::Interface::File;
 
 use constant DEFAULT_READ_LEN => 64;
 
-=item new
+=head2 new
 
 This is the constructor. You need to set the filehandle which the object should work on
 or pass a filename. If you pass a filehandle, it has to be a C<Rex::Interface::File::*>
@@ -123,7 +121,7 @@ sub DESTROY {
   }
 }
 
-=item write($buf)
+=head2 write($buf)
 
 Write $buf into the filehandle.
 
@@ -147,7 +145,7 @@ sub write {
   }
 }
 
-=item seek($offset)
+=head2 seek($offset)
 
 Seek to the file position $offset.
 
@@ -164,7 +162,7 @@ sub seek {
   $fh->seek($offset);
 }
 
-=item read($len)
+=head2 read($len)
 
 Read $len bytes out of the filehandle.
 
@@ -180,7 +178,7 @@ sub read {
   return $fh->read($len);
 }
 
-=item read_all
+=head2 read_all
 
 Read everything out of the filehandle.
 
@@ -201,7 +199,7 @@ sub read_all {
   return $all;
 }
 
-=item close
+=head2 close
 
 Close the file.
 
@@ -214,9 +212,5 @@ sub close {
   my $fh = $self->{'fh'};
   $fh->close;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Group/Lookup/Command.pm
+++ b/lib/Rex/Group/Lookup/Command.pm
@@ -22,8 +22,6 @@ With this module you can define hostgroups out of a command.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Group::Lookup::Command;
@@ -67,9 +65,5 @@ sub lookup_command {
   Rex::Logger::info("You must give a valid command.") unless $#content;
   return @content;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Group/Lookup/DBI.pm
+++ b/lib/Rex/Group/Lookup/DBI.pm
@@ -20,8 +20,6 @@ With this module you can define hostgroups out of an DBI source.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Group::Lookup::DBI;
@@ -41,18 +39,18 @@ use vars qw(@EXPORT);
 use Rex::Helper::DBI;
 @EXPORT = qw(groups_dbi);
 
-=item groups_dbi($dsn, $user, $password, $sql)
+=head2 groups_dbi($dsn, $user, $password, $sql)
 
  With this function you can read groups from DBI source.
 
-=item Example:
+=head2 Example:
  groups_dbi( 'DBI:mysql:rex;host=db01',
    user             => 'username',
    password         => 'password',
    sql              => "SELECT * FROM HOST",
    create_all_group => TRUE);
 
-=item Database sample for MySQL
+=head2 Database sample for MySQL
 
  CREATE TABLE IF NOT EXISTS `HOST` (
    `ID` int(11) NOT NULL,
@@ -61,7 +59,7 @@ use Rex::Helper::DBI;
    PRIMARY KEY (`ID`)
  );
 
-=item Data sample for MySQL
+=head2 Data sample for MySQL
 
  INSERT INTO `HOST` (`ID`, `GROUP`, `HOST`) VALUES
    (1, 'db', 'db01'),
@@ -101,9 +99,5 @@ sub groups_dbi {
     group( "all", values %all_hosts );
   }
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Group/Lookup/File.pm
+++ b/lib/Rex/Group/Lookup/File.pm
@@ -20,8 +20,6 @@ With this module you can define hostgroups out of a file.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Group::Lookup::File;
@@ -37,7 +35,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(lookup_file);
 
-=item lookup_file($file)
+=head2 lookup_file($file)
 
 With this function you can read hostnames from a file. Every hostname in one line.
 
@@ -57,9 +55,5 @@ sub lookup_file {
 
   return @content;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Group/Lookup/INI.pm
+++ b/lib/Rex/Group/Lookup/INI.pm
@@ -20,8 +20,6 @@ With this module you can define hostgroups out of an ini style file.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Group::Lookup::INI;
@@ -41,7 +39,7 @@ use Rex::Helper::INI;
 
 @EXPORT = qw(groups_file);
 
-=item groups_file($file)
+=head2 groups_file($file)
 
 With this function you can read groups from ini style files.
 
@@ -90,9 +88,5 @@ sub groups_file {
     group( "$k" => @servers );
   }
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Group/Lookup/XML.pm
+++ b/lib/Rex/Group/Lookup/XML.pm
@@ -20,8 +20,6 @@ With this module you can define hostgroups out of an xml file.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Group::Lookup::XML;
@@ -39,7 +37,7 @@ XML::LibXML->require;
 
 @EXPORT = qw(groups_xml);
 
-=item groups_xml($file)
+=head2 groups_xml($file)
 
 With this function you can read groups from xml files.
 
@@ -66,7 +64,7 @@ File Example:
  
 =cut
 
-=item $schema_file
+=head2 $schema_file
 
 A global that defines the XSD schema for which the XML is check against.
 
@@ -133,9 +131,5 @@ sub groups_xml {
   }
   group( $_ => @{ $groups{$_} } ) foreach ( keys(%groups) );
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Group/Lookup/YAML.pm
+++ b/lib/Rex/Group/Lookup/YAML.pm
@@ -20,8 +20,6 @@ With this module you can define hostgroups out of an yaml file.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Group::Lookup::YAML;
@@ -41,7 +39,7 @@ use YAML qw/LoadFile/;
 
 @EXPORT = qw(groups_yaml);
 
-=item groups_yaml($file)
+=head2 groups_yaml($file)
 
 With this function you can read groups from yaml files.
 
@@ -88,9 +86,5 @@ sub groups_yaml {
     group( "all", values %all_hosts );
   }
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Hardware.pm
+++ b/lib/Rex/Hardware.pm
@@ -21,8 +21,6 @@ This module is the base class for hardware/information gathering.
 
 =head1 CLASS METHODS
 
-=over 4
-
 =cut
 
 package Rex::Hardware;
@@ -36,7 +34,7 @@ use Rex::Logger;
 
 require Rex::Args;
 
-=item get(@modules)
+=head2 get(@modules)
 
 Returns a hash with the wanted information.
 
@@ -116,9 +114,5 @@ sub get {
 
   return %hardware_information;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Helper/SSH2/Expect.pm
+++ b/lib/Rex/Helper/SSH2/Expect.pm
@@ -58,9 +58,7 @@ use warnings;
 
 # VERSION
 
-=over 4
-
-=item new($ssh2)
+=head2 new($ssh2)
 
 Constructor: You need to parse an connected Net::SSH2 Object. 
 
@@ -85,7 +83,7 @@ sub new {
   return $self;
 }
 
-=item log_stdout(0|1)
+=head2 log_stdout(0|1)
 
 Log on STDOUT.
 
@@ -96,7 +94,7 @@ sub log_stdout {
   $self->{"__log_stdout"} = $log;
 }
 
-=item log_file($file)
+=head2 log_file($file)
 
 Log everything to a file. $file can be a filename, a filehandle or a subRef.
 
@@ -112,7 +110,7 @@ sub shell {
   return $self->{"__shell"};
 }
 
-=item spawn($command, @parameters)
+=head2 spawn($command, @parameters)
 
 Spawn $command with @parameters as parameters.
 
@@ -125,7 +123,7 @@ sub spawn {
   $self->shell->write("$cmd\n");
 }
 
-=item soft_close()
+=head2 soft_close()
 
 Currently only an alias to hard_close();
 
@@ -136,7 +134,7 @@ sub soft_close {
   $self->hard_close;
 }
 
-=item hard_close();
+=head2 hard_close();
 
 Stops the execution of the process.
 
@@ -147,7 +145,7 @@ sub hard_close {
   die;
 }
 
-=item expect($timeout, @match_patters)
+=head2 expect($timeout, @match_patters)
 
 This method controls the execution of your process.
 
@@ -179,7 +177,7 @@ sub expect {
   };
 }
 
-=item send($string)
+=head2 send($string)
 
 Send a string to the running command.
 
@@ -222,9 +220,4 @@ sub _log {
 
 }
 
-=back
-
-=cut
-
 1;
-

--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -23,8 +23,6 @@ The Task Object. Typically you only need this class if you want to manipulate ta
 
 =head1 METHODS
 
-=over 4
-
 =cut
 
 package Rex::Task;
@@ -54,7 +52,7 @@ require Rex::Commands;
 
 require Rex::Args;
 
-=item new
+=head2 new
 
 This is the constructor.
 
@@ -107,7 +105,7 @@ sub new {
   return $self;
 }
 
-=item connection
+=head2 connection
 
 Returns the current connection object.
 
@@ -123,7 +121,7 @@ sub connection {
   $self->{connection};
 }
 
-=item executor
+=head2 executor
 
 Returns the current executor object.
 
@@ -135,7 +133,7 @@ sub executor {
   return $self->{executor};
 }
 
-=item hidden
+=head2 hidden
 
 Returns true if the task is hidden. (Should not be displayed on ,,rex -T''.)
 
@@ -146,7 +144,7 @@ sub hidden {
   return $self->{hidden};
 }
 
-=item server
+=head2 server
 
 Returns the servers on which the task should be executed as an ArrayRef.
 
@@ -202,7 +200,7 @@ sub server {
   return [@ret];
 }
 
-=item set_server(@server)
+=head2 set_server(@server)
 
 With this method you can set new servers on which the task should be executed on.
 
@@ -213,7 +211,7 @@ sub set_server {
   $self->{server} = \@server;
 }
 
-=item delete_server
+=head2 delete_server
 
 Delete every server registered to the task.
 
@@ -226,7 +224,7 @@ sub delete_server {
   $self->rethink_connection;
 }
 
-=item current_server
+=head2 current_server
 
 Returns the current server on which the tasks gets executed right now.
 
@@ -238,7 +236,7 @@ sub current_server {
     || Rex::Group::Entry::Server->new( name => "<local>" );
 }
 
-=item desc
+=head2 desc
 
 Returns the description of a task.
 
@@ -249,7 +247,7 @@ sub desc {
   return $self->{desc};
 }
 
-=item set_desc($description)
+=head2 set_desc($description)
 
 Set the description of a task.
 
@@ -260,7 +258,7 @@ sub set_desc {
   $self->{desc} = $desc;
 }
 
-=item is_remote
+=head2 is_remote
 
 Returns true (1) if the task will be executed remotely.
 
@@ -282,7 +280,7 @@ sub is_remote {
   return 0;
 }
 
-=item is_local
+=head2 is_local
 
 Returns true (1) if the task gets executed on the local host.
 
@@ -293,7 +291,7 @@ sub is_local {
   return $self->is_remote() == 0 ? 1 : 0;
 }
 
-=item is_http
+=head2 is_http
 
 Returns true (1) if the task gets executed over http protocol.
 
@@ -317,7 +315,7 @@ sub is_openssh {
       && lc( $self->{"connection_type"} ) eq "openssh" );
 }
 
-=item want_connect
+=head2 want_connect
 
 Returns true (1) if the task will establish a connection to a remote system.
 
@@ -328,7 +326,7 @@ sub want_connect {
   return $self->{no_ssh} == 0 ? 1 : 0;
 }
 
-=item get_connection_type
+=head2 get_connection_type
 
 This method tries to guess the right connection type for the task and returns it.
 
@@ -365,7 +363,7 @@ sub get_connection_type {
   }
 }
 
-=item modify($key, $value)
+=head2 modify($key, $value)
 
 With this method you can modify values of the task.
 
@@ -390,7 +388,7 @@ sub rethink_connection {
   $self->connection;
 }
 
-=item user
+=head2 user
 
 Returns the current user the task will use.
 
@@ -403,7 +401,7 @@ sub user {
   }
 }
 
-=item set_user($user)
+=head2 set_user($user)
 
 Set the user of a task.
 
@@ -414,7 +412,7 @@ sub set_user {
   $self->{auth}->{user} = $user;
 }
 
-=item password
+=head2 password
 
 Returns the password that will be used.
 
@@ -427,7 +425,7 @@ sub password {
   }
 }
 
-=item set_password($password)
+=head2 set_password($password)
 
 Set the password of the task.
 
@@ -438,7 +436,7 @@ sub set_password {
   $self->{auth}->{password} = $password;
 }
 
-=item name
+=head2 name
 
 Returns the name of the task.
 
@@ -449,7 +447,7 @@ sub name {
   return $self->{name};
 }
 
-=item code
+=head2 code
 
 Returns the code of the task.
 
@@ -460,7 +458,7 @@ sub code {
   return $self->{func};
 }
 
-=item set_code(\&code_ref)
+=head2 set_code(\&code_ref)
 
 Set the code of the task.
 
@@ -471,7 +469,7 @@ sub set_code {
   $self->{func} = $code;
 }
 
-=item run_hook($server, $hook)
+=head2 run_hook($server, $hook)
 
 This method is used internally to execute the specified hooks.
 
@@ -498,7 +496,7 @@ sub run_hook {
   }
 }
 
-=item set_auth($key, $value)
+=head2 set_auth($key, $value)
 
 Set the authentication of the task.
 
@@ -519,7 +517,7 @@ sub set_auth {
   }
 }
 
-=item merge_auth($server)
+=head2 merge_auth($server)
 
 Merges the authentication information from $server into the task.
 Tasks authentication information have precedence.
@@ -545,7 +543,7 @@ sub get_sudo_password {
   return $auth{sudo_password};
 }
 
-=item parallelism
+=head2 parallelism
 
 Get the parallelism count of a task.
 
@@ -556,7 +554,7 @@ sub parallelism {
   return $self->{parallelism};
 }
 
-=item set_parallelism($count)
+=head2 set_parallelism($count)
 
 Set the parallelism of the task.
 
@@ -567,7 +565,7 @@ sub set_parallelism {
   $self->{parallelism} = $para;
 }
 
-=item connect($server)
+=head2 connect($server)
 
 Initiate the connection to $server.
 
@@ -676,7 +674,7 @@ sub connect {
   return 1;
 }
 
-=item disconnect
+=head2 disconnect
 
 Disconnect from the current connection.
 
@@ -724,7 +722,7 @@ sub get_data {
 # for compatibility
 #####################################
 
-=item run($server, %options)
+=head2 run($server, %options)
 
 Run the task on $server.
 
@@ -858,7 +856,7 @@ sub get_desc {
   return Rex::TaskList->create()->get_desc(@tmp);
 }
 
-=item exit_on_connect_fail()
+=head2 exit_on_connect_fail()
 
 Returns true if rex should exit on connect failure.
 
@@ -873,9 +871,5 @@ sub set_exit_on_connect_fail {
   my ( $self, $exit ) = @_;
   $self->{exit_on_connect_fail} = $exit;
 }
-
-=back
-
-=cut
 
 1;

--- a/lib/Rex/Template.pm
+++ b/lib/Rex/Template.pm
@@ -19,8 +19,6 @@ This is a simple template engine for configuration files.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Template;
@@ -222,7 +220,7 @@ sub _normalize_var_name {
   return $input;
 }
 
-=item is_defined($variable, $default_value)
+=head2 is_defined($variable, $default_value)
 
 This function will check if $variable is defined. If yes, it will return the value of $variable, otherwise it will return $default_value.
 
@@ -239,9 +237,4 @@ sub is_defined {
   return $default;
 }
 
-=back
-
-=cut
-
 1;
-

--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -48,8 +48,6 @@ This is a basic test module to test your code with the help of local VMs. You ca
 
 =head1 METHODS
 
-=over 4
-
 =cut
 
 package Rex::Test::Base;
@@ -71,7 +69,7 @@ use base qw(Exporter);
 use vars qw(@EXPORT);
 @EXPORT = qw(test);
 
-=item new(name => $test_name)
+=head2 new(name => $test_name)
 
 Constructor if used in OO mode.
 
@@ -94,7 +92,7 @@ sub new {
   return $self;
 }
 
-=item name($name)
+=head2 name($name)
 
 The name of the test. A VM called $name will be created for each test. If the VM already exists, Rex will try to reuse it.
 
@@ -105,7 +103,7 @@ sub name {
   $self->{name} = $name;
 }
 
-=item vm_auth(%auth)
+=head2 vm_auth(%auth)
 
 Authentication options for the VM. It accepts the same parameters as C<Rex::Box::Base-E<gt>auth()>.
 
@@ -116,7 +114,7 @@ sub vm_auth {
   $self->{auth} = \%auth;
 }
 
-=item base_vm($vm)
+=head2 base_vm($vm)
 
 The URL to a base image to be used for the test VM.
 
@@ -133,7 +131,7 @@ sub test(&) {
   $code->($test);
 }
 
-=item redirect_port($port)
+=head2 redirect_port($port)
 
 Redirect local $port to the VM's SSH port (default: 2222).
 
@@ -144,7 +142,7 @@ sub redirect_port {
   $self->{redirect_port} = $port;
 }
 
-=item run_task($task)
+=head2 run_task($task)
 
 The task to run on the test VM. You can run multiple tasks by passing an array reference.
 
@@ -208,37 +206,33 @@ sub finish {
   Rex::pop_connection();
 }
 
-=back
-
 =head1 TEST METHODS
 
-=over 4
-
-=item has_content($file, $regexp)
+=head2 has_content($file, $regexp)
 
 Test if the content of $file matches against $regexp.
 
-=item has_dir($path)
+=head2 has_dir($path)
 
 Test if $path is present and is a directory.
 
-=item has_file($file)
+=head2 has_file($file)
 
 Test if $file is present.
 
-=item has_package($package, $version)
+=head2 has_package($package, $version)
 
 Test if $package is installed, optionally at $version.
 
-=item has_service_running($service)
+=head2 has_service_running($service)
 
 Test if $service is running.
 
-=item has_service_stopped($service)
+=head2 has_service_stopped($service)
 
 Test if $service is stopped.
 
-=item has_stat($file, $stat)
+=head2 has_stat($file, $stat)
 
 Test if $file has properties described in hash reference $stat. List of supported checks:
 
@@ -247,8 +241,6 @@ Test if $file has properties described in hash reference $stat. List of supporte
 =item group
 
 =item owner
-
-=back
 
 =back
 

--- a/lib/Rex/Transaction.pm
+++ b/lib/Rex/Transaction.pm
@@ -29,8 +29,6 @@ With this module you can define transactions and rollback scenarios on failure.
 
 =head1 EXPORTED FUNCTIONS
 
-=over 4
-
 =cut
 
 package Rex::Transaction;
@@ -51,7 +49,7 @@ use Data::Dumper;
 
 @EXPORT = qw(transaction on_rollback);
 
-=item transaction($codeRef)
+=head2 transaction($codeRef)
 
 Start a transaction for $codeRef. If $codeRef dies it will rollback the transaction.
 
@@ -110,7 +108,7 @@ sub transaction(&) {
 
 }
 
-=item on_rollback($codeRef)
+=head2 on_rollback($codeRef)
 
 This code will be executed if one step in the transaction fails.
 
@@ -129,9 +127,5 @@ sub on_rollback(&) {
     }
   );
 }
-
-=back
-
-=cut
 
 1;


### PR DESCRIPTION
- For all instances of (R)?ex class methods and exported DSL functions, convert the POD of those items to use the `=head2` directive, not the `=item` directive, so the methods/functions are show in the POD's index (at the top of the page)

For reference, the script I used is here:

https://github.com/cpanxaoc/rex-misc/blob/master/convert_item_to_head2.pl

And output from the script is here:

https://gist.github.com/cpanxaoc/24d94a0bb1df2e525555