### PR TITLE
Better error handling when loading the Rexfile

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -177,9 +177,7 @@ FORCE_SERVER: {
     Rex::Output->get( $opts{'o'} );
   }
 
-  # Load Rexfile before exec in order to suppport group exec
-  if ( -f $::rexfile ) {
-    Rex::Logger::debug("$::rexfile exists");
+    # handle lock file
     if ( $^O !~ m/^MSWin/ ) {
       if ( -f "$::rexfile.lock" && !exists $opts{'F'} ) {
         Rex::Logger::debug("Found $::rexfile.lock");
@@ -236,14 +234,6 @@ FORCE_SERVER: {
     if ($@) { print $@ . "\n"; exit 1; }
 
     load_rexfile($::rexfile);
-  }
-  else {
-    Rex::Logger::info( "No Rexfile found.", "warn" );
-    Rex::Logger::info(
-      "Please create a file named 'Rexfile' inside this directory,", "warn" );
-    Rex::Logger::info( "or specify the file you want to use with:", "warn" );
-    Rex::Logger::info( "   rex -f file_to_use task_to_run",         "warn" );
-  }
 
   #### check if some parameters should be overwritten from the command line
 CHECK_OVERWRITE: {
@@ -703,6 +693,14 @@ sub summarize {
 sub load_rexfile {
   my $rexfile = shift;
   Rex::Logger::debug("Loading $rexfile");
+
+  if (! -f $rexfile ) {
+    Rex::Logger::info( "No Rexfile found.", "warn" );
+    Rex::Logger::info( "Create a file named 'Rexfile' in this directory,", "warn" );
+    Rex::Logger::info( "or specify the file you want to use with:", "warn" );
+    Rex::Logger::info( "   rex -f file_to_use task_to_run",         "warn" );
+    return;
+  }
 
   # load Rexfile
   eval { require $rexfile };

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -220,20 +220,8 @@ FORCE_SERVER: {
       }
     }
 
-    eval {
-      my $env             = environment;
-      my $ini_dir         = dirname($::rexfile);
-      my $server_ini_file = "$ini_dir/server.$env.ini";
-      $server_ini_file = "$ini_dir/server.ini"
-        if !-f $server_ini_file;
-      if ( -f $server_ini_file && Rex::Group::Lookup::INI->is_loadable ) {
-        Rex::Group::Lookup::INI::groups_file($server_ini_file);
-      }
-    };
-
-    if ($@) { print $@ . "\n"; exit 1; }
-
-    load_rexfile($::rexfile);
+  load_server_ini_file($::rexfile);
+  load_rexfile($::rexfile);
 
   #### check if some parameters should be overwritten from the command line
 CHECK_OVERWRITE: {
@@ -688,6 +676,21 @@ sub summarize {
          ncmp( $a->{task}, $b->{task} )
       || ncmp( $a->{server}, $b->{server} )
     } @failures;
+}
+
+sub load_server_ini_file {
+  my $rexfile = shift;
+
+  # load server ini file
+  my $env             = environment;
+  my $ini_dir         = dirname($rexfile);
+  my $server_ini_file = "$ini_dir/server.$env.ini";
+  $server_ini_file = "$ini_dir/server.ini" unless -f $server_ini_file;
+
+  if (-f $server_ini_file && Rex::Group::Lookup::INI->is_loadable) {
+    Rex::Logger::debug("Loading $server_ini_file");
+    Rex::Group::Lookup::INI::groups_file($server_ini_file);
+  }
 }
 
 sub load_rexfile {

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -180,25 +180,6 @@ FORCE_SERVER: {
   # Load Rexfile before exec in order to suppport group exec
   if ( -f $::rexfile ) {
     Rex::Logger::debug("$::rexfile exists");
-
-    Rex::Logger::debug("Checking Rexfile Syntax...");
-
-    if ( !exists $ENV{PAR_TEMP} ) {
-
-      # don't check syntax under PAR
-
-      my $out =
-        qx{$^X -MRex::Commands -MRex::Commands::Run -MRex::Commands::Fs -MRex::Commands::Download -MRex::Commands::Upload -MRex::Commands::File -MRex::Commands::Gather -MRex::Commands::Kernel -MRex::Commands::Pkg -MRex::Commands::Service -MRex::Commands::Sysctl -MRex::Commands::Tail -MRex::Commands::Process -c $::rexfile 2>&1};
-      if ( $? > 0 ) {
-        print $out;
-      }
-
-      if ( $? != 0 ) {
-        exit 1;
-      }
-
-    }
-
     if ( $^O !~ m/^MSWin/ ) {
       if ( -f "$::rexfile.lock" && !exists $opts{'F'} ) {
         Rex::Logger::debug("Found $::rexfile.lock");
@@ -223,11 +204,8 @@ FORCE_SERVER: {
       close($f);
     }
     else {
-      Rex::Logger::debug("Running on windows. Disabled syntax checking.");
       Rex::Logger::debug("Running on windows. Disabled lock file support.");
     }
-
-    Rex::Logger::debug("Including/Parsing $::rexfile");
 
     Rex::Config->set_environment( $opts{"E"} ) if ( $opts{"E"} );
 
@@ -253,87 +231,11 @@ FORCE_SERVER: {
       if ( -f $server_ini_file && Rex::Group::Lookup::INI->is_loadable ) {
         Rex::Group::Lookup::INI::groups_file($server_ini_file);
       }
-      my $ok = do($::rexfile);
-
-      if ( !$ok ) {
-
-        # read rexfile
-        my $content = eval { local ( @ARGV, $/ ) = ($::rexfile); <>; };
-
-        # and try to evaluate it
-        my @rex_code = ("package Rex::Test::Rexfile::Syntax;");
-        if ( $content !~ m/use Rex \-.*;/ ) {
-          push @rex_code, "use Rex -base;";
-        }
-        push @rex_code, "my \$b=\$Rex::Commands::dont_register_tasks;";
-        push @rex_code, "\$Rex::Commands::dont_register_tasks = 1;";
-        push @rex_code, "our \$syntax_check = 1;";
-        push @rex_code, "$content";
-        push @rex_code, "\$Rex::Commands::dont_register_tasks = \$b;";
-        push @rex_code, "1;";
-
-        eval join( "\n", @rex_code );
-
-        if ($@) {
-          $ok = 0;
-        }
-        else {
-          Rex::Logger::debug(
-            "We can't load your Rexfile but the syntax seems to be correct.");
-          Rex::Logger::debug(
-            "This happens if the Rexfile doesn't return a true value.");
-          Rex::Logger::debug(
-            "Please append a '1;' at the very end of your Rexfile.");
-          $ok = 1;
-        }
-      }
-
-      Rex::Logger::debug("eval your Rexfile.");
-      if ( !$ok ) {
-        Rex::Logger::info(
-          "There seems to be an error on some of your required files. $@",
-          "error" );
-
-        if ( !exists $ENV{PAR_TEMP} ) {
-
-          my @dir = ( dirname($::rexfile) );
-          for my $d (@dir) {
-            opendir( my $dh, $d ) or die($!);
-            while ( my $entry = readdir($dh) ) {
-              if ( $entry =~ m/^\./ ) {
-                next;
-              }
-
-              if ( -d "$d/$entry" ) {
-                push( @dir, "$d/$entry" );
-                next;
-              }
-
-              if ( $entry =~ m/Rexfile/ || $entry =~ m/\.pm$/ ) {
-
-                # check files for syntax errors
-                my $check_out =
-                  qx{$^X -MRex::Commands -MRex::Commands::Run -MRex::Commands::Fs -MRex::Commands::Download -MRex::Commands::Upload -MRex::Commands::File -MRex::Commands::Gather -MRex::Commands::Kernel -MRex::Commands::Pkg -MRex::Commands::Service -MRex::Commands::Sysctl -MRex::Commands::Tail -MRex::Commands::Process -c $d/$entry 2>&1};
-                if ( $? > 0 ) {
-                  print "$d/$entry\n";
-                  print
-                    "--------------------------------------------------------------------------------\n";
-                  print $check_out;
-                  print "\n";
-                }
-              }
-            }
-            closedir($dh);
-          }
-
-        }
-
-        exit 1;
-      }
     };
 
     if ($@) { print $@ . "\n"; exit 1; }
 
+    load_rexfile($::rexfile);
   }
   else {
     Rex::Logger::info( "No Rexfile found.", "warn" );
@@ -796,6 +698,19 @@ sub summarize {
          ncmp( $a->{task}, $b->{task} )
       || ncmp( $a->{server}, $b->{server} )
     } @failures;
+}
+
+sub load_rexfile {
+  my $rexfile = shift;
+  Rex::Logger::debug("Loading $rexfile");
+
+  # load Rexfile
+  eval { require $rexfile };
+  if ($@) {
+    chomp $@;
+    Rex::Logger::info("Compile time errors:\n$@", 'error');
+    exit 1;
+  }
 }
 
 1;

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -179,20 +179,20 @@ FORCE_SERVER: {
 
   handle_lock_file($::rexfile);
 
-    Rex::Config->set_environment( $opts{"E"} ) if ( $opts{"E"} );
+  Rex::Config->set_environment( $opts{"E"} ) if ( $opts{"E"} );
 
-    if ( $opts{'g'} || $opts{'G'} ) {
+  if ( $opts{'g'} || $opts{'G'} ) {
 
-      #$::FORCE_SERVER = "\0" . $opts{'g'};
-      $opts{'g'} ||= $opts{'G'};
+    #$::FORCE_SERVER = "\0" . $opts{'g'};
+    $opts{'g'} ||= $opts{'G'};
 
-      if ( ref $opts{'g'} ne "ARRAY" ) {
-        $::FORCE_SERVER = [ $opts{'g'} ];
-      }
-      else {
-        $::FORCE_SERVER = $opts{'g'};
-      }
+    if ( ref $opts{'g'} ne "ARRAY" ) {
+      $::FORCE_SERVER = [ $opts{'g'} ];
     }
+    else {
+      $::FORCE_SERVER = $opts{'g'};
+    }
+  }
 
   load_server_ini_file($::rexfile);
   load_rexfile($::rexfile);

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -348,6 +348,7 @@ sub task {
     };
   }
 
+  $options->{'dont_register'} ||= $dont_register_tasks;
   return $task_o;
 }
 

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -336,8 +336,6 @@ sub run {
 sub modify {
   my ( $self, $type, $task, $code, $package, $file, $line ) = @_;
 
-  return if defined $Rex::Test::Rexfile::Syntax::syntax_check;
-
   if ( $package ne "main" && $package ne "Rex::CLI" ) {
     if ( $task !~ m/:/ ) {
 

--- a/t/include.t
+++ b/t/include.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::More tests => 2;
+use Test::Deep;
+
+use Rex::Commands;
+use Rex::Commands::Run;
+
+use t::tasks::cowboy;
+
+$::QUIET = 1;
+
+my $task_list = Rex::TaskList->create;
+
+my @task_names = $task_list->get_tasks;
+cmp_deeply
+    \@task_names,
+    [qw/t:tasks:cowboy:roundup/],
+    "found visible task";
+
+my @all_task_names = sort $task_list->get_all_tasks(qr/.*/);
+cmp_deeply 
+    \@all_task_names,
+    [qw/t:tasks:alien:negotiate t:tasks:cowboy:roundup/],
+    "found hidden task";
+
+done_testing();

--- a/t/lib/t/tasks/alien.pm
+++ b/t/lib/t/tasks/alien.pm
@@ -1,0 +1,7 @@
+package t::tasks::alien;
+use Rex -base;
+
+desc "negotiate with the aliens";
+task "negotiate" => sub { return 1 };
+
+1;

--- a/t/lib/t/tasks/cowboy.pm
+++ b/t/lib/t/tasks/cowboy.pm
@@ -1,0 +1,9 @@
+package t::tasks::cowboy;
+use Rex -base;
+
+desc "bring in the cattle";
+task "roundup" => sub { return 1 };
+
+include 't::tasks::alien';
+
+1;


### PR DESCRIPTION
The code for loading the Rexfile seems to be unnecessarily complicated and doesn't work well.  Here are some of the problems this fixes:

  1. Can't use `perl -d:Confess rex` to force a stack trace
  2. I use Carton and Rex appears to hang whenever there is a syntax error because Rex tries to syntax check every file in `./local/lib` which takes forever (see https://github.com/RexOps/Rex/issues/622).
  3. The current code seems to me way way more complicated than it needs to be.
  4. I also refactored out some logic from `Rex::CLI::_run__()`.  It was about 600 lines long.  Now its only 400 lines long.  Stuff I refactored out:
    1. Logic for loading the server ini file is now in `load_server_ini_file()`.
    1. Logic for loading the Rexfile is now in `load_rexfile()`.
    1. Logic for handling the lockfile is now in `handle_lockfile()`.