### PR TITLE
Fail early on unsupported Windows versions (fix #751)

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,12 @@ author = Jan Gehring <jfried@rexify.org>
 license = Apache_2_0
 copyright_holder = Jan Gehring
 
-[@Basic]
+[@Filter]
+-bundle = @Basic
+-remove = MakeMaker
+
+[MakeMaker::Awesome]
+header = die 'Unsupported OS' if ( $^O eq 'MSWin32' && scalar((Win32::GetOSVersion())[1]) < 6 );
 
 [ManifestSkip]
 [Prereqs]

--- a/dist.ini
+++ b/dist.ini
@@ -9,28 +9,15 @@ copyright_holder = Jan Gehring
 -bundle = @Basic
 -remove = MakeMaker
 
+[AutoPrereqs]
+
 [MakeMaker::Awesome]
 header = die 'Unsupported OS' if ( $^O eq 'MSWin32' && scalar((Win32::GetOSVersion())[1]) < 6 );
 
 [ManifestSkip]
-[Prereqs]
-perl = 5.008008
-[OSPrereqs / !~MSWin]
-IO::Pty = 0
-Net::OpenSSH = 0
-Net::SFTP::Foreign = 0
-[OSPrereqs / ~MSWin]
-Net::SSH2 = 0
-[Prereqs / BuildRequires]
-Test::Pod = 0
-[AutoPrereqs]
-[PodSyntaxTests]
-; [PodCoverageTests]
-[Test::MinimumVersion]
-max_target_perl = 5.8.8
-[Test::Perl::Critic]
-critic_config = ../../.perlcriticrc
-[OurPkgVersion]
+
+[MetaProvides::Package]
+
 [MetaResources]
 homepage        = http://www.rexify.org
 bugtracker.web  = https://github.com/RexOps/Rex/issues
@@ -39,4 +26,29 @@ repository.web  = https://github.com/RexOps/Rex
 repository.type = git
 x_twitter       = https://twitter.com/RexOps
 x_IRC           = irc://irc.freenode.net/rex
-[MetaProvides::Package]
+
+[OSPrereqs / !~MSWin]
+IO::Pty = 0
+Net::OpenSSH = 0
+Net::SFTP::Foreign = 0
+
+[OSPrereqs / ~MSWin]
+Net::SSH2 = 0
+
+[OurPkgVersion]
+
+; [PodCoverageTests]
+
+[PodSyntaxTests]
+
+[Prereqs]
+perl = 5.008008
+
+[Prereqs / BuildRequires]
+Test::Pod = 0
+
+[Test::MinimumVersion]
+max_target_perl = 5.8.8
+
+[Test::Perl::Critic]
+critic_config = ../../.perlcriticrc


### PR DESCRIPTION
This should make it possible to fail early in the installation process on unsupported Windows versions (all that is discontinued already, basically everything older than Vista, or in other words the versions which doesn't have the `where` command needed for `can_run` functionality).

Technically it might be possible to support those, but we believe there's not much value in doing so for an abandoned OS version. Additionally, and *IMHO* rex as a tool should not encourage their usage.

That being said, if you feel like it, patches are welcome to make rex work on old OSes, and we probably would help hosting code and/or documentation for those who are adventurous enough to play with unsupported stuff.

This is also expected to decrease the amount of false positive "broken" test results from CPAN Testers.