### PR TITLE
Fixes #760 timeout for OpenSSH

### DIFF
--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -79,6 +79,7 @@ sub connect {
   Rex::Logger::debug( Dumper( \%ssh_opts ) );
 
   $ssh_opts{LogLevel} ||= "QUIET";
+  $ssh_opts{ConnectTimeout} = $timeout;
 
   my %net_openssh_constructor_options = (
     exists $ssh_opts{initialize_options} ? $ssh_opts{initialize_options} : () );


### PR DESCRIPTION
I have verified that this works when setting 
```perl
timeout $int;
``` 
in Rexfile.