### PR TITLE
Don't recreate connection when executing rethink_connection.

### DIFF
--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -385,7 +385,6 @@ sub modify {
 sub rethink_connection {
   my ($self) = @_;
   delete $self->{connection};
-  $self->connection;
 }
 
 =head2 user


### PR DESCRIPTION
We need to create a task object's connection as late as possible, so
that everything is setup that it relies on. When modifying one of a tasks
hooks, it would run rethink_connection which in turn would re-create a
local connection before it knew it was supposed to be an ssh connection.

This should fix issue #694 