### PR TITLE
Do not silently fail on update_system errors

### DIFF
--- a/lib/Rex/Pkg/Base.pm
+++ b/lib/Rex/Pkg/Base.pm
@@ -94,7 +94,17 @@ sub update_system {
   }
 
   my $cmd = $self->{commands}->{update_system};
-  i_run $cmd;
+  my $f = i_run $cmd;
+
+  unless ( $? == 0 ) {
+    Rex::Logger::info( "Error updating system.", "warn" );
+    Rex::Logger::debug($f);
+    die("Error updating system");
+  }
+
+  Rex::Logger::debug("System successfully updated.");
+
+  return 1;
 }
 
 sub remove {


### PR DESCRIPTION
The ```update_system``` command silently fails in the event of an error. Most of the other Pkg commands correctly report errors; this patch ensures that ```update_system``` does the same.