### PR TITLE
Add 'print => boolean' option to 'run' command for printing continuously

### DIFF
--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -99,6 +99,11 @@ Supported options are:
   creates       => $file_to_create
     tries to create $file_to_create upon execution
     skips execution if the file already exists
+  print           => TRUE
+    Automatically prints using Rex::Logger::info. Used for printing lines from
+    long running processes that has output during the run. The external script
+    must not buffer output if continuous printing is wanted. In a Perl script
+    this can be achieved by setting $|=1.
 
 Examples:
 
@@ -136,7 +141,12 @@ If you want to set custom environment variables you can do it like this:
 If you want to end the command upon receiving a certain output:
  run "my_command",
    end_if_matched => qr/PATTERN/;
-   
+
+If you want to run an external script and print output continuously:
+ run "description",
+   command  => "perl myscript.pl",
+   print    => TRUE;
+
 =cut
 
 our $LAST_OUTPUT; # this variable stores the last output of a run.

--- a/lib/Rex/Helper/SSH2.pm
+++ b/lib/Rex/Helper/SSH2.pm
@@ -62,6 +62,10 @@ sub net_ssh2_exec {
 
       for my $line (@lines) {
         $line =~ s/[\r\n]//gms;
+        if ( $option->{print} ) {
+          chomp(my $print = $line);
+          Rex::Logger::info($print);
+        }
         $line .= "\n";
         $base->execute_line_based_operation( $line, $option ) && goto END_READ;
       }
@@ -81,6 +85,10 @@ sub net_ssh2_exec {
 
     for my $line (@lines_err) {
       $line =~ s/[\r\n]//gms;
+      if ( $option->{print} ) {
+        chomp(my $print = $line);
+        Rex::Logger::info($print, 'error');
+      }
       $line .= "\n";
       $base->execute_line_based_operation( $line, $option ) && goto END_READ;
     }

--- a/lib/Rex/Interface/Exec/Local.pm
+++ b/lib/Rex/Interface/Exec/Local.pm
@@ -95,12 +95,20 @@ sub exec {
     $pid = open3( $writer, $reader, $error, $cmd );
 
     while ( my $output = <$reader> ) {
+      if ( $option->{print} ) {
+        chomp(my $print = $output);
+        Rex::Logger::info($print);
+      }
       $out .= $output;
       $self->execute_line_based_operation( $output, $option )
         && goto END_OPEN3;
     }
 
     while ( my $errout = <$error> ) {
+      if ( $option->{print} ) {
+        chomp(my $print = $errout);
+        Rex::Logger::info($print, 'error');
+      }
       $err .= $errout;
       $self->execute_line_based_operation( $errout, $option )
         && goto END_OPEN3;
@@ -111,6 +119,10 @@ sub exec {
   else {
     $pid = open( my $fh, "$cmd 2>&1 |" ) or die($!);
     while (<$fh>) {
+      if ( $option->{print} ) {
+        chomp(my $print = $_);
+        Rex::Logger::info($print);
+      }
       $out .= $_;
       $self->execute_line_based_operation( $_, $option )
         && do { kill( 'KILL', $pid ); last };

--- a/lib/Rex/Interface/Exec/OpenSSH.pm
+++ b/lib/Rex/Interface/Exec/OpenSSH.pm
@@ -37,6 +37,10 @@ sub _exec {
   ( undef, $out_fh, $err_fh, $pid ) = $ssh->open3( { tty => $tty }, $exec );
   while ( my $line = <$out_fh> ) {
     $line =~ s/(\r?\n)$/\n/;
+    if ( $option->{print} ) {
+      chomp(my $print = $line);
+      Rex::Logger::info($print);
+    }
     $out .= $line;
     $self->execute_line_based_operation( $line, $option )
       && do { kill( 'KILL', $pid ); goto END_OPEN };
@@ -44,6 +48,10 @@ sub _exec {
   }
   while ( my $line = <$err_fh> ) {
     $line =~ s/(\r?\n)$/\n/;
+    if ( $option->{print} ) {
+      chomp(my $print = $line);
+      Rex::Logger::info($print, 'error');
+    }
     $err .= $line;
     $self->execute_line_based_operation( $line, $option )
       && do { kill( 'KILL', $pid ); goto END_OPEN };

--- a/lib/Rex/Logger.pm
+++ b/lib/Rex/Logger.pm
@@ -17,7 +17,7 @@ This module is the logging module. You can define custom logformats.
  $Rex::Logger::format = '[%D] %s';
  # will output something like
  # [2012-04-12 18:35:12] Installing package vim
-   
+
  $Rex::Logger::format = '%h - %D - %s';
  # will output something like
  # srv001 - 2012-04-12 18:35:12 - Installing package vim


### PR DESCRIPTION
This patch makes it possible for printing the output of an external command continuously while it is running. It only works for local connections since the implementation of that and SSH etc are separate and has to be solved separately.

Using the functionality in this patch it is possible to call external scripts from Rex when using it in Jenkins jobs and similar situations where you want the output to be printed to see the progress of long running tasks.
