### PR TITLE
Reuse VM name as image filename when importing

### DIFF
--- a/lib/Rex/Virtualization/LibVirt/import.pm
+++ b/lib/Rex/Virtualization/LibVirt/import.pm
@@ -34,8 +34,9 @@ sub execute {
   my $cwd = i_run "pwd";
   chomp $cwd;
 
-  my $dir  = dirname $opt{file};
-  my $file = "storage/" . basename $opt{file};
+  my $dir = dirname $opt{file};
+  my ( undef, undef, $suffix ) = fileparse( $opt{file}, qr{\.[^.]*} );
+  my $file = "storage/" . $dom . $suffix;
   mkdir "./storage";
 
   my $format = "qcow2";


### PR DESCRIPTION
This helps identifying images under `./storage` directory, and also enables Rex to use the same base image from `./tmp` for different VMs.