### PR TITLE
 Add support for ip6tables

### DIFF
--- a/lib/Rex/Commands/Iptables.pm
+++ b/lib/Rex/Commands/Iptables.pm
@@ -127,7 +127,7 @@ Open a port for inbound connections.
 =cut
 
 sub open_port {
-  my (@params) = @_;
+  my @params     = @_;
   my $ip_version = _get_ip_version( \@params );
   my ( $port, $option ) = @params;
 
@@ -165,7 +165,7 @@ Close a port for inbound connections.
 =cut
 
 sub close_port {
-  my (@params) = @_;
+  my @params     = @_;
   my $ip_version = _get_ip_version( \@params );
   my ( $port, $option ) = @params;
 
@@ -203,7 +203,7 @@ Redirect $in_port to another local port.
 =cut
 
 sub redirect_port {
-  my (@params) = @_;
+  my @params     = @_;
   my $ip_version = _get_ip_version( \@params );
   if ( $ip_version == -6 ) {
     my $iptables_version = _iptables_version();
@@ -305,7 +305,7 @@ flush.
 =cut
 
 sub iptables {
-  my (@params) = @_;
+  my @params   = @_;
   my $iptables = _get_executable( \@params );
 
   if ( $params[0] eq "flush" || $params[0] eq "-flush" || $params[0] eq "-F" ) {
@@ -363,7 +363,7 @@ This function creates a NAT gateway for the device the default route points to.
 =cut
 
 sub is_nat_gateway {
-  my (@params) = @_;
+  my @params     = @_;
   my $ip_version = _get_ip_version( \@params );
 
   Rex::Logger::debug("Changing this system to a nat gateway.");
@@ -414,7 +414,7 @@ Set the default state rules for the given device.
 =cut
 
 sub default_state_rule {
-  my (@params)   = @_;
+  my @params     = @_;
   my $ip_version = _get_ip_version( \@params );
   my (%option)   = @params;
 
@@ -450,7 +450,7 @@ List all iptables rules.
 =cut
 
 sub iptables_list {
-  my (@params) = @_;
+  my @params   = @_;
   my $iptables = _get_executable( \@params );
   my @lines    = run "/sbin/$iptables-save";
   _iptables_list(@lines);
@@ -458,7 +458,7 @@ sub iptables_list {
 
 sub _iptables_list {
   my ( %tables, $ret );
-  my (@lines) = @_;
+  my @lines = @_;
 
   my ($current_table);
   for my $line (@lines) {
@@ -503,7 +503,7 @@ Remove all iptables rules.
 =cut
 
 sub iptables_clear {
-  my (@params) = @_;
+  my @params     = @_;
   my $ip_version = _get_ip_version( \@params );
 
   for my $table (qw/nat mangle filter/) {

--- a/lib/Rex/Commands/Iptables.pm
+++ b/lib/Rex/Commands/Iptables.pm
@@ -628,7 +628,8 @@ sub _get_executable {
 sub _iptables_version {
   my $version = join "", map { sprintf "%03d", $_ } split /[.]/,
     substr run("iptables -V"), 10;
-  return $version =~ s/^0+//r;
+  $version =~ s/^0+//;
+  return $version;
 }
 
 1;

--- a/lib/Rex/Commands/Iptables.pm
+++ b/lib/Rex/Commands/Iptables.pm
@@ -336,17 +336,11 @@ sub iptables {
     }
   }
 
-  if ( can_run($iptables) ) {
-    my $output = run "$iptables $cmd";
+  my $output = run "$iptables $cmd";
 
-    if ( $? != 0 ) {
-      Rex::Logger::info( "Error setting iptable rule: $cmd", "warn" );
-      die("Error setting iptable rule: $cmd; command output: $output");
-    }
-  }
-  else {
-    Rex::Logger::info("$iptables not found.");
-    die("$iptables not found.");
+  if ( $? != 0 ) {
+    Rex::Logger::info( "Error setting iptable rule: $cmd", "warn" );
+    die("Error setting iptable rule: $cmd; command output: $output");
   }
 }
 
@@ -619,7 +613,10 @@ sub _get_ip_version {
 
 sub _get_executable {
   my ($params) = @_;
-  return _get_ip_version($params) == -6 ? "ip6tables" : "iptables";
+  my $binary = _get_ip_version($params) == -6 ? "ip6tables" : "iptables";
+  my $executable = can_run($binary);
+  die "Can't find $binary in PATH" if $executable eq '';
+  return $executable;
 }
 
 sub _iptables_version {

--- a/lib/Rex/Commands/Iptables.pm
+++ b/lib/Rex/Commands/Iptables.pm
@@ -57,8 +57,7 @@ Only I<open_port> and I<close_port> are idempotent.
          jump            => "MASQUERADE";
 
    # Version of IP can be specified in the first argument
-   # of any function: -4 or -6 (if no version specified,
-   # -4 implies)
+   # of any function: -4 or -6 (defaults to -4)
    iptables_clear -6;
 
    open_port -6, [22, 80];

--- a/lib/Rex/Commands/Iptables.pm
+++ b/lib/Rex/Commands/Iptables.pm
@@ -207,8 +207,8 @@ sub redirect_port {
   if ( $ip_version == -6 ) {
     my $iptables_version = _iptables_version();
     if ( $iptables_version < 1_004_018 ) {
-      Rex::Logger::info("IPtables < v1.4.18 doesn't support NAT for IPv6");
-      die("IPtables < v1.4.18 doesn't support NAT for IPv6");
+      Rex::Logger::info("iptables < v1.4.18 doesn't support NAT for IPv6");
+      die("iptables < v1.4.18 doesn't support NAT for IPv6");
     }
   }
 
@@ -269,7 +269,7 @@ sub redirect_port {
 
 Write standard iptable comands.
 
-Note that there is a short form for the IPTables C<--flush> option; when you
+Note that there is a short form for the iptables C<--flush> option; when you
 pass the option of C<-F|"flush"> as the only argument, the command
 C<iptables -F> is run on the connected host.  With the two argument form of
 C<flush> shown in the examples below, the second argument is table you want to
@@ -576,7 +576,7 @@ sub _open_or_close_port {
   }
 
   if ( _rule_exists( $ip_version, @opts ) ) {
-    Rex::Logger::debug("IPTables rule already exists. skipping...");
+    Rex::Logger::debug("iptables rule already exists. skipping...");
     return;
   }
 


### PR DESCRIPTION
Hello!

I've tried to add support for IPv6 in Rex::Commands::Iptables functions. Version of IP can be specified in the first argument of any function: -4 or -6 (like popular parameters in network tools). If no version specified, -4 implies (for full backward compatibility) .

Examples:

    iptables_clear -6;

    open_port -6, [22, 80];
    close_port -6, "all";
    redirect_port -6, 80 => 10080;
    default_state_rule -6;
    is_nat_gateway -6;

    iptables -6, "flush";
    iptables -6,
          t     => "filter",
          A     => "INPUT",
          i     => "eth0",
          m     => "state",
          state => "RELATED,ESTABLISHED",
          j     => "ACCEPT";

Please review this patch.