### PR TITLE
Task chaining

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -562,10 +562,11 @@ CHECK_OVERWRITE: {
     }
 
     if ( defined $ARGV[0] ) {
+      my @tasks;
+
       for my $task (@ARGV) {
         if ( Rex::TaskList->create()->is_task($task) ) {
-          Rex::Logger::debug("Running task: $task");
-          Rex::TaskList->run($task);
+          push @tasks, $task;
         }
         elsif ( $task =~ m/^\-\-/ || $task =~ m/=/ ) {
 
@@ -578,6 +579,9 @@ CHECK_OVERWRITE: {
           );
         }
       }
+
+     #Rex::Logger::debug("Running task: $task");
+      Rex::TaskList->run(\@tasks);
     }
   };
 

--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -748,10 +748,11 @@ sub run {
     # this is a method call
     # so run the task
 
-    my $in_transaction = $options{in_transaction};
+    my $in_transaction    = $options{in_transaction};
+    my $cached_connection = $options{cached_connection};
 
     $self->run_hook( \$server, "before" );
-    $self->connect($server);
+    $self->connect($server) unless $cached_connection;
 
     my $start_time = time;
 
@@ -813,7 +814,7 @@ sub run {
 
     Rex::get_current_connection()->{reporter}->write_report();
 
-    $self->disconnect($server) unless ($in_transaction);
+    $self->disconnect($server) unless $in_transaction || $cached_connection;
     $self->run_hook( \$server, "after" );
 
     return $ret;

--- a/lib/Rex/TaskList.pm
+++ b/lib/Rex/TaskList.pm
@@ -50,16 +50,18 @@ sub create {
 }
 
 sub run {
-  my ( $class, $task_name ) = @_;
-  my $task_object = $class->create()->get_task($task_name);
+  my ( $class, $task_names ) = @_;
 
-  for my $code ( @{ $task_object->{before_task_start} } ) {
-    $code->($task_object);
+  my @tasks;
+  push @tasks, $class->create()->get_task($_) for @$task_names;
+
+  for my $task (@tasks) {
+    $_->($task) for @{ $task->{before_task_start} };
   }
 
-  $class->create()->run($task_name);
+  $class->create()->run($task_names);
 
-  for my $code ( @{ $task_object->{after_task_finished} } ) {
-    $code->($task_object);
+  for my $task (@tasks) {
+    $_->($task) for @{ $task->{after_task_finished} };
   }
 }

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -311,12 +311,15 @@ sub run {
         $run_task->connect($server) if !$connected;
         $connected = 1;
 
-        $run_task->run(
-          $server,
-          in_transaction    => $self->{IN_TRANSACTION},
-          params            => $option{params},
-          cached_connection => 1,
-        );
+        my $success = eval {
+          $run_task->run(
+            $server,
+            in_transaction    => $self->{IN_TRANSACTION},
+            params            => $option{params},
+            cached_connection => 1,
+          );
+        };
+        last if $@ || !$success;
       }
 
       Rex::Logger::debug("Destroying all cached os information");


### PR DESCRIPTION
# The present
If you issue a command like `rex -G group task1 task2 task3`, Rex will:

 1. Run task1 on all servers, 
 2. Run task2 on all servers,
 2. Run task3 on all servers.  

# The desired future
At $work, we would prefer to see:
 1. Connect to server1 and run task1 && task2 && task3,
 2. Connect to server2 and run task1 && task2 && task3,
 2. Connect to server3 and run task1 && task2 && task3,
 2. etc

The '&&' signifies that task2 won't happen unless task1 is successful.  Success is is determined first by exit status and second by the return value of the task.

# Why this future is desireable

1.  Its quite a bit faster.  The current solution can be slow if you are deploying to lots of servers because it needs to re-connect and re-authenticate and it adds up.  This pr reuses the connection for each task.  

2. To minimize time between steps.  If I do something like change how data is stored in memcache, I want to restart the web server right away after that.  I could build a custom task every time, but there are a large number of possible permutations and task chaining is really a flexible solution.

3. It is often unsafe to run subsequent tasks if the first one fails.

This pr implements these ideas.  I'm happy to improve this pr.  Its admittedly a little rough around the edges, but I wanted to get some review/discussion of this idea, before going farther.