### PR TITLE
The after hook now runs even if the ssh connection fails.  +tests

### DIFF
--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -178,7 +178,8 @@ sub server {
     }
   }
 
-  if ( ref( $self->{server} ) eq "ARRAY" && scalar( @{ $self->{server} } ) > 0 )
+  if ( ref( $self->{server} ) eq "ARRAY"
+    && scalar( @{ $self->{server} } ) > 0 )
   {
     for my $srv ( @{ $self->{server} } ) {
       if ( ref($srv) eq "CODE" ) {
@@ -770,14 +771,14 @@ sub run {
 
     $self->run_hook( \$server, "before" );
 
-    eval {
-      $self->connect($server);
-      1;
-    } or do {
+    eval { $self->connect($server) };
+    if ($@) {
+      my $error = $@;
       $self->{"__was_authenticated"} = 0;
       $self->run_hook( \$server, "after" );
-      die $@;
-    };
+      die $error;
+    }
+
     push @{ Rex::get_current_connection()->{task} }, $self;
 
     if ( Rex::Args->is_opt("c") ) {

--- a/t/after.t
+++ b/t/after.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+use File::Temp;
+use Rex::Commands;
+
+#$Rex::Logger::debug = 1;
+$::QUIET = 1;
+
+my $fh = File::Temp->new;
+
+timeout 1;
+
+task  foo => "asdfsadfasdf" => sub { return "yo" };
+after foo => sub { unlink $fh->filename; };
+
+Rex::TaskList->run("foo");
+ok ! -e $fh->filename, "after hook runs even when the ssh connection fails";
+


### PR DESCRIPTION
This is a fix for https://github.com/RexOps/Rex/issues/794.  