### PR TITLE
Colorize and simplify summary

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -18,6 +18,7 @@ use Cwd qw(getcwd);
 use List::Util qw(max);
 use Text::Wrap;
 use Term::ReadKey;
+use Sort::Naturally;
 
 use Rex;
 use Rex::Args;
@@ -791,7 +792,10 @@ sub summarize {
     "error" );
 
   Rex::Logger::info( "\t$_->{task} failed on $_->{server}", "error" )
-    foreach @failures;
+    foreach sort {
+         ncmp( $a->{task}, $b->{task} )
+      || ncmp( $a->{server}, $b->{server} )
+    } @failures;
 }
 
 1;

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -502,7 +502,7 @@ CHECK_OVERWRITE: {
 
     Rex::TaskList->create()->create_task( "eval-line", @params );
     Rex::Commands::do_task("eval-line");
-    Rex::Logger::info($_) for summarize();
+    summarize();
     CORE::exit(0);
   }
   elsif ( $opts{'M'} ) {
@@ -538,7 +538,7 @@ CHECK_OVERWRITE: {
     @exit_codes = Rex::TaskList->create()->get_exit_codes();
   }
 
-  Rex::Logger::info($_) for summarize();
+  summarize();
 
   #print ">> $$\n";
   #print Dumper(\@exit_codes);
@@ -779,25 +779,24 @@ sub summarize {
   return if $opts{'T'};
 
   my @summary = Rex::TaskList->create()->get_summary();
-  my @msgs    = ("SUMMARY");
+  Rex::Logger::info("SUMMARY");
 
   my @failures = grep { $_->{exit_code} != 0 } @summary;
+
   if ( !@failures ) {
-    push @msgs, "All tasks successful on all hosts";
-    return @msgs;
+    Rex::Logger::info("All tasks successful on all hosts");
+    return;
   }
 
   for my $failure (@failures) {
     my $task   = $failure->{task};
     my $server = $failure->{server};
-    push @msgs, " - $task failed on $server";
+    Rex::Logger::info( " - $task failed on $server", "error" );
   }
 
   my $total      = scalar @summary;
   my $fail_count = scalar @failures;
-  push @msgs, "$fail_count/$total task execution failures";
-
-  return @msgs;
+  Rex::Logger::info( "$fail_count/$total task execution failures", "error" );
 }
 
 1;

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -779,7 +779,6 @@ sub summarize {
   return if $opts{'T'};
 
   my @summary = Rex::TaskList->create()->get_summary();
-  Rex::Logger::info("SUMMARY");
 
   my @failures = grep { $_->{exit_code} != 0 } @summary;
 
@@ -788,11 +787,11 @@ sub summarize {
     return;
   }
 
+  Rex::Logger::info( @failures . " out of " . @summary . " task(s) failed:",
+    "error" );
+
   Rex::Logger::info( "\t$_->{task} failed on $_->{server}", "error" )
     foreach @failures;
-
-  Rex::Logger::info( @failures . " out of " . @summary . " task(s) failed",
-    "error" );
 }
 
 1;

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -788,15 +788,11 @@ sub summarize {
     return;
   }
 
-  for my $failure (@failures) {
-    my $task   = $failure->{task};
-    my $server = $failure->{server};
-    Rex::Logger::info( " - $task failed on $server", "error" );
-  }
+  Rex::Logger::info( "\t$_->{task} failed on $_->{server}", "error" )
+    foreach @failures;
 
-  my $total      = scalar @summary;
-  my $fail_count = scalar @failures;
-  Rex::Logger::info( "$fail_count/$total task execution failures", "error" );
+  Rex::Logger::info( @failures . " out of " . @summary . " task(s) failed",
+    "error" );
 }
 
 1;


### PR DESCRIPTION
This PR makes the summary output more obvious at the end of run by using error level messages if there were failures (making the output red).

Plus it simplifies the summary printing code, and uses a slightly modified wording.

@kablamo, @krimdomu: what do you think?