### PR TITLE
Fix undef warnings if calling get() without param

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -865,6 +865,7 @@ sub unset {
 
 sub get {
   my ( $class, $var ) = @_;
+  $var or return;
   if ( exists $set_param->{$var} ) {
     return $set_param->{$var};
   }


### PR DESCRIPTION
When using the firewall module, lots of ```Use of uninitialized value $var in exists at /usr/local/share/perl/5.18.2/Rex/Config.pm line 870``` warnings are generated. The offending code is here: https://github.com/RexOps/rex-recipes/blob/1.3/Rex/Ext/ParamLookup/__module__.pm#L41 (```Rex::CMDB::cmdb($cmdb_key)``` is often undefined).