### PR TITLE
Detect services that are not already on runlevels

### DIFF
--- a/lib/Rex/Service/Gentoo.pm
+++ b/lib/Rex/Service/Gentoo.pm
@@ -33,7 +33,7 @@ sub new {
     ensure_stop    => 'rc-update del %s',
     ensure_start   => 'rc-update add %s',
     action         => '/etc/init.d/%s %s',
-    service_exists => 'rc-config list | grep "\s%s\s"',
+    service_exists => 'rc-config list | awk \'!/^(Available i|I)nit scripts/ && $1 ~ /^%s$/{print$1}\'',
   };
 
   return $self;


### PR DESCRIPTION
Services that are not enabled in a runlevel are terminated with a
newline in `rc-config list`. This newline does not match the grep
pattern "\s" and Rex reports that the service does not exist.

Make service_exists look for word breaks "\b". This includes spaces and
newlines.

	$ rc-config list | grep "\sepmd\s"
	$ rc-config list | grep "\bepmd\b"
	  epmd
	$ rc-config list | grep "\bepmd\b" | xxd
	0000000: 2020 6570 6d64 0a                          epmd.
	$ rc-config list | grep "\budev\b" | xxd
	0000000: 2020 7564 6576 2020 2020 2020 2020 2020    udev
	0000010: 2020 2020 2020 2020 2020 2020 7379 7369    sysi
	0000020: 6e69 740a                                  nit.