### PR TITLE
Fix missing Data::Dumper import in Rex::Args

### DIFF
--- a/lib/Rex/Args.pm
+++ b/lib/Rex/Args.pm
@@ -13,6 +13,7 @@ use warnings;
 
 use vars qw(%rex_opts);
 use Rex::Logger;
+use Data::Dumper;
 
 our $CLEANUP = 1;
 


### PR DESCRIPTION
Fixes issue #828.

```text
$ rex -t
No parameter for t
```