### PR TITLE
Recognize LinuxMint as a Debian clone (close #506)

### DIFF
--- a/lib/Rex/Commands/Gather.pm
+++ b/lib/Rex/Commands/Gather.pm
@@ -334,7 +334,7 @@ sub is_mageia {
 sub is_debian {
   my $os = @_ ? shift : get_operating_system();
 
-  my @debian_clones = ( "Debian", "Ubuntu" );
+  my @debian_clones = ( "Debian", "Ubuntu", "LinuxMint" );
 
   if ( grep { /$os/i } @debian_clones ) {
     return 1;

--- a/lib/Rex/Pkg.pm
+++ b/lib/Rex/Pkg.pm
@@ -41,6 +41,10 @@ sub get {
     $host->{"operatingsystem"} = "Redhat";
   }
 
+  if ( is_debian() ) {
+    $host->{"operatingsystem"} = "Debian";
+  }
+
   my $class = "Rex::Pkg::" . $host->{"operatingsystem"};
 
   my $provider;

--- a/lib/Rex/Service.pm
+++ b/lib/Rex/Service.pm
@@ -59,8 +59,11 @@ sub get {
   }
   elsif ( is_debian($operatingsystem) && $can_run_systemctl ) {
 
-    # this also counts for Ubuntu
+    # this also counts for Ubuntu and LinuxMint
     $class = "Rex::Service::Debian::systemd";
+  }
+  elsif ( is_debian($operatingsystem) ) {
+    $class = "Rex::Service::Debian";
   }
 
   my $provider_for = Rex::Config->get("service_provider") || {};


### PR DESCRIPTION
@JJ: this patch let's Rex recognize Linux Mint as a Debian clone (which internally is the same as an Ubuntu clone as of this moment). Unfortunately we don't have a Linux Mint KVM image yet to test against, but it should do the trick. Can you test this branch before we merge it, please?