### PR TITLE
Filter changelogger output

### DIFF
--- a/misc/changelogger.sh
+++ b/misc/changelogger.sh
@@ -14,7 +14,13 @@ firstline="$date $release_manager <$email> ($version)"
 git checkout $changelog
 
 echo $firstline > $tmp_file
-git log --format='  * %s - %an' $lasttag..HEAD >> $tmp_file
+git log --format='  * %s - %an' $lasttag..HEAD \
+    | grep -Piv 'Merge pull request' \
+    | grep -Piv 'perltidy' \
+    | grep -Piv 'Update list of contributors' \
+    | grep -Piv 'version bump' \
+    | grep -Piv 'updated? (changelog|version)' \
+    >> $tmp_file
 echo >> $tmp_file
 cat $changelog >> $tmp_file
 mv $tmp_file $changelog


### PR DESCRIPTION
@krimdomu: this is a last minute PR for 1.3.0. Should not change any Rex behaviour, but generates a more precise ChangeLog, by filtering common commit messages out that we would cleanup by hand anyway.