### PR TITLE
force apt-listchanges to not run

### DIFF
--- a/lib/Rex/Pkg/Debian.pm
+++ b/lib/Rex/Pkg/Debian.pm
@@ -28,11 +28,11 @@ sub new {
 
   $self->{commands} = {
     install =>
-      'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold -y install %s',
+      'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold -y install %s',
     install_version =>
-      'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold -y install %s=%s',
+      'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold -y install %s=%s',
     update_system =>
-      'APT_LISTCHANGES_FRONTEND=text DEBIAN_FRONTEND=noninteractive apt-get -y -qq upgrade',
+      'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y -qq upgrade',
     remove            => 'apt-get -y remove %s',
     purge             => 'dpkg --purge %s',
     update_package_db => 'apt-get -y update',


### PR DESCRIPTION
depending on user configuration, it might ask for confirmation and thus
require interactivity. Since it can't tell the difference between apt
invoked by a user, and apt invoked by rex, and since we can't rely on
there being a speciel profile just for rex that we can use, just disable
apt-listchanges completely.