### PR TITLE
Fix managing a user's own crontab via cron_entry

### DIFF
--- a/lib/Rex/Cron/Base.pm
+++ b/lib/Rex/Cron/Base.pm
@@ -174,6 +174,7 @@ sub read_user_cron {
 
   my $command = 'crontab -l';
   $command .= " -u $user" if defined $user;
+  $command .= ' 2> /dev/null';
 
   my @lines = i_run $command;
   $self->parse_cron(@lines);

--- a/lib/Rex/Cron/Base.pm
+++ b/lib/Rex/Cron/Base.pm
@@ -159,16 +159,22 @@ sub write_cron {
 
 sub activate_user_cron {
   my ( $self, $file, $user ) = @_;
+  $user = undef if $user eq &_whoami;
+
   my $command = 'crontab';
   $command .= " -u $user" if defined $user;
+
   i_run "$command $file";
   unlink $file;
 }
 
 sub read_user_cron {
   my ( $self, $user ) = @_;
+  $user = undef if $user eq &_whoami;
+
   my $command = 'crontab -l';
   $command .= " -u $user" if defined $user;
+
   my @lines = i_run $command;
   $self->parse_cron(@lines);
 }

--- a/lib/Rex/Cron/Base.pm
+++ b/lib/Rex/Cron/Base.pm
@@ -266,4 +266,8 @@ sub _create_defaults {
   return %config;
 }
 
+sub _whoami {
+  return i_run q(perl -e 'print scalar getpwuid($<)');
+}
+
 1;


### PR DESCRIPTION
`cron_entry` fails without passing a user to it (correctly), however this enforces calling `crontab` CLI command on the remotes with the `-u` option, which in turn requires superuser privileges.

This patch resolves that situation, by checking if the effective remote username is the same as the username for which the crontab operation is requested. If yes, it means the user manages his/her own crontab, so Rex avoids using the `-u` CLI option.