### PR TITLE
Switch from dzil [autoprereqs] to [PrereqsFromCPANfile]

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,62 @@
+requires 'attributes';
+requires 'base';
+requires 'Carp';
+requires 'constant';
+requires 'Cwd';
+requires 'Data::Dumper';
+requires 'Devel::Caller';
+requires 'Digest::MD5';
+requires 'Exporter';
+requires 'ExtUtils::MakeMaker';
+requires 'Fcntl';
+requires 'File::Basename';
+requires 'File::Spec';
+requires 'File::Spec::Unix';
+requires 'File::Spec::Win32';
+requires 'File::Temp';
+requires 'FindBin';
+requires 'Hash::Merge';
+requires 'HTTP::Request';
+requires 'HTTP::Request::Common';
+requires 'IO::File';
+requires 'IO::Socket';
+requires 'IO::String';
+requires 'IPC::Open3';
+requires 'JSON::XS';
+requires 'List::MoreUtils';
+requires 'List::Util';
+requires 'LWP::UserAgent';
+requires 'MIME::Base64';
+requires 'overload';
+requires 'POSIX';
+requires 'Sort::Naturally';
+requires 'Storable';
+requires 'strict';
+requires 'String::Escape';
+requires 'Symbol';
+requires 'Term::ReadKey';
+requires 'Test::Builder::Module';
+requires 'Test::Deep';
+requires 'Test::More';
+requires 'Test::Pod';
+requires 'Test::UseAllModules';
+requires 'Text::Glob';
+requires 'Text::Wrap';
+requires 'Time::HiRes';
+requires 'UNIVERSAL';
+requires 'URI';
+requires 'URI::QueryParam';
+requires 'vars';
+requires 'warnings';
+requires 'XML::LibXML';
+requires 'XML::Simple';
+requires 'YAML';
+
+if ($^O =~ /MSWin/) {
+    requires 'Net::SSH2';
+}
+else {
+    requires 'IO::Pty';
+    requires 'Net::OpenSSH';
+    requires 'Net::SFTP::Foreign';
+}

--- a/dist.ini
+++ b/dist.ini
@@ -9,7 +9,7 @@ copyright_holder = Jan Gehring
 -bundle = @Basic
 -remove = MakeMaker
 
-[AutoPrereqs]
+[Prereqs::FromCPANfile]
 
 [MakeMaker::Awesome]
 header = die 'Unsupported OS' if ( $^O eq 'MSWin32' && scalar((Win32::GetOSVersion())[1]) < 6 );
@@ -26,14 +26,6 @@ repository.web  = https://github.com/RexOps/Rex
 repository.type = git
 x_twitter       = https://twitter.com/RexOps
 x_IRC           = irc://irc.freenode.net/rex
-
-[OSPrereqs / !~MSWin]
-IO::Pty = 0
-Net::OpenSSH = 0
-Net::SFTP::Foreign = 0
-
-[OSPrereqs / ~MSWin]
-Net::SSH2 = 0
 
 [OurPkgVersion]
 


### PR DESCRIPTION
# The problem

Rex complains Net::SSH2 is not installed when I run it.  This happened
 - because I didn't have Net::OpenSSH installed
 - which happened because `dzil listdeps` doesn't list Net::OpenSSH as dependency for me even though I'm on Ubuntu. 
 - which happened because `[OSPrereqs]` needs `[MakeMaker]` or `[ModuleBuild]` but instead we are using `[MakeMaker::Awesome]`.

# A solution

I'm sure there is more than one solution here.  I'm kind of going with what I know.  I'm a big fan of Carton and Minilla.  My solution is to use Miyagawa's `[Prereqs::FromCPANfile]` module to replace `[OSPrereqs]` and `[Autoprereqs]`.

**Pros**
 - `dzil listdeps` only takes 12 seconds to run instead of 32 seconds.
 - Contributors don't have to install dzil to develop rex.  They can optionally use Carton which is simpler to use and *way* faster to install.  I think its good to reduce barriers.  I've even heard of developers saying they won't contribute to projects which use dzil.  Which I think is kind of extreme, but I get where they are coming from.
 - cpanfile is more flexible and easier to work with than dist.ini.

**Cons**
 - We have to manually maintain dependencies in the cpanfile.  We could run [scan-prereqs-cpanfile](https://metacpan.org/pod/distribution/App-scan_prereqs_cpanfile/script/scan-prereqs-cpanfile) to automatically find dependencies, but there isn't a dzil plugin for it atm that I know of.  And if there was that would make things slower again.