### PR TITLE
Make "ensure" work properly on FreeBSD

### DIFF
--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -49,9 +49,9 @@ sub ensure {
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
     $self->start( $service, $options );
-    append_if_no_such_line "/etc/rc.conf",
+    append_or_amend_line "/etc/rc.conf",
       line => "${service}_enable=\"YES\"",
-      regexp => qr/^\s*${service}_enable="?[Yy][Ee][Ss]"?/;
+      regexp => qr/^\s*${service}_enable="?([Yy][Ee][Ss]|[Nn][Oo])"?/;
   }
 
   return 1;

--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -26,12 +26,12 @@ sub new {
   bless( $self, $proto );
 
   $self->{commands} = {
-    start   => '/usr/local/etc/rc.d/%s onestart',
-    restart => '/usr/local/etc/rc.d/%s onerestart',
-    stop    => '/usr/local/etc/rc.d/%s onestop',
-    reload  => '/usr/local/etc/rc.d/%s onereload',
-    status  => '/usr/local/etc/rc.d/%s onestatus',
-    action  => '/usr/local/etc/rc.d/%s %s',
+    start   => '/usr/sbin/service %s onestart',
+    restart => '/usr/sbin/service %s onerestart',
+    stop    => '/usr/sbin/service %s onestop',
+    reload  => '/usr/sbin/service %s onereload',
+    status  => '/usr/sbin/service %s onestatus',
+    action  => '/usr/sbin/service %s %s',
   };
 
   return $self;

--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -44,11 +44,19 @@ sub ensure {
 
   if ( $what =~ /^stop/ ) {
     $self->stop( $service, $options );
+    file "/etc/rc.conf.d/${service}",
+      ensure => "absent";
+    delete_lines_matching "/etc/rc.conf.local",
+      matching => qr/^\s*${service}_enable="?((?i)YES)"?/;
     delete_lines_matching "/etc/rc.conf",
       matching => qr/^\s*${service}_enable="?((?i)YES)"?/;
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
     $self->start( $service, $options );
+    file "/etc/rc.conf.d/${service}",
+      ensure => "absent";
+    delete_lines_matching "/etc/rc.conf.local",
+      matching => qr/^\s*${service}_enable="?((?i)YES|NO)"?/;
     append_or_amend_line "/etc/rc.conf",
       line => "${service}_enable=\"YES\"",
       regexp => qr/^\s*${service}_enable="?((?i)YES|NO)"?/;

--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -45,11 +45,13 @@ sub ensure {
   if ( $what =~ /^stop/ ) {
     $self->stop( $service, $options );
     delete_lines_matching "/etc/rc.conf",
-      matching => qr/${service}_enable="YES"/;
+      matching => qr/${service}_enable="?[Yy][Ee][Ss]"?/;
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
     $self->start( $service, $options );
-    append_if_no_such_line "/etc/rc.conf", "${service}_enable=\"YES\"\n";
+    append_if_no_such_line "/etc/rc.conf",
+      line => "${service}_enable=\"YES\"",
+      regexp => qr/^\s*${service}_enable="?[Yy][Ee][Ss]"?/;
   }
 
   return 1;

--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -45,13 +45,13 @@ sub ensure {
   if ( $what =~ /^stop/ ) {
     $self->stop( $service, $options );
     delete_lines_matching "/etc/rc.conf",
-      matching => qr/${service}_enable="?[Yy][Ee][Ss]"?/;
+      matching => qr/^\s*${service}_enable="?((?i)YES)"?/;
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
     $self->start( $service, $options );
     append_or_amend_line "/etc/rc.conf",
       line => "${service}_enable=\"YES\"",
-      regexp => qr/^\s*${service}_enable="?([Yy][Ee][Ss]|[Nn][Oo])"?/;
+      regexp => qr/^\s*${service}_enable="?((?i)YES|NO)"?/;
   }
 
   return 1;


### PR DESCRIPTION
1. A small change for FreeBSD, that makes "ensure" work properly.
Try to make it smart and keep simple as possible.

2. Make (R)?ex work with FreeBSD base system services too.