### PR TITLE
Better argument parsing to support task chaining

### DIFF
--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -786,6 +786,12 @@ sub import {
         $found_feature = 1;
       }
 
+      if ( $add eq "task_chaining_cmdline_args" ) {
+        Rex::Logger::debug("Enabling task_chaining_cmdline_args feature");
+        Rex::Config->set_task_chaining_cmdline_args(1);
+        $found_feature = 1;
+      }
+
       if ( $found_feature == 0 ) {
         Rex::Logger::info(
           "You tried to load a feature ($add) that doesn't exists in your Rex version. Please update.",

--- a/lib/Rex/Args.pm
+++ b/lib/Rex/Args.pm
@@ -11,9 +11,8 @@ use warnings;
 
 # VERSION
 
-use vars qw(%task_opts %rex_opts);
+use vars qw(%rex_opts);
 use Rex::Logger;
-use Data::Dumper;
 
 our $CLEANUP = 1;
 
@@ -107,21 +106,6 @@ sub parse_rex_opts {
   }
 }
 
-# parse tasks and task options
-sub parse_task_opts {
-  my ($class) = @_;
-
-  my @params = @ARGV;
-
-  for my $p (@params) {
-    my ($key, $val) = split /=/, $p, 2;
-
-    $key =~ s/^--//;
-
-    $task_opts{$key} = defined $val ? $val : 1;
-  }
-}
-
 sub getopts { return %rex_opts; }
 
 sub is_opt {
@@ -130,7 +114,5 @@ sub is_opt {
     return $rex_opts{$opt};
   }
 }
-
-sub get { return %task_opts; }
 
 1;

--- a/lib/Rex/Args.pm
+++ b/lib/Rex/Args.pm
@@ -19,7 +19,7 @@ our $KEY_VAL             = 1;
 our $REMOVE_TASK_OPTIONS = 0;
 our $CLEANUP             = 1;
 
-sub import {
+sub parse_args {
   my ( $class, %args ) = @_;
 
   #### clean up @ARGV

--- a/lib/Rex/Args.pm
+++ b/lib/Rex/Args.pm
@@ -15,11 +15,9 @@ use vars qw(%task_opts %rex_opts);
 use Rex::Logger;
 use Data::Dumper;
 
-our $KEY_VAL             = 1;
-our $REMOVE_TASK_OPTIONS = 0;
-our $CLEANUP             = 1;
+our $CLEANUP = 1;
 
-sub parse_args {
+sub parse_rex_opts {
   my ( $class, %args ) = @_;
 
   #### clean up @ARGV
@@ -107,29 +105,21 @@ sub parse_args {
       last;
     }
   }
+}
 
-  #### parse task options
+# parse tasks and task options
+sub parse_task_opts {
+  my ($class) = @_;
 
-  @params = @ARGV[ 1 .. $#ARGV ];
+  my @params = @ARGV;
 
-  my $counter = 1;
   for my $p (@params) {
-    my ( $key, $val ) = split( /=/, $p, 2 );
-
-    if ( defined $val ) {
-      if ($REMOVE_TASK_OPTIONS) {
-        splice( @ARGV, $counter, 1 );
-      }
-    }
+    my ($key, $val) = split /=/, $p, 2;
 
     $key =~ s/^--//;
 
-    if ( defined $val ) { $task_opts{$key} = $val; next; }
-    $task_opts{$key} = $KEY_VAL;
-
-    $counter++;
+    $task_opts{$key} = defined $val ? $val : 1;
   }
-
 }
 
 sub getopts { return %rex_opts; }

--- a/lib/Rex/Args.pm
+++ b/lib/Rex/Args.pm
@@ -54,7 +54,7 @@ sub args_spec {
 sub parse_rex_opts {
   my ($class) = @_;
 
-  %args = $class->args_spec;
+  my %args = $class->args_spec;
 
   #### clean up @ARGV
   my $runner = 0;

--- a/lib/Rex/Args.pm
+++ b/lib/Rex/Args.pm
@@ -16,8 +16,45 @@ use Rex::Logger;
 
 our $CLEANUP = 1;
 
+sub args_spec {
+  return (
+    C => {},
+    c => {},
+    q => {},
+    Q => {},
+    F => {},
+    T => {},
+    h => {},
+    v => {},
+    d => {},
+    s => {},
+    m => {},
+    y => {},
+    w => {},
+    S => { type => "string" },
+    E => { type => "string" },
+    o => { type => "string" },
+    f => { type => "string" },
+    M => { type => "string" },
+    b => { type => "string" },
+    e => { type => "string" },
+    H => { type => "string" },
+    u => { type => "string" },
+    p => { type => "string" },
+    P => { type => "string" },
+    K => { type => "string" },
+    G => { type => "string" },
+    g => { type => "string" },
+    z => { type => "string" },
+    O => { type => "string" },
+    t => { type => "string" },
+  );
+}
+
 sub parse_rex_opts {
-  my ( $class, %args ) = @_;
+  my ($class) = @_;
+
+  %args = $class->args_spec;
 
   #### clean up @ARGV
   my $runner = 0;

--- a/lib/Rex/Batch.pm
+++ b/lib/Rex/Batch.pm
@@ -29,7 +29,7 @@ sub create_batch {
   }
 
   $batchs{$batch_name} = {
-    desc  => $batch_desc,
+    desc       => $batch_desc,
     task_names => \@task_names
   };
 }

--- a/lib/Rex/Batch.pm
+++ b/lib/Rex/Batch.pm
@@ -20,11 +20,17 @@ sub create_batch {
   my $class      = shift;
   my $batch_name = shift;
   my $batch_desc = pop;
-  my @tasks      = @_;
+  my @task_names = @_;
+  my $task_list  = Rex::TaskList->create;
+
+  for my $task_name (@task_names) {
+    die "ERROR: no task: $task_name"
+      if $task_list->is_task($task_name);
+  }
 
   $batchs{$batch_name} = {
     desc  => $batch_desc,
-    tasks => \@tasks
+    task_names => \@task_names
   };
 }
 
@@ -32,7 +38,7 @@ sub get_batch {
   my $class      = shift;
   my $batch_name = shift;
 
-  return @{ $batchs{$batch_name}->{'tasks'} };
+  return @{ $batchs{$batch_name}->{'task_names'} };
 }
 
 sub get_desc {
@@ -53,22 +59,6 @@ sub is_batch {
 
   if ( defined $batchs{$batch_name} ) { return 1; }
   return 0;
-}
-
-sub run {
-  my $class = shift;
-  my $batch = shift;
-
-  my @tasks = $class->get_batch($batch);
-  for my $t (@tasks) {
-    if ( Rex::TaskList->create()->is_task($t) ) {
-      Rex::TaskList->create()->run($t);
-    }
-    else {
-      print STDERR "ERROR: no task: $t\n";
-      die;
-    }
-  }
 }
 
 1;

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -61,43 +61,9 @@ sub new {
 }
 
 sub __run__ {
-
   my ( $self, %more_args ) = @_;
 
-  Rex::Args->parse_rex_opts(
-    C => {},
-    c => {},
-    q => {},
-    Q => {},
-    F => {},
-    T => {},
-    h => {},
-    v => {},
-    d => {},
-    s => {},
-    m => {},
-    y => {},
-    w => {},
-    S => { type => "string" },
-    E => { type => "string" },
-    o => { type => "string" },
-    f => { type => "string" },
-    M => { type => "string" },
-    b => { type => "string" },
-    e => { type => "string" },
-    H => { type => "string" },
-    u => { type => "string" },
-    p => { type => "string" },
-    P => { type => "string" },
-    K => { type => "string" },
-    G => { type => "string" },
-    g => { type => "string" },
-    z => { type => "string" },
-    O => { type => "string" },
-    t => { type => "string" },
-    %more_args,
-  );
-
+  Rex::Args->parse_rex_opts;
   %opts = Rex::Args->getopts;
 
   if ( $opts{'Q'} ) {

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -64,7 +64,7 @@ sub __run__ {
 
   my ( $self, %more_args ) = @_;
 
-  Rex::Args->parse_args(
+  Rex::Args->parse_rex_opts(
     C => {},
     c => {},
     q => {},
@@ -543,6 +543,8 @@ CHECK_OVERWRITE: {
     $mod =~ s{::}{/}g;
     require "$mod.pm";
   }
+
+  Rex::Args->parse_task_opts;
 
   eval {
     if ( $opts{'b'} ) {

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -544,19 +544,15 @@ CHECK_OVERWRITE: {
     require "$mod.pm";
   }
 
-  Rex::Args->parse_task_opts;
-
   eval {
+    my $run_list = Rex::RunList->instance;
 
     if ( $opts{'b'} ) {
-      Rex::Logger::debug( "Running batch: " . $opts{'b'} );
       my $batch = $opts{'b'};
-      if ( Rex::Batch->is_batch($batch) ) {
-        Rex::Batch->run($batch);
-      }
+      Rex::Logger::debug("Running batch: $batch");
+      $run_list->add_task($_) for Rex::Batch->get_batch($batch);
     }
 
-    my $run_list = Rex::RunList->instance;
     $run_list->parse_opts(@ARGV);
     $run_list->run_tasks;
   };

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -547,6 +547,7 @@ CHECK_OVERWRITE: {
   Rex::Args->parse_task_opts;
 
   eval {
+
     if ( $opts{'b'} ) {
       Rex::Logger::debug( "Running batch: " . $opts{'b'} );
       my $batch = $opts{'b'};
@@ -555,24 +556,9 @@ CHECK_OVERWRITE: {
       }
     }
 
-    if ( defined $ARGV[0] ) {
-      for my $task (@ARGV) {
-        if ( Rex::TaskList->create()->is_task($task) ) {
-          Rex::Logger::debug("Running task: $task");
-          Rex::TaskList->run($task);
-        }
-        elsif ( $task =~ m/^\-\-/ || $task =~ m/=/ ) {
-
-          # skip, is parameter
-        }
-        else {
-          Rex::Logger::info(
-            "No task named '$task' found. Task names are case sensitive and the module delimiter is a single colon.",
-            "error"
-          );
-        }
-      }
-    }
+    my $run_list = Rex::RunList->instance;
+    $run_list->parse_opts(@ARGV);
+    $run_list->run_tasks;
   };
 
   if ($@) {

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -20,6 +20,7 @@ use Text::Wrap;
 use Term::ReadKey;
 
 use Rex;
+use Rex::Args;
 use Rex::Config;
 use Rex::Group;
 use Rex::Batch;
@@ -49,8 +50,6 @@ if ( $#ARGV < 0 ) {
   @ARGV = qw(-h);
 }
 
-require Rex::Args;
-
 sub new {
   my $that  = shift;
   my $proto = ref($that) || $that;
@@ -65,7 +64,7 @@ sub __run__ {
 
   my ( $self, %more_args ) = @_;
 
-  Rex::Args->import(
+  Rex::Args->parse_args(
     C => {},
     c => {},
     q => {},

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1097,20 +1097,20 @@ sub needs {
   my @tasks_to_run = @{"${self}::tasks"};
   use strict;
 
-  my $run_list = Rex::RunList->instance;
+  my $run_list     = Rex::RunList->instance;
   my $current_task = $run_list->current_task;
-  my %task_opts = $current_task->get_opts;
-  my @task_args = $current_task->get_args;
+  my %task_opts    = $current_task->get_opts;
+  my @task_args    = $current_task->get_args;
 
   for my $task (@tasks_to_run) {
     my $task_name = $task->{"name"};
     if ( @args && grep ( /^$task_name$/, @args ) ) {
       Rex::Logger::debug( "Calling " . $task->{"name"} );
-      $task->{"code"}->(\%task_opts, \@task_args);
+      $task->{"code"}->( \%task_opts, \@task_args );
     }
     elsif ( !@args ) {
       Rex::Logger::debug( "Calling " . $task->{"name"} );
-      $task->{"code"}->(\%task_opts, \@task_args);
+      $task->{"code"}->( \%task_opts, \@task_args );
     }
   }
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1096,17 +1096,15 @@ sub needs {
   my @tasks_to_run = @{"${self}::tasks"};
   use strict;
 
-  my %opts = Rex::Args->get;
-
   for my $task (@tasks_to_run) {
     my $task_name = $task->{"name"};
     if ( @args && grep ( /^$task_name$/, @args ) ) {
       Rex::Logger::debug( "Calling " . $task->{"name"} );
-      &{ $task->{"code"} }( \%opts );
+      $task->{"code"}->({ $task->get_opts });
     }
     elsif ( !@args ) {
       Rex::Logger::debug( "Calling " . $task->{"name"} );
-      &{ $task->{"code"} }( \%opts );
+      $task->{"code"}->({ $task->get_opts });
     }
   }
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -121,6 +121,7 @@ use Rex::Profiler;
 use Rex::Report;
 use Rex;
 use Rex::Helper::Misc;
+use Rex::RunList;
 
 use vars
   qw(@EXPORT $current_desc $global_no_ssh $environments $dont_register_tasks $profiler %auth_late);
@@ -1096,15 +1097,20 @@ sub needs {
   my @tasks_to_run = @{"${self}::tasks"};
   use strict;
 
+  my $run_list = Rex::RunList->instance;
+  my $current_task = $run_list->current_task;
+  my %task_opts = $current_task->get_opts;
+  my @task_args = $current_task->get_args;
+
   for my $task (@tasks_to_run) {
     my $task_name = $task->{"name"};
     if ( @args && grep ( /^$task_name$/, @args ) ) {
       Rex::Logger::debug( "Calling " . $task->{"name"} );
-      $task->{"code"}->({ $task->get_opts });
+      $task->{"code"}->(\%task_opts, \@task_args);
     }
     elsif ( !@args ) {
       Rex::Logger::debug( "Calling " . $task->{"name"} );
-      $task->{"code"}->({ $task->get_opts });
+      $task->{"code"}->(\%task_opts, \@task_args);
     }
   }
 

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -60,7 +60,7 @@ our (
   $register_cmdb_template,   $check_service_exists,
   $set_no_append,            $use_net_openssh_if_present,
   $use_template_ng,          $use_rex_kvm_agent,
-  $autodie,
+  $autodie,                  $task_chaining_cmdline_args,
 
 );
 
@@ -160,6 +160,15 @@ sub set_disable_taskname_warning {
 
 sub get_disable_taskname_warning {
   return $disable_taskname_warning;
+}
+
+sub set_task_chaining_cmdline_args {
+  my $class = shift;
+  $task_chaining_cmdline_args = shift;
+}
+
+sub get_task_chaining_cmdline_args {
+  return $task_chaining_cmdline_args;
 }
 
 sub set_verbose_run {

--- a/lib/Rex/Interface/Executor/Default.pm
+++ b/lib/Rex/Interface/Executor/Default.pm
@@ -31,9 +31,7 @@ sub new {
 }
 
 sub exec {
-  my ( $self, $opts ) = @_;
-
-  $opts ||= { Rex::Args->get };
+  my ( $self, $opts, $args ) = @_;
 
   my $task = $self->{task};
 
@@ -45,7 +43,7 @@ sub exec {
 
     Rex::Hook::run_hook( task => "before_execute", $task->name, @_ );
 
-    $ret = &$code($opts);
+    $ret = $code->($opts, $args);
 
     Rex::Hook::run_hook( task => "after_execute", $task->name, @_ );
   };

--- a/lib/Rex/Interface/Executor/Default.pm
+++ b/lib/Rex/Interface/Executor/Default.pm
@@ -43,7 +43,7 @@ sub exec {
 
     Rex::Hook::run_hook( task => "before_execute", $task->name, @_ );
 
-    $ret = $code->($opts, $args);
+    $ret = $code->( $opts, $args );
 
     Rex::Hook::run_hook( task => "after_execute", $task->name, @_ );
   };

--- a/lib/Rex/Interface/Executor/Default.pm
+++ b/lib/Rex/Interface/Executor/Default.pm
@@ -48,16 +48,17 @@ sub exec {
     Rex::Hook::run_hook( task => "after_execute", $task->name, @_ );
   };
 
-  my %opts = Rex::Args->getopts;
-  if ($@) {
-    my $error = $@;
+  my $error = $@;
+  my %opts  = Rex::Args->getopts;
+
+  if ($error) {
     if ( exists $opts{o} ) {
-      Rex::Output->get->add( $task->name, error => 1, msg => $@ );
+      Rex::Output->get->add( $task->name, error => 1, msg => $error );
     }
     else {
       Rex::Logger::info( "Error executing task:", "error" );
       Rex::Logger::info( "$error",                "error" );
-      die($@);
+      die($error);
     }
   }
   else {

--- a/lib/Rex/RunList.pm
+++ b/lib/Rex/RunList.pm
@@ -10,7 +10,6 @@ use strict;
 use warnings;
 
 use Rex::Logger;
-use Rex::Task;
 use Rex::TaskList;
 
 # VERSION

--- a/lib/Rex/RunList.pm
+++ b/lib/Rex/RunList.pm
@@ -1,0 +1,119 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::RunList;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Rex::Logger;
+use Rex::Task;
+use Rex::TaskList;
+#use Rex::Config;
+#use Rex::Interface::Executor;
+#use Rex::Fork::Manager;
+#use Rex::Report;
+#use Rex::Group;
+#use Time::HiRes qw(time);
+#use POSIX qw(floor);
+
+my $INSTANCE;
+
+sub new {
+  my ($class, %args) = @_;
+  return bless \%args, $class;
+}
+
+# returns a singleton
+sub instance {
+  my $class = shift;
+  return $INSTANCE if $INSTANCE;
+  $INSTANCE = $class->new(@_);
+}
+
+sub add_task {
+  my ($self, $task_name, $task_args, $task_opts) = @_;
+  $task_args ||= [];
+  $task_opts ||= {};
+  my $task = $self->task_list->get_task($task_name)->clone;
+  $task->set_args(@$task_args);
+  $task->set_opts(%$task_opts);
+  push @{ $self->{tasks} }, $task;
+}
+
+sub current_index {
+  my ($self) = @_;
+  return $self->{current_index} || 0;
+}
+
+sub increment_current_index {
+  my ($self) = @_;
+  return $self->{current_index} += 1;
+}
+
+sub current_task {
+  my $self = shift;
+  my $i = $self->current_index;
+  $self->{tasks}->[$i];
+}
+
+sub tasks { @{ shift->{tasks} } }
+
+sub task_list    { 
+  my $self = shift;
+  return $self->{task_list} if $self->{task_list};
+  $self->{task_list} = Rex::TaskList->create;
+}
+
+sub run_tasks {
+  my ($self) = @_;
+  
+  for my $task ($self->tasks) {
+    $_->($task) for @{ $task->{before_task_start} };
+    $self->task_list->run($task);
+    $_->($task) for @{ $task->{after_task_finished} };
+    $self->increment_current_index;
+  }
+}
+
+# Parse @ARGV to get tasks, task args, and task opts.  Use these values to
+# generate a list of tasks the user wants to run.
+sub parse_opts {
+  my ($self, @params) = @_;
+
+  while (my $task_name = shift @params) {
+    die "Expected a task name but found '$task_name' instead\n"
+      unless $self->task_list->is_task($task_name);
+
+    my @args;
+    my %opts;
+
+    while (my $param = shift @params) {
+      if ($self->task_list->is_task($param)) {
+        unshift @params, $param;
+        last;
+      }
+
+      if ($param =~ /^--/) {
+        my ($key, $val) = split /=/, $param, 2;
+        $key =~ s/^--//;
+
+        $opts{$key} = defined $val ? $val : 1;
+      }
+      else {
+        push @args, $param;
+      }
+    }
+
+    $self->add_task($task_name, \@args, \%opts);
+  }
+
+  return $self;
+}
+
+1;

--- a/lib/Rex/RunList.pm
+++ b/lib/Rex/RunList.pm
@@ -9,18 +9,11 @@ package Rex::RunList;
 use strict;
 use warnings;
 
-# VERSION
-
 use Rex::Logger;
 use Rex::Task;
 use Rex::TaskList;
-#use Rex::Config;
-#use Rex::Interface::Executor;
-#use Rex::Fork::Manager;
-#use Rex::Report;
-#use Rex::Group;
-#use Time::HiRes qw(time);
-#use POSIX qw(floor);
+
+# VERSION
 
 my $INSTANCE;
 

--- a/lib/Rex/RunList.pm
+++ b/lib/Rex/RunList.pm
@@ -17,7 +17,7 @@ use Rex::TaskList;
 my $INSTANCE;
 
 sub new {
-  my ($class, %args) = @_;
+  my ( $class, %args ) = @_;
   return bless \%args, $class;
 }
 
@@ -29,7 +29,7 @@ sub instance {
 }
 
 sub add_task {
-  my ($self, $task_name, $task_args, $task_opts) = @_;
+  my ( $self, $task_name, $task_args, $task_opts ) = @_;
   $task_args ||= [];
   $task_opts ||= {};
   my $task = $self->task_list->get_task($task_name)->clone;
@@ -50,13 +50,13 @@ sub increment_current_index {
 
 sub current_task {
   my $self = shift;
-  my $i = $self->current_index;
+  my $i    = $self->current_index;
   $self->{tasks}->[$i];
 }
 
 sub tasks { @{ shift->{tasks} } }
 
-sub task_list    { 
+sub task_list {
   my $self = shift;
   return $self->{task_list} if $self->{task_list};
   $self->{task_list} = Rex::TaskList->create;
@@ -64,8 +64,8 @@ sub task_list    {
 
 sub run_tasks {
   my ($self) = @_;
-  
-  for my $task ($self->tasks) {
+
+  for my $task ( $self->tasks ) {
     $_->($task) for @{ $task->{before_task_start} };
     $self->task_list->run($task);
     $_->($task) for @{ $task->{after_task_finished} };
@@ -76,26 +76,26 @@ sub run_tasks {
 # Parse @ARGV to get tasks, task args, and task opts.  Use these values to
 # generate a list of tasks the user wants to run.
 sub parse_opts {
-  my ($self, @params) = @_;
+  my ( $self, @params ) = @_;
 
-  return $self->deprecated(@params) 
+  return $self->deprecated(@params)
     unless Rex::Config->get_task_chaining_cmdline_args;
 
-  while (my $task_name = shift @params) {
+  while ( my $task_name = shift @params ) {
     die "Expected a task name but found '$task_name' instead\n"
       unless $self->task_list->is_task($task_name);
 
     my @args;
     my %opts;
 
-    while (my $param = shift @params) {
-      if ($self->task_list->is_task($param)) {
+    while ( my $param = shift @params ) {
+      if ( $self->task_list->is_task($param) ) {
         unshift @params, $param;
         last;
       }
 
-      if ($param =~ /^--/) {
-        my ($key, $val) = split /=/, $param, 2;
+      if ( $param =~ /^--/ ) {
+        my ( $key, $val ) = split /=/, $param, 2;
         $key =~ s/^--//;
 
         $opts{$key} = defined $val ? $val : 1;
@@ -105,14 +105,14 @@ sub parse_opts {
       }
     }
 
-    $self->add_task($task_name, \@args, \%opts);
+    $self->add_task( $task_name, \@args, \%opts );
   }
 
   return $self;
 }
 
 sub deprecated {
-  my ($self, @params) = @_;
+  my ( $self, @params ) = @_;
 
   my $msg = <<EOF;
 The default way command line arguments work will change somewhat in a future
@@ -123,7 +123,7 @@ Use the feature 'task_chaining_cmdline_args' to remove this warning and enable
 the new features.  For more info see:
 http://www.rexify.org/docs/other/a_word_on_backward_compatibility.html
 EOF
-  Rex::Logger::info($msg, 'warn');
+  Rex::Logger::info( $msg, 'warn' );
 
   #### parse task options
   my %task_opts;
@@ -141,7 +141,7 @@ EOF
     next if $task_name =~ m/^\-\-/ || $task_name =~ m/=/;
     next unless $self->task_list->is_task($task_name);
 
-    $self->add_task($task_name, [], \%task_opts);
+    $self->add_task( $task_name, [], \%task_opts );
   }
 }
 

--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -486,18 +486,12 @@ sub run_hook {
       $code->(
         $$server,
         ( $self->{"__was_authenticated"} ? undef : 1 ),
-        { $self->get_opts },
-        @more_args
+        { $self->get_opts }, @more_args
       );
     }
     else {
       my $old_server = $$server if $server;
-      $code->(
-        $$server,
-        $server,
-        { $self->get_opts },
-        @more_args
-      );
+      $code->( $$server, $server, { $self->get_opts }, @more_args );
       if ( $old_server && $old_server ne $$server ) {
         $self->{current_server} = $$server;
       }
@@ -898,12 +892,12 @@ sub get_opts {
 }
 
 sub set_args {
-  my ($self, @args) = @_;
+  my ( $self, @args ) = @_;
   $self->{args} = \@args;
 }
 
 sub set_opts {
-  my ($self, %opts) = @_;
+  my ( $self, %opts ) = @_;
   $self->{opts} = \%opts;
 }
 

--- a/lib/Rex/TaskList.pm
+++ b/lib/Rex/TaskList.pm
@@ -38,7 +38,7 @@ sub create {
 
   eval "use $class_name";
   if ($@) {
-    die("TaskList module not found.");
+    die("TaskList module not found: $@");
   }
 
   $task_list = $class_name->new;
@@ -51,15 +51,8 @@ sub create {
 
 sub run {
   my ( $class, $task_name ) = @_;
-  my $task_object = $class->create()->get_task($task_name);
-
-  for my $code ( @{ $task_object->{before_task_start} } ) {
-    $code->($task_object);
-  }
-
-  $class->create()->run($task_name);
-
-  for my $code ( @{ $task_object->{after_task_finished} } ) {
-    $code->($task_object);
-  }
+  my $task = $class->create()->get_task($task_name);
+  $_->($task) for @{ $task->{before_task_start} };
+  $class->create->run($task);
+  $_->($task) for @{ $task->{after_task_finished} };
 }

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -286,11 +286,9 @@ sub is_task {
 }
 
 sub run {
-  my ( $self, $task_name, %option ) = @_;
-  my $task = $self->get_task($task_name);
+  my ( $self, $task, %options ) = @_;
 
-  $option{params} ||= { Rex::Args->get };
-
+  my $task_name  = $task->name;
   my @all_server = @{ $task->server };
 
   my $fm = Rex::Fork::Manager->new( max => $self->get_thread_count($task) );
@@ -304,12 +302,13 @@ sub run {
       # create a single task object for the run on $server
 
       Rex::Logger::info("Running task $task_name on $server");
-      my $run_task = Rex::Task->new( %{ $task->get_data } );
+      my $run_task = $task->clone;
 
       $run_task->run(
         $server,
         in_transaction => $self->{IN_TRANSACTION},
-        params         => $option{params}
+        params         => $options{params},
+        args           => $options{args},
       );
 
       # destroy cached os info

--- a/lib/Rex/TaskList/Parallel_ForkManager.pm
+++ b/lib/Rex/TaskList/Parallel_ForkManager.pm
@@ -40,11 +40,9 @@ sub new {
 }
 
 sub run {
-  my ( $self, $task_name, %option ) = @_;
-  my $task = $self->get_task($task_name);
+  my ( $self, $task, %option ) = @_;
 
-  $option{params} ||= { Rex::Args->get };
-
+  my $task_name  = $task->name;
   my @all_server = @{ $task->server };
 
   my $fm = Parallel::ForkManager->new( $self->get_thread_count($task) );
@@ -66,12 +64,13 @@ sub run {
       # create a single task object for the run on $server
 
       Rex::Logger::info("Running task $task_name on $server");
-      my $run_task = Rex::Task->new( %{ $task->get_data } );
+      my $run_task = $task->clone;
 
       $run_task->run(
         $server,
         in_transaction => $self->{IN_TRANSACTION},
-        params         => $option{params}
+        params         => $option{params},
+        args           => $option{args},
       );
 
       # destroy cached os info

--- a/t/args.t
+++ b/t/args.t
@@ -6,7 +6,7 @@ use Test::More;
 use Rex::Args;
 
 @ARGV = qw(
-    -h -g test1 -g test2 -T -dv -u user -p pass -t 5 foo --name=thename --num=5
+  -h -g test1 -g test2 -T -dv -u user -p pass -t 5 foo --name=thename --num=5
 );
 
 Rex::Args->parse_rex_opts;

--- a/t/args.t
+++ b/t/args.t
@@ -1,41 +1,15 @@
 use strict;
 use warnings;
 
-use Test::More tests => 13;
+use Test::More;
 
 use Rex::Args;
 
-push( @ARGV,
-  qw(-h -g test1 -g test2 -T -dv -u user -p pass -t 5 foo --name=thename --num=5)
+@ARGV = qw(
+    -h -g test1 -g test2 -T -dv -u user -p pass -t 5 foo --name=thename --num=5
 );
 
-Rex::Args->import(
-  C => {},
-  c => {},
-  q => {},
-  Q => {},
-  F => {},
-  T => {},
-  h => {},
-  v => {},
-  d => {},
-  s => {},
-  S => { type => "string" },
-  E => { type => "string" },
-  o => { type => "string" },
-  f => { type => "string" },
-  M => { type => "string" },
-  b => { type => "string" },
-  e => { type => "string" },
-  H => { type => "string" },
-  u => { type => "string" },
-  p => { type => "string" },
-  P => { type => "string" },
-  K => { type => "string" },
-  G => { type => "string" },
-  g => { type => "string" },
-  t => { type => "integer" },
-);
+Rex::Args->parse_rex_opts;
 
 my %opts   = Rex::Args->getopts;
 my $groups = $opts{g};
@@ -58,12 +32,4 @@ ok( exists $opts{t} && $opts{t} == 5, "parameter with option (3) / integer" );
 
 is( $ARGV[0], "foo", "got the taskname" );
 
-my %params = Rex::Args->get;
-
-is( $ARGV[1], "--name=thename", "got the whole parameter (1)" );
-is( $ARGV[2], "--num=5",        "got the whole parameter (2)" );
-
-ok( exists $params{name} && $params{name} eq "thename",
-  "got task parameter (1)" );
-ok( exists $params{num} && $params{num} == 5, "got task parameter (2)" );
-
+done_testing;

--- a/t/needs.t
+++ b/t/needs.t
@@ -8,13 +8,13 @@ $::QUIET = 1;
 use Rex::Commands;
 
 task "test1", sub {
-    open( my $fh, ">", "test1.txt" );
-    close($fh);
+  open( my $fh, ">", "test1.txt" );
+  close($fh);
 };
 
 task "test2", sub {
-    open( my $fh, ">", "test2.txt" );
-    close($fh);
+  open( my $fh, ">", "test2.txt" );
+  close($fh);
 };
 
 1;
@@ -26,53 +26,53 @@ use Test::More;
 use Rex::Commands;
 
 task "test", sub {
-    needs MyTest;
+  needs MyTest;
 
-    if ( -f "test1.txt" && -f "test2.txt" ) {
-      unlink("test1.txt");
-      unlink("test2.txt");
+  if ( -f "test1.txt" && -f "test2.txt" ) {
+    unlink("test1.txt");
+    unlink("test2.txt");
 
-      return 1;
-    }
+    return 1;
+  }
 
-    is( 1, -1 );
+  is( 1, -1 );
 };
 
 task "test2", sub {
-    needs MyTest "test2";
+  needs MyTest "test2";
 
-    if ( -f "test2.txt" ) {
-      unlink("test2.txt");
-      return 1;
-    }
+  if ( -f "test2.txt" ) {
+    unlink("test2.txt");
+    return 1;
+  }
 
-    is( 1, -1 );
+  is( 1, -1 );
 
 };
 
 task "test3", sub {
-    needs("test4");
+  needs("test4");
 
-    if ( -f "test4.txt" ) {
-      unlink("test4.txt");
-      return 1;
-    }
+  if ( -f "test4.txt" ) {
+    unlink("test4.txt");
+    return 1;
+  }
 
-    is( 1, -1 );
+  is( 1, -1 );
 };
 
 task "test4", sub {
-    open( my $fh, ">", "test4.txt" );
-    close($fh);
+  open( my $fh, ">", "test4.txt" );
+  close($fh);
 };
 
 my $task_list = Rex::TaskList->create;
-my $run_list = Rex::RunList->instance;
+my $run_list  = Rex::RunList->instance;
 $run_list->parse_opts(qw/test test2 test3/);
-  
-for my $task ($run_list->tasks) {
-    ok $task_list->run($task), $task->name;
-    $run_list->increment_current_index;
+
+for my $task ( $run_list->tasks ) {
+  ok $task_list->run($task), $task->name;
+  $run_list->increment_current_index;
 }
 
 #my $task  = $run_list->next_task;

--- a/t/needs.t
+++ b/t/needs.t
@@ -7,37 +7,25 @@ $::QUIET = 1;
 
 use Rex::Commands;
 
-desc("MyTest - Test1");
-task(
-  "test1",
-  sub {
+task "test1", sub {
     open( my $fh, ">", "test1.txt" );
     close($fh);
-  }
-);
+};
 
-desc("MyTest - Test2");
-task(
-  "test2",
-  sub {
+task "test2", sub {
     open( my $fh, ">", "test2.txt" );
     close($fh);
-  }
-);
+};
 
 1;
 
 package main;
 
-use Test::More tests => 3;
+use Test::More;
 
 use Rex::Commands;
 
-desc("Test");
-task(
-  "test",
-  sub {
-
+task "test", sub {
     needs MyTest;
 
     if ( -f "test1.txt" && -f "test2.txt" ) {
@@ -48,14 +36,9 @@ task(
     }
 
     is( 1, -1 );
-  }
-);
+};
 
-desc("Test 2");
-task(
-  "test2",
-  sub {
-
+task "test2", sub {
     needs MyTest "test2";
 
     if ( -f "test2.txt" ) {
@@ -65,14 +48,9 @@ task(
 
     is( 1, -1 );
 
-  }
-);
+};
 
-desc("Test 3");
-task(
-  "test3",
-  sub {
-
+task "test3", sub {
     needs("test4");
 
     if ( -f "test4.txt" ) {
@@ -81,21 +59,30 @@ task(
     }
 
     is( 1, -1 );
-  }
-);
+};
 
-desc("Test 4");
-task(
-  "test4",
-  sub {
+task "test4", sub {
     open( my $fh, ">", "test4.txt" );
     close($fh);
-  }
-);
+};
 
-ok( Rex::TaskList->create()->run("test"),  "testing needs" );
-ok( Rex::TaskList->create()->run("test2"), "testing needs" );
-ok( Rex::TaskList->create()->run("test3"), "testing needs - local namespace" );
+my $task_list = Rex::TaskList->create;
+my $run_list = Rex::RunList->instance;
+$run_list->parse_opts(qw/test test2 test3/);
+  
+for my $task ($run_list->tasks) {
+    ok $task_list->run($task), $task->name;
+    $run_list->increment_current_index;
+}
+
+#my $task  = $run_list->next_task;
+#my $task2 = $task_list->get_task("test2");
+#my $task3 = $task_list->get_task("test3");
+#
+#ok $task_list->run($task),  "testing needs";
+##ok $task_list->run($task2), "testing needs";
+##ok $task_list->run($task3), "testing needs - local namespace";
+
+done_testing;
 
 1;
-

--- a/t/runlist.t
+++ b/t/runlist.t
@@ -8,6 +8,7 @@ use Rex::RunList;
 use Rex::Commands;
 
 $Rex::Logger::silent = 1;
+Rex::Config->set_task_chaining_cmdline_args(1);
 
 task task1 => sub { };
 task task2 => sub { };

--- a/t/runlist.t
+++ b/t/runlist.t
@@ -26,14 +26,15 @@ is scalar @tasks, 3, "run list has 3 tasks";
 is ref $_, 'Rex::Task', "object isa Rex::Task" for @tasks;
 
 note "opts";
-is_deeply {$tasks[0]->get_opts}, { name => 'thename', num => 5 }, "task0 opts";
-is_deeply {$tasks[1]->get_opts}, {},                              "task1 opts";
-is_deeply {$tasks[2]->get_opts}, { hey => 'what' },               "task2 opts";
+is_deeply { $tasks[0]->get_opts }, { name => 'thename', num => 5 },
+  "task0 opts";
+is_deeply { $tasks[1]->get_opts }, {}, "task1 opts";
+is_deeply { $tasks[2]->get_opts }, { hey => 'what' }, "task2 opts";
 
 note "args";
-is_deeply [$tasks[0]->get_args], [qw/arg1 arg2/], "task0 args";
-is_deeply [$tasks[1]->get_args], [qw/arg/],       "task1 args";
-is_deeply [$tasks[2]->get_args], [qw//],          "task2 args";
+is_deeply [ $tasks[0]->get_args ], [qw/arg1 arg2/], "task0 args";
+is_deeply [ $tasks[1]->get_args ], [qw/arg/],       "task1 args";
+is_deeply [ $tasks[2]->get_args ], [qw//],          "task2 args";
 
 $run_list->run_tasks;
 

--- a/t/runlist.t
+++ b/t/runlist.t
@@ -1,0 +1,39 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Rex::Args;
+use Rex::RunList;
+use Rex::Commands;
+
+$Rex::Logger::silent = 1;
+
+task task1 => sub { };
+task task2 => sub { };
+task task3 => sub { };
+task task4 => sub { };
+
+@ARGV = qw(task1 arg1 arg2 --name=thename --num=5 task2 arg task3 --hey=what);
+
+my $run_list = Rex::RunList->instance;
+$run_list->parse_opts(@ARGV);
+
+my @tasks = $run_list->tasks;
+
+is scalar @tasks, 3, "run list has 3 tasks";
+is ref $_, 'Rex::Task', "object isa Rex::Task" for @tasks;
+
+note "opts";
+is_deeply {$tasks[0]->get_opts}, { name => 'thename', num => 5 }, "task0 opts";
+is_deeply {$tasks[1]->get_opts}, {},                              "task1 opts";
+is_deeply {$tasks[2]->get_opts}, { hey => 'what' },               "task2 opts";
+
+note "args";
+is_deeply [$tasks[0]->get_args], [qw/arg1 arg2/], "task0 args";
+is_deeply [$tasks[1]->get_args], [qw/arg/],       "task1 args";
+is_deeply [$tasks[2]->get_args], [qw//],          "task2 args";
+
+$run_list->run_tasks;
+
+done_testing;


### PR DESCRIPTION
# Overview

Currently rex has very limited support for task chaining.  The following works:
```
rex task1 task2 task3
```

But as soon as you start passing options to tasks, things break down in a couple of ways.  The goal of this pr is to fix this.

# Concepts

A `Rex::TaskList` object holds a *hash* defining every task defined in a user's Rexfile.

A `Rex::RunList` object holds a *list* of all the `Rex::Task` objects that are going to get executed in a single run of rex.  In other words, it contains all the tasks specified by the user on the command line.  Note that `Rex::Task` objects now contain `args` and `opts` attributes.

# Fixes

  * `Rex::Args` parses @ARGV every time it was used.  Moved code out of `import()`.
  * Users can pass in multiple tasks to rex on the command line.  But `Rex::Args` assumes all options are for the first task.  Argument parsing is now fixed in `Rex::RunList->parse_opts()`.  Example:
```
rex lib:task1 --option1=value1 lib:task2 --option1=value2
```
  * Even if Rex::Args parses the arguments correctly, rex can't run a task more than once with different options using only the `Rex::TaskList` concept because it contains a hash of all the tasks (and hashes don't allow duplicate keys).  Fixed this by adding the `Rex::RunList` concept which is based around an arrayref instead of a hashref.  Example:
```
rex lib:task1 --option=value1 lib:task2 --option=value2
```
  * Tasks can now accept arguments as well as options. Example:
```
rex lib:task1 <arg> --option=value
```

# Note

I structured my commits neatly (I hope).  It may help to review them one at a time to understand this pr.