### PR TITLE
Pkg/Gentoo.pm: Avoid needless rebuilds

### DIFF
--- a/lib/Rex/Pkg/Gentoo.pm
+++ b/lib/Rex/Pkg/Gentoo.pm
@@ -25,7 +25,7 @@ sub new {
   bless( $self, $proto );
 
   $self->{commands} = {
-    install           => 'emerge %s',
+    install           => 'emerge -u %s',
     install_version   => 'emerge =%s-%s',
     update_system     => 'emerge --update --deep --with-bdeps=y --newuse world',
     remove            => 'emerge -C %s',

--- a/lib/Rex/Pkg/Gentoo.pm
+++ b/lib/Rex/Pkg/Gentoo.pm
@@ -25,8 +25,8 @@ sub new {
   bless( $self, $proto );
 
   $self->{commands} = {
-    install           => 'emerge -u %s',
-    install_version   => 'emerge =%s-%s',
+    install           => 'emerge --update %s',
+    install_version   => 'emerge --update =%s-%s',
     update_system     => 'emerge --update --deep --with-bdeps=y --newuse world',
     remove            => 'emerge -C %s',
     update_package_db => 'emerge --sync',


### PR DESCRIPTION
Using emerge -u will install package if absent, update if needed, and noop if already the newest version.
This avoids rebuilding in the last case, where before it always re-built the package.