### PR TITLE
Change the order for ssh username guesses, prefer current uid 

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -441,7 +441,7 @@ sub get_user {
     return $user;
   }
 
-  return getlogin || getpwuid($<) || "Kilroy";
+  return getpwuid($<) || getlogin || "Kilroy";
 }
 
 sub get_password {


### PR DESCRIPTION
Change the order for ssh username guesses, prefer current uid over getlogin