### PR TITLE
Make "ensure" work properly on FreeBSD by deleting "\n" when calling …

### DIFF
--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -49,7 +49,8 @@ sub ensure {
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
     $self->start( $service, $options );
-    append_if_no_such_line "/etc/rc.conf", "${service}_enable=\"YES\"\n";
+    append_if_no_such_line "/etc/rc.conf",
+      line => "${service}_enable=\"YES\"";
   }
 
   return 1;


### PR DESCRIPTION
A small change for FreeBSD. It makes "ensure" work. Before that it couldn't recognize that service is already added to /etc/rc.conf.

Looks like the same fix should be applied on OpenBSD and NetBSD.