### PR TITLE
Template::NG fixes

### DIFF
--- a/lib/Rex/Template/NG.pm
+++ b/lib/Rex/Template/NG.pm
@@ -276,10 +276,14 @@ sub _parse {
     }
 
     # catch ' %>'
-    if ( $code_block
-      && ( $prev_char eq " " || $prev_char eq "\n" || $prev_char eq "-" )
+    if (
+      $code_block
+      && ( ( $code_block_output || $prev_char eq " " )
+        || $prev_char eq "\n"
+        || $prev_char eq "-" )
       && $curr_char eq "%"
-      && $next_char eq ">" )
+      && $next_char eq ">"
+      )
     {
       $code_block = 0;
 

--- a/lib/Rex/Template/NG.pm
+++ b/lib/Rex/Template/NG.pm
@@ -335,7 +335,7 @@ sub _parse {
       next;
     }
 
-    $parsed .= $curr_char;
+    $parsed .= $curr_char =~ m/[{}]/ ? "\\$curr_char" : $curr_char;
 
   }
 

--- a/t/template_ng.t
+++ b/t/template_ng.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 18;
+use Test::More tests => 19;
 use Rex::Template::NG;
 use Rex::Config;
 
@@ -10,6 +10,16 @@ my $t = Rex::Template::NG->new;
 my $content = 'one two three';
 
 is( $t->parse( $content, {} ), "one two three", "just text" );
+
+$content = '{
+1
+}';
+
+my $content_ok = '{
+1
+}';
+
+is( $t->parse( $content, {} ), $content_ok, "curly braces" );
 
 $content = 'Hello this is <%= $::name %>';
 is(
@@ -24,7 +34,7 @@ Logged in!
 Logged out!
 <% } %>';
 
-my $content_ok = "
+$content_ok = "
 Logged in!
 ";
 

--- a/t/template_ng.t
+++ b/t/template_ng.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 19;
+use Test::More tests => 20;
 use Rex::Template::NG;
 use Rex::Config;
 
@@ -26,6 +26,13 @@ is(
   $t->parse( $content, { name => "foo" } ),
   "Hello this is foo",
   "simple variable"
+);
+
+$content = 'Hello this is <%=$::name%>';
+is(
+  $t->parse( $content, { name => "bar" } ),
+  "Hello this is bar",
+  "simple variable - no spaces around tag"
 );
 
 $content = '<% if($::logged_in) { %>


### PR DESCRIPTION
- Fix code block output when there's no space before closing tag
- Escape curly braces in template content