### PR TITLE
More fixes for ensure option for FreeBSD services

### DIFF
--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -43,35 +43,34 @@ sub ensure {
 
   my $what = $options->{ensure};
 
-  my $rcout = i_run "/usr/sbin/service $service rcvar";
-
-  my ( $rcvar, $rcvalue );
-  unless ( ( $rcvar, $rcvalue ) = $rcout =~ m/^(\S+)=(\S+)$/m ) {
-    Rex::Logger::info(
-      "Service $service can't be started: not installed or no such rc scipt.",
-      "error" );
+  my $rccom = "/usr/sbin/service $service rcvar";
+  my $rcout = i_run $rccom;
+  if ( $? != 0 ) {
+    Rex::Logger::info( "Running `$rccom` failed", "error" );
     return 0;
   }
-  $rcvar = $rcvar =~ s/^\$//r;
 
-  my $status = i_run "/usr/sbin/service $service onestatus";
+  my ( $rcvar, $rcvalue ) = $rcout =~ m/^\$?(\w+)="?(\w+)"?$/m;
+  unless ($rcvar) {
+    Rex::Logger::info( "Error getting service name.", "error" );
+    return 0;
+  }
 
   if ( $what =~ /^stop/ ) {
-    if ( $rcvalue =~ m/^"?YES"?$/i ) {
+    $self->stop( $service, $options );
+    if ( $rcvalue =~ m/^YES$/i ) {
       file "/etc/rc.conf.d/${service}", ensure => "absent";
       if ( is_file("/etc/rc.conf.local") ) {
         delete_lines_matching "/etc/rc.conf.local",
-          matching => qr/^\s*${rcvar}=((?i)YES|"YES"|'YES')/;
+          matching => qr/^\s*${rcvar}=((?i)["']?YES["']?)/;
       }
       delete_lines_matching "/etc/rc.conf",
-        matching => qr/^\s*${rcvar}=((?i)YES|"YES"|'YES')/;
-    }
-    if ( $status =~ m/is running/ ) {
-      $self->stop( $service, $options );
+        matching => qr/^\s*${rcvar}=((?i)["']?YES["']?)/;
     }
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
-    unless ( $rcvalue =~ m/^"?YES"?$/i ) {
+    $self->start( $service, $options );
+    unless ( $rcvalue =~ m/^YES$/i ) {
       file "/etc/rc.conf.d/${service}", ensure => "absent";
       if ( is_file("/etc/rc.conf.local") ) {
         delete_lines_matching "/etc/rc.conf.local",
@@ -80,9 +79,6 @@ sub ensure {
       append_or_amend_line "/etc/rc.conf",
         line   => "${rcvar}=\"YES\"",
         regexp => qr/^\s*${rcvar}=/;
-    }
-    unless ( $status =~ m/is running/ ) {
-      $self->start( $service, $options );
     }
   }
 

--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -58,27 +58,29 @@ sub ensure {
 
   if ( $what =~ /^stop/ ) {
     $self->stop( $service, $options );
+    my $stop_regexp = qr/^\s*${rcvar}=((?i)["']?YES["']?)/;
     if ( $rcvalue =~ m/^YES$/i ) {
       file "/etc/rc.conf.d/${service}", ensure => "absent";
       if ( is_file("/etc/rc.conf.local") ) {
         delete_lines_matching "/etc/rc.conf.local",
-          matching => qr/^\s*${rcvar}=((?i)["']?YES["']?)/;
+          matching => $stop_regexp;
       }
       delete_lines_matching "/etc/rc.conf",
-        matching => qr/^\s*${rcvar}=((?i)["']?YES["']?)/;
+        matching => $stop_regexp;
     }
   }
   elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
     $self->start( $service, $options );
+    my $start_regexp = qr/^\s*${rcvar}=/;
     unless ( $rcvalue =~ m/^YES$/i ) {
       file "/etc/rc.conf.d/${service}", ensure => "absent";
       if ( is_file("/etc/rc.conf.local") ) {
         delete_lines_matching "/etc/rc.conf.local",
-          matching => qr/^\s*${rcvar}=/;
+          matching => $start_regexp;
       }
       append_or_amend_line "/etc/rc.conf",
         line   => "${rcvar}=\"YES\"",
-        regexp => qr/^\s*${rcvar}=/;
+        regexp => $start_regexp;
     }
   }
 

--- a/lib/Rex/Service/FreeBSD.pm
+++ b/lib/Rex/Service/FreeBSD.pm
@@ -81,7 +81,7 @@ sub ensure {
         line   => "${rcvar}=\"YES\"",
         regexp => qr/^\s*${rcvar}=/;
     }
-    if ( $status =~ m/is not running/ ) {
+    unless ( $status =~ m/is running/ ) {
       $self->start( $service, $options );
     }
   }


### PR DESCRIPTION
1. Service's rc_script name can differ from rcvar which is used to make service start from boot.
Extract rcvar from rc script.
2. As additional profit we can even complain about incorrect service name.
3. As another profit we can get current rcvar value ($rcvalue) and decide if we actually need to make our manipulations with rc.conf*.
4. Wrap /etc/rc.conf.local editing inside is_file to calm down warnings.
5. Get current service status (already running?) and do our stuff if it's really needed.
6. Edit regexp when we need to enable service in /etc/rc.conf* files. I. e. catch incorrect assignments like 'mysql_enable="bla"'.

perltidy is happy if you care =)