### PR TITLE
Fix auth test when REX_USER env is present

### DIFF
--- a/t/0.31.t
+++ b/t/0.31.t
@@ -5,6 +5,8 @@ use Test::More tests => 139;
 
 use Rex -feature => '0.31';
 
+delete $ENV{REX_USER};
+
 user("root3");
 password("pass3");
 private_key("priv.key3");

--- a/t/auth.t
+++ b/t/auth.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 44;
+use Test::More tests => 48;
 
 use Rex::Commands;
 use Rex::Group;
@@ -13,6 +13,8 @@ use Rex::Group;
 
 group( "srvgr1", "srv1" );
 group( "srvgr2", "srv2", "srv3" );
+
+delete $ENV{REX_USER};
 
 user("root1");
 password("pass1");
@@ -152,4 +154,23 @@ is( $auth->{user},        "baruser" );
 is( $auth->{password},    "barpass" );
 is( $auth->{private_key}, "testa4.priv" );
 is( $auth->{public_key},  "testa4.pub" );
+
+$ENV{REX_USER} = "root5";
+
+user("toor5");
+password("pass5");
+private_key("testa5.priv");
+public_key("testa5.pub");
+
+task(
+  "testa5",
+  sub {
+  }
+);
+
+$auth = Rex::TaskList->create()->get_task("testa5")->{auth};
+is( $auth->{user},        "root5" );
+is( $auth->{password},    "pass5" );
+is( $auth->{private_key}, "testa5.priv" );
+is( $auth->{public_key},  "testa5.pub" );
 

--- a/t/commands.t
+++ b/t/commands.t
@@ -5,6 +5,8 @@ use Test::More tests => 18;
 
 use Rex::Commands;
 
+delete $ENV{REX_USER};
+
 user("test");
 is( Rex::Config->get_user, "test", "setting user" );
 

--- a/t/group.t
+++ b/t/group.t
@@ -5,6 +5,8 @@ use Test::More tests => 95;
 
 use Rex -feature => '0.31';
 
+delete $ENV{REX_USER};
+
 user("root3");
 password("pass3");
 private_key("priv.key3");

--- a/t/ini.t
+++ b/t/ini.t
@@ -56,6 +56,8 @@ SKIP: {
   ok( grep { $_ eq "memcache01" } @{ $groups{memcache} }, "got memcache01" );
   ok( grep { $_ eq "memcache02" } @{ $groups{memcache} }, "got memcache02" );
 
+  delete $ENV{REX_USER};
+
   user("krimdomu");
   password("foo");
   pass_auth();


### PR DESCRIPTION
Guys, please review.

This patch adds new tests which checks if REX_USER environment variable correctly overwrites user from Rexfile. And fixes other auth test by deleteing REX_USER environment variable before user being set.