### PR TITLE
Read STDOUT and STDERR in parallel (fix #756)

### DIFF
--- a/lib/Rex/Interface/Exec/OpenSSH.pm
+++ b/lib/Rex/Interface/Exec/OpenSSH.pm
@@ -14,6 +14,7 @@ use warnings;
 use Rex::Helper::SSH2;
 require Rex::Commands;
 use Rex::Interface::Exec::SSH;
+use IO::Select;
 
 use base qw(Rex::Interface::Exec::SSH);
 
@@ -35,22 +36,30 @@ sub _exec {
   my $tty = !Rex::Config->get_no_tty;
 
   ( undef, $out_fh, $err_fh, $pid ) = $ssh->open3( { tty => $tty }, $exec );
-  while ( my $line = <$out_fh> ) {
-    $line =~ s/(\r?\n)$/\n/;
-    $out .= $line;
-    $self->execute_line_based_operation( $line, $option )
-      && do { kill( 'KILL', $pid ); goto END_OPEN };
 
-  }
-  while ( my $line = <$err_fh> ) {
-    $line =~ s/(\r?\n)$/\n/;
-    $err .= $line;
-    $self->execute_line_based_operation( $line, $option )
-      && do { kill( 'KILL', $pid ); goto END_OPEN };
+  my $selector = IO::Select->new();
+  $selector->add($out_fh);
+  $selector->add($err_fh);
+
+  my $line;
+
+  while ( my @ready = $selector->can_read ) {
+    foreach my $fh (@ready) {
+      my $line = <$fh>;
+      goto END_OPEN unless defined $line;
+      $line =~ s/(\r?\n)$/\n/;
+
+      $out .= $line if $fh == $out_fh;
+      $err .= $line if $fh == $err_fh;
+
+      $self->execute_line_based_operation( $line, $option )
+        && do { kill( 'KILL', $pid ); goto END_OPEN };
+    }
   }
 
 END_OPEN:
   waitpid( $pid, 0 ) or die($!);
   return ( $out, $err );
 }
+
 1;


### PR DESCRIPTION
Draining the pipes for both STDOUT and STDERR line-by-line whenever any of them has readable data, we can prevent filling up their transfer windows (64k on my machine), which in turn causes the process on the other end of the pipes to wait until the filled buffer gets drained. This should fix #756.

Tested manually by me with OpenSSH and Local connection methods, with both enabled and disabled `Rex::Config->set_no_tty`. I'm not sure how to test it programmatically though.