### PR TITLE
Race condition in Rex::Shared::Var

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -277,14 +277,6 @@ FORCE_SERVER: {
       }
     }
 
-    if ( -f "vars.db" ) {
-      CORE::unlink("vars.db");
-    }
-
-    if ( -f "vars.db.lock" ) {
-      CORE::unlink("vars.db.lock");
-    }
-
     eval {
       my $env             = environment;
       my $ini_dir         = dirname($::rexfile);
@@ -601,15 +593,6 @@ CHECK_OVERWRITE: {
   Rex::global_sudo(0);
   Rex::Logger::debug("Removing lockfile") if ( !exists $opts{'F'} );
   CORE::unlink("$::rexfile.lock") if ( !exists $opts{'F'} );
-
-  # delete shared variable db
-  if ( -f "vars.db" ) {
-    CORE::unlink("vars.db");
-  }
-
-  if ( -f "vars.db.lock" ) {
-    CORE::unlink("vars.db.lock");
-  }
 
   select STDOUT;
 

--- a/lib/Rex/Shared/Var/Common.pm
+++ b/lib/Rex/Shared/Var/Common.pm
@@ -1,0 +1,62 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Shared::Var::Common;
+
+use strict;
+use warnings;
+
+require Exporter;
+use base qw/Exporter/;
+our @EXPORT_OK = qw/__lock __store __retrieve/;
+
+# VERSION
+
+use Fcntl qw(:DEFAULT :flock);
+use Storable;
+
+our $FILE      = "vars.db.$$";
+our $LOCK_FILE = "vars.db.lock.$$";
+our $PID       = $$;
+
+sub __lock {
+  sysopen( my $dblock, $LOCK_FILE, O_RDONLY | O_CREAT ) or die($!);
+  flock( $dblock, LOCK_EX ) or die($!);
+
+  my $ret = $_[0]->();
+
+  close($dblock);
+
+  return $ret;
+}
+
+sub __store {
+  my $ref = shift;
+  store( $ref, $FILE );
+}
+
+sub __retrieve {
+  return {} unless -f $FILE;
+  return retrieve($FILE);
+
+}
+
+sub END {
+    # $PID gets set when Rex starts.  This value remains the same after the
+    # process forks.  So $PID is always the pid of the master process.  $$
+    # however is always the pid of the current process.  This checks if we are
+    # in the master process or not and only removes the $FILE and $LOCK_FILE if
+    # we are in the master process.
+
+    # return if we exiting a child process
+    return unless $$ eq $Rex::Shared::Var::Common::PID;
+
+    # we are exiting the master process
+    unlink $FILE      if -f $FILE;
+    unlink $LOCK_FILE if -f $LOCK_FILE;
+}
+
+1;

--- a/t/shared.t
+++ b/t/shared.t
@@ -2,10 +2,10 @@ use strict;
 use warnings;
 
 BEGIN {
-  use Test::More tests => 8;
-
+  use Test::More tests => 9;
+  use Test::Deep;
+  use Time::HiRes;
   use Rex::Shared::Var;
-
   share(qw($scalar @array %hash));
 }
 
@@ -33,5 +33,27 @@ is( $hash{multi}->{key1},      "foo", "multidimension, key1" );
 is( $hash{multi}->{arr1}->[0], "bar", "multidimension, arr1 - key0" );
 is( $hash{multi}->{arr1}->[1], "baz", "multidimension, arr1 - key1" );
 
-unlink("vars.db");
-unlink("vars.db.lock");
+{
+    # Sleeping in a test is not ideal.  But can't replace Time::HiRes::usleep()
+    # with POSIX::pause() because kill doesn't send signals on win32. See
+    # 'perldoc -f kill', 'perldoc perlport' and
+    # https://github.com/RexOps/Rex/pull/774
+
+    @array = (0);
+    my @pids;
+
+    for my $i (0..5) {
+        my $pid = fork();
+        if ($pid == 0) {
+            # child
+            Time::HiRes::usleep 100_000; # .1 seconds
+            push @array, 1;
+            exit 0;
+        }
+        push @pids, $pid;
+    }
+
+    waitpid $_, 0 for @pids;
+
+    cmp_deeply \@array, [qw/0 1 1 1 1 1 1/], 'race condition avoided';
+}


### PR DESCRIPTION
`Rex::Shared::Var` is a tool for doing IPC (inter process communication).  It uses Storable to write data to a file in one process and read the data from the file in another.  This useful when you want to run tasks in parallel and fork children but need to communicate data between processes.  There are a couple problems with the current implementation:

## Shared lock instead of exclusive lock.

The main problem is it uses a shared lock for both reading and writing.  (See this [stackoverflow question](http://stackoverflow.com/questions/11837428/whats-the-difference-between-an-exclusive-lock-and-a-shared-lock) for more details).  This allows a race condition to occur between reading from the file and writing to the file which could cause a loss of data.  Currently `Rex::Shared::Var` is only used in `Rex::Fork::Task`.  I suspect the problem is likely become more visible if [this pr](https://github.com/RexOps/Rex/pull/697) is merged.

My first commit includes a a test which demonstrates this problem.  If you run `t/shared.t` several times in a row you will usually see the test fail.

The simplest solution is to use an exclusive lock to both read and write.  Processes will block until an exclusive lock becomes available.  

## If users run more than one instance of rex from the same directory data loss occurs

`Rex::Shared::Var` writes data to a file named `vars.db`.  All processes share this file.  For the most part thats a good thing -- the point is for children and parent to communicate after all.  But it becomes bad if you are running more than one instance of `rex -F` from the same directory.