### PR TITLE
added ParamLookup, also for RexOps/Rex#545

### DIFF
--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -527,6 +527,8 @@ sub import {
     require Rex::Commands::User;
     Rex::Commands::User->import( register_in => $register_to );
 
+    require Rex::Helper::Rexfile::ParamLookup;
+    Rex::Helper::Rexfile::ParamLookup->import( register_in => $register_to );
   }
 
   if ( $what eq "-feature" || $what eq "feature" ) {

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -785,7 +785,13 @@ sub set_template_function {
 
 sub get_template_function {
   if ( ref($template_function) eq "CODE" ) {
-    return $template_function;
+    return sub {
+      my ( $content, $template_vars ) = @_;
+      $template_vars =
+        { %{ Rex::Commands::task()->get_all_parameters }, %{$template_vars} }
+        if ( Rex::Commands::task() );
+      return $template_function->( $content, $template_vars );
+    };
   }
 
   if ( Rex::Template::NG->is_loadable && get_use_template_ng() ) {
@@ -793,6 +799,9 @@ sub get_template_function {
     # new template engine
     return sub {
       my ( $content, $template_vars ) = @_;
+      $template_vars =
+        { %{ Rex::Commands::task()->get_all_parameters }, %{$template_vars} }
+        if ( Rex::Commands::task() );
       Rex::Template::NG->require;
       my $t = Rex::Template::NG->new;
       return $t->parse( $content, %{$template_vars} );
@@ -801,6 +810,9 @@ sub get_template_function {
 
   return sub {
     my ( $content, $template_vars ) = @_;
+    $template_vars =
+      { %{ Rex::Commands::task()->get_all_parameters }, %{$template_vars} }
+      if ( Rex::Commands::task() );
     use Rex::Template;
     my $template = Rex::Template->new;
     return $template->parse( $content, $template_vars );

--- a/lib/Rex/Helper/Rexfile/ParamLookup.pm
+++ b/lib/Rex/Helper/Rexfile/ParamLookup.pm
@@ -69,8 +69,7 @@ sub param_lookup {
     $ret = $default;
   }
 
-  # make the variable also known to templates
-  Rex::Commands::set( $key => $ret );
+  Rex::Commands::task()->set_parameter( $key => $ret );
 
   return $ret;
 }
@@ -90,7 +89,7 @@ This module also looks inside a CMDB (if present) for a valid key.
 
 =head1 SYNOPSIS
 
- task "setup", make {
+ task "setup", sub {
    my $var = param_lookup "param_name", "default_value";
  };
 

--- a/lib/Rex/Helper/Rexfile/ParamLookup.pm
+++ b/lib/Rex/Helper/Rexfile/ParamLookup.pm
@@ -1,0 +1,103 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=3 sw=3 tw=0:
+# vim: set expandtab:
+
+package Rex::Helper::Rexfile::ParamLookup;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Devel::Caller;
+use Data::Dumper;
+require Rex::Exporter;
+require Rex::Commands;
+
+use base qw(Rex::Exporter);
+use vars qw (@EXPORT);
+
+@EXPORT = qw(param_lookup);
+
+sub param_lookup {
+  my ( $key, $default ) = @_;
+
+  my $ret;
+
+  my ($caller_pkg) = caller(0);
+
+  my @args = Devel::Caller::caller_args(1);
+  if ( ref $args[0] eq "HASH" ) {
+    if ( exists $args[0]->{$key} ) {
+      $ret = $args[0]->{$key};
+    }
+  }
+
+  if ( !$ret ) {
+
+    # check if cmdb is loaded
+    my ($use_cmdb) = grep { m/CMDB\.pm/ } keys %INC;
+    if ($use_cmdb) {
+
+      # look inside cmdb
+      my $cmdb_key = "${caller_pkg}::$key";
+      $ret = Rex::Commands::get( Rex::CMDB::cmdb($cmdb_key) );
+
+      if ( !$ret ) {
+
+        # check in resource
+        if ($Rex::Resource::INSIDE_RES) {
+          $cmdb_key =
+              "${caller_pkg}::"
+            . $Rex::Resource::CURRENT_RES[-1]->display_name
+            . "::$key";
+          $ret = Rex::Commands::get( Rex::CMDB::cmdb($cmdb_key) );
+        }
+      }
+
+      if ( !$ret ) {
+
+        # check in global namespace
+        $ret = Rex::Commands::get( Rex::CMDB::cmdb($key) );
+      }
+    }
+  }
+
+  if ( !$ret ) {
+    $ret = $default;
+  }
+
+  # make the variable also known to templates
+  Rex::Commands::set( $key => $ret );
+
+  return $ret;
+}
+
+1;
+
+=pod
+
+=head1 NAME
+
+Rex::Helper::Rexfile::ParamLookup - A command to manage task parameters.
+
+A command to manage task parameters. Additionally it register the parameters as template values.
+
+This module also looks inside a CMDB (if present) for a valid key.
+
+
+=head1 SYNOPSIS
+
+ task "setup", make {
+   my $var = param_lookup "param_name", "default_value";
+ };
+
+=head1 LOOKUP
+
+First I<param_lookup> checks the task parameters for a valid parameter. If none is found and if a CMDB is used, it will look inside the cmdb.
+
+If your module is named "Rex::NTP" than it will first look if the key "Rex::NTP::param_name" exists. If it doesn't exists it checks for the key "param_name".
+
+=cut

--- a/lib/Rex/Interface/Executor/Default.pm
+++ b/lib/Rex/Interface/Executor/Default.pm
@@ -37,13 +37,20 @@ sub exec {
 
   Rex::Logger::debug( "Executing " . $task->name );
 
-  my $ret;
+  my $wantarray = wantarray;
+
+  my @ret;
   eval {
     my $code = $task->code;
 
     Rex::Hook::run_hook( task => "before_execute", $task->name, @_ );
 
-    $ret = $code->( $opts, $args );
+    if ($wantarray) {
+      @ret = $code->( $opts, $args );
+    }
+    else {
+      $ret[0] = $code->( $opts, $args );
+    }
 
     Rex::Hook::run_hook( task => "after_execute", $task->name, @_ );
   };
@@ -67,7 +74,12 @@ sub exec {
     }
   }
 
-  return $ret;
+  if ($wantarray) {
+    return @ret;
+  }
+  else {
+    return $ret[0];
+  }
 }
 
 1;

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -227,6 +227,7 @@ sub create_task {
 
   $self->{tasks}->{$task_name} = Rex::Task->new(%task_hash);
 
+  return $self->{tasks}->{$task_name};
 }
 
 sub get_tasks {

--- a/t/cmdb.t
+++ b/t/cmdb.t
@@ -69,13 +69,13 @@ set(
 );
 
 my $foo_all = get( cmdb( undef, "foo" ) );
-
 is_deeply(
   $foo_all,
   {
     'ntp'    => [ 'ntp1',            'ntp2' ],
     'newntp' => [ 'ntpdefaultfoo01', 'ntpdefaultfoo02', 'ntp1', 'ntp2' ],
     'dns'    => [ '1.1.1.1',         '2.2.2.2' ],
+    'MyTest::foo::mode' => '0666',
     'vhost' => {
       'name'     => 'foohost',
       'doc_root' => '/var/www'

--- a/t/cmdb/default.yml
+++ b/t/cmdb/default.yml
@@ -11,3 +11,6 @@ users:
   root:
     id: 0
     password: proot
+    
+MyTest::foo::mode: '0666'
+

--- a/t/param_lookup.t
+++ b/t/param_lookup.t
@@ -1,0 +1,28 @@
+
+package main;
+
+use Test::More tests => 2;
+use Rex -base;
+
+task(
+  "test1",
+  sub {
+    my $x = param_lookup("name", "foo");
+    is($x, "foo", "got default value");
+  }
+);
+
+task(
+  "test2",
+  sub {
+    my $x = param_lookup("name", "foo");
+    is($x, "rex", "got parameter value");
+  }
+);
+
+
+
+test1();
+test2({name => "rex"});
+
+

--- a/t/param_lookup.t
+++ b/t/param_lookup.t
@@ -1,14 +1,17 @@
 
 package main;
 
-use Test::More tests => 2;
+use Test::More tests => 4;
 use Rex -base;
 
 task(
   "test1",
   sub {
     my $x = param_lookup("name", "foo");
+    my $tp = template(\'<%= $name %>');
+    
     is($x, "foo", "got default value");
+    is($tp, "foo", "got default value in template");
   }
 );
 
@@ -16,7 +19,10 @@ task(
   "test2",
   sub {
     my $x = param_lookup("name", "foo");
+    my $tp = template(\'<%= $name %>');
+    
     is($x, "rex", "got parameter value");
+    is($tp, "rex", "got parameter value in template");
   }
 );
 

--- a/t/param_lookup_cmdb.t
+++ b/t/param_lookup_cmdb.t
@@ -1,0 +1,28 @@
+
+use Rex -base;
+use Test::More;
+
+use Rex::CMDB;
+use Rex::Commands;
+
+set(
+  cmdb => {
+    type => "YAML",
+    path => "t/cmdb",
+  }
+);
+
+
+use Test::More tests => 1;
+use Rex -base;
+
+task(
+  "test1",
+  sub {
+    my $x = param_lookup("name", "foo");
+    is($x, "defaultname", "got default value");
+  }
+);
+
+test1();
+

--- a/t/param_lookup_resource.t
+++ b/t/param_lookup_resource.t
@@ -1,0 +1,47 @@
+package MyTest;
+
+
+use Rex -base;
+use Rex::Resource::Common;
+use Test::More;
+
+resource "foo", sub {
+  my $test_name = resource_name;
+  my $mode = param_lookup "mode", "0755";
+
+  is($test_name, "testname", "resource name is testname");
+  is($mode, "0666", "got mode 0666");
+};
+
+1;
+
+package main;
+
+use Rex -base;
+use Test::More;
+
+use Rex::CMDB;
+use Rex::Commands;
+
+import MyTest;
+
+set(
+  cmdb => {
+    type => "YAML",
+    path => "t/cmdb",
+  }
+);
+
+
+use Test::More tests => 2;
+use Rex -base;
+
+task(
+  "test1",
+  sub {
+    MyTest::foo("testname");
+  }
+);
+
+test1();
+

--- a/t/template.t
+++ b/t/template.t
@@ -3,6 +3,8 @@ use warnings;
 
 use Test::More tests => 18;
 
+use Rex::Config;
+use Rex::Commands;
 use Rex::Template;
 
 my $t = Rex::Template->new;

--- a/t/template_ng.t
+++ b/t/template_ng.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More tests => 20;
 use Rex::Template::NG;
+use Rex::Commands;
 use Rex::Config;
 
 my $t = Rex::Template::NG->new;


### PR DESCRIPTION
This pr adds the Rex::Ext::ParamLookup module, because this module is the prefered way to handle task parameters.