### PR TITLE
Improve NetBSD support

### DIFF
--- a/lib/Rex/Service/NetBSD.pm
+++ b/lib/Rex/Service/NetBSD.pm
@@ -44,18 +44,18 @@ sub ensure {
 
   if ( $what =~ /^stop/ ) {
     $self->stop( $service, $options );
-    delete_lines_matching "/etc/rc.conf",
-      matching => qr/^\s*${service}="?((?i)YES)"?/;
     file "/etc/rc.conf.d/${service}",
       ensure => "absent";
+    delete_lines_matching "/etc/rc.conf",
+      matching => qr/^\s*${service}="?((?i)YES)"?/;
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
     $self->start( $service, $options );
+    file "/etc/rc.conf.d/${service}",
+      ensure => "absent";
     append_or_amend_line "/etc/rc.conf",
       line => "${service}=YES",
       regexp => qr/^\s*${service}="?((?i)YES|NO)"?/;
-    file "/etc/rc.conf.d/${service}",
-      ensure => "absent";
   }
 
   return 1;

--- a/lib/Rex/Service/NetBSD.pm
+++ b/lib/Rex/Service/NetBSD.pm
@@ -44,11 +44,18 @@ sub ensure {
 
   if ( $what =~ /^stop/ ) {
     $self->stop( $service, $options );
-    delete_lines_matching "/etc/rc.conf", matching => qr/${service}=YES/;
+    delete_lines_matching "/etc/rc.conf",
+      matching => qr/^\s*${service}="?((?i)YES)"?/;
+    file "/etc/rc.conf.d/${service}",
+      ensure => "absent";
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
     $self->start( $service, $options );
-    append_if_no_such_line "/etc/rc.conf", "${service}=YES\n";
+    append_or_amend_line "/etc/rc.conf",
+      line => "${service}=YES",
+      regexp => qr/^\s*${service}="?((?i)YES|NO)"?/;
+    file "/etc/rc.conf.d/${service}",
+      ensure => "absent";
   }
 
   return 1;


### PR DESCRIPTION
1. Use the same way to enable service in NetBSD like recently proposed for FreeBSD.

2. Enable/disable services in NetBSD carefully.
In NetBSD we also should keep in mind /etc/rc.conf.d/${service} file. It's a per service config file and its content has higher precedence than /etc/rc.conf settings.