### PR TITLE
Test kvm improvements

### DIFF
--- a/lib/Rex/Box/Base.pm
+++ b/lib/Rex/Box/Base.pm
@@ -37,7 +37,6 @@ BEGIN {
 
 use Time::HiRes qw(tv_interval gettimeofday);
 use File::Basename qw(basename);
-use Data::Dumper;
 
 sub new {
   my $that  = shift;
@@ -196,7 +195,7 @@ Sets the memory of a VM in megabyte.
 
 sub memory {
   my ( $self, $mem ) = @_;
-  $self->{memory} = $mem * 1024; # libvirt wants kilobytes
+  $self->{memory} = $mem;
 }
 
 =head2 network(%option)

--- a/lib/Rex/Box/Base.pm
+++ b/lib/Rex/Box/Base.pm
@@ -196,7 +196,7 @@ Sets the memory of a VM in megabyte.
 
 sub memory {
   my ( $self, $mem ) = @_;
-  $self->{memory} = $mem;
+  $self->{memory} = $mem * 1024; # libvirt wants kilobytes
 }
 
 =head2 network(%option)

--- a/lib/Rex/Box/KVM.pm
+++ b/lib/Rex/Box/KVM.pm
@@ -110,6 +110,17 @@ sub new {
   return $self;
 }
 
+=head2 memory($memory_size)
+
+Sets the memory of a VM in megabyte.
+
+=cut
+
+sub memory {
+  my ( $self, $mem ) = @_;
+  $self->{memory} = $mem * 1024; # libvirt wants kilobytes
+}
+
 sub import_vm {
   my ($self) = @_;
 

--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -89,6 +89,9 @@ sub new {
   $self->{name} ||= $file;
   $self->{redirect_port} = 2222;
 
+  $self->{memory} = 512; # default
+  $self->{cpu}    = 1;   # default
+
   return $self;
 }
 
@@ -101,6 +104,28 @@ The name of the test. A VM called $name will be created for each test. If the VM
 sub name {
   my ( $self, $name ) = @_;
   $self->{name} = $name;
+}
+
+=head2 memory($amount)
+
+The amount of memory the VM should use, in Megabytes.
+
+=cut
+
+sub memory {
+  my ( $self, $memory ) = @_;
+  $self->{memory} = $memory;
+}
+
+=head2 cpu($number)
+
+The number of CPUs the VM should use.
+
+=cut
+
+sub cpu {
+  my ( $self, $cpu ) = @_;
+  $self->{cpu} = $cpu;
 }
 
 =head2 vm_auth(%auth)
@@ -156,6 +181,8 @@ sub run_task {
     $box = shift;
     $box->name( $self->{name} );
     $box->url( $self->{vm} );
+    $box->memory( $self->{memory} );
+    $box->cpus( $self->{cpu} );
 
     $box->network(
       1 => {

--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -89,7 +89,7 @@ sub new {
   $self->{name} ||= $file;
   $self->{redirect_port} = 2222;
 
-  $self->{memory} = 512 * 1024; # default, in kB
+  $self->{memory} = 512;	# default, in MB
   $self->{cpu}    = 1;          # default
 
   return $self;

--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -89,8 +89,8 @@ sub new {
   $self->{name} ||= $file;
   $self->{redirect_port} = 2222;
 
-  $self->{memory} = 512; # default
-  $self->{cpu}    = 1;   # default
+  $self->{memory} = 512 * 1024; # default, in kB
+  $self->{cpu}    = 1;          # default
 
   return $self;
 }

--- a/lib/Rex/Virtualization/LibVirt/import.pm
+++ b/lib/Rex/Virtualization/LibVirt/import.pm
@@ -114,6 +114,8 @@ sub execute {
     ],
     network        => \@network,
     serial_devices => \@serial_devices,
+    memory         => $opt{memory},
+    cpus           => $opt{cpus},
   );
 
   if ( exists $opt{__forward_port} ) {


### PR DESCRIPTION
Wires through memory and cpu setting from Test::Base to Box to Virtualization/libvirt.

Allows setting `$t->cpu( 2 ); $t->memory( 2048 );` in tests to have a VM with larger-than default settings.
Also fixes missing wiring in Rex::Box that didn't pass through values to libvirt, so all machines would end up with default 512MB RAM. 