### PR TITLE
Added key_file method to pkg/Debian and added to pod for Pkg about keys

### DIFF
--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -646,10 +646,15 @@ For Debian: If you have no source repository, or if you don't want to add it, ju
  task "add-repo", "server1", "server2", sub {
    repository "add" => "repository-name",
       url      => "http://rex.linux-files.org/debian/squeeze",
+      key_url  => "http://rex.linux-files.org/DPKG-GPG-KEY-REXIFY-REPO"
       distro    => "squeeze",
       repository => "rex",
       source    => 1;
  };
+
+To specify a key from a file use key_file => '/tmp/mykeyfile'.
+
+To use a keyserver use key_server and key_id.
 
 For ALT Linux: If repository is unsigned, just remove the I<sign_key> parameter.
 

--- a/lib/Rex/Pkg/Debian.pm
+++ b/lib/Rex/Pkg/Debian.pm
@@ -112,6 +112,10 @@ sub add_repository {
     i_run "wget -O - " . $data{"key_url"} . " | apt-key add -";
   }
 
+  if ( exists $data{"key_file"} ) {
+    i_run "apt-key add $data{'key_file'} ";
+  }  
+
   if ( exists $data{"key_id"} && $data{"key_server"} ) {
     i_run "apt-key adv --keyserver "
       . $data{"key_server"}


### PR DESCRIPTION
The Pkg :: repository documentation made no mention of how to import the signing keys, I had to read the Debian submodule to figure it out. I also had to add a key from a file and wget doesn't accept the file:// resource type, so I added a method for file (the other option I considered was to switch from wget to curl). 