### PR TITLE
Refactor Rex::TaskList.  No functional change.

### DIFF
--- a/lib/Rex/Fork/Manager.pm
+++ b/lib/Rex/Fork/Manager.pm
@@ -27,12 +27,9 @@ sub new {
 }
 
 sub add {
-  my ( $self, $coderef, $task, $server ) = @_;
-  my $f = Rex::Fork::Task->new(
-    coderef => $coderef,
-    task    => $task,
-    server  => $server,
-  );
+  my ( $self, $coderef ) = @_;
+
+  my $f = Rex::Fork::Task->new( coderef => $coderef );
 
   push( @{ $self->{'forks'} }, $f );
 

--- a/lib/Rex/Fork/Task.pm
+++ b/lib/Rex/Fork/Task.pm
@@ -12,11 +12,6 @@ use POSIX ":sys_wait_h";
 
 # VERSION
 
-BEGIN {
-  use Rex::Shared::Var;
-  share qw(@SUMMARY);
-}
-
 sub new {
   my $that  = shift;
   my $proto = ref($that) || $that;
@@ -31,20 +26,12 @@ sub new {
 
 sub start {
   my ($self) = @_;
+
   $self->{'running'} = 1;
-  if ( $self->{pid} = fork ) { return $self->{pid}; }
-  else {
-    $self->{chld} = 1;
+  $self->{pid} = fork;
 
-    eval { $self->{coderef}->($self) };
-    my $exit_code = $@ ? ( ( $? >> 8 ) || 1 ) : 0;
-    push @SUMMARY,
-      {
-      task      => $self->{task}->name,
-      server    => $self->{server},
-      exit_code => $exit_code,
-      };
-
+  if ( !$self->{pid} ) {
+    $self->{coderef}->($self);
     $self->{'running'} = 0;
     exit();
   }

--- a/lib/Rex/TaskList/Parallel_ForkManager.pm
+++ b/lib/Rex/TaskList/Parallel_ForkManager.pm
@@ -21,30 +21,16 @@ use Rex::Report;
 use Time::HiRes qw(time);
 
 BEGIN {
-  use Rex::Shared::Var;
-  share qw(@SUMMARY);
-
   use Rex::Require;
   Parallel::ForkManager->require;
 }
 
 use base qw(Rex::TaskList::Base);
 
-sub new {
-  my $that  = shift;
-  my $proto = ref($that) || $that;
-  my $self  = $proto->SUPER::new(@_);
-
-  bless( $self, $proto );
-
-  return $self;
-}
-
 sub run {
   my ( $self, $task, %options ) = @_;
 
-  my $fm        = Parallel::ForkManager->new( $self->get_thread_count($task) );
-  my $task_name = $task->name;
+  my $fm = Parallel::ForkManager->new( $self->get_thread_count($task) );
   my $all_servers = $task->server;
 
   $fm->run_on_finish(
@@ -55,44 +41,18 @@ sub run {
   );
 
   for my $server (@$all_servers) {
-    my $forked_sub = sub {
-      Rex::Logger::init();
-      Rex::Logger::info("Running task $task_name on $server");
-
-      my $run_task     = $task->clone;
-      my $return_value = $run_task->run(
-        $server,
-        in_transaction => $self->{IN_TRANSACTION},
-        params         => $options{params},
-        args           => $options{args},
-      );
-
-      Rex::Logger::debug("Destroying all cached os information");
-      Rex::Logger::shutdown();
-
-      return $return_value;
-    };
+    my $child_coderef = $self->build_child_coderef($task, $server, %options);
 
     if ( $self->{IN_TRANSACTION} ) {
 
       # Inside a transaction -- no forking and no chance to get zombies.
       # This only happens if someone calls do_task() from inside a transaction.
-      # Note the result is not appended to @SUMMARY.
-      $forked_sub->();
+      $child_coderef->();
     }
     else {
       # Not inside a transaction, so lets fork
       $fm->start and next;
-
-      eval { $forked_sub->() };
-      my $exit_code = $@ ? ( ( $? >> 8 ) || 1 ) : 0;
-      push @SUMMARY,
-        {
-        task      => $task_name,
-        server    => $server->to_s,
-        exit_code => $exit_code,
-        };
-
+      $child_coderef->();
       $fm->finish;
     }
   }
@@ -102,23 +62,6 @@ sub run {
   Rex::reconnect_lost_connections();
 
   return $ret;
-}
-
-sub get_exit_codes {
-  my ($self) = @_;
-  return map { $_->{exit_code} } @SUMMARY;
-}
-
-sub get_summary { @SUMMARY }
-
-sub set_in_transaction {
-  my ( $self, $val ) = @_;
-  $self->{IN_TRANSACTION} = $val;
-}
-
-sub is_transaction {
-  my ($self) = @_;
-  return $self->{IN_TRANSACTION};
 }
 
 1;

--- a/lib/Rex/Transaction.pm
+++ b/lib/Rex/Transaction.pm
@@ -100,6 +100,8 @@ sub transaction(&) {
       Rex::pop_connection();
     }
 
+    Rex::TaskList->create()->set_in_transaction(0);
+
     die("Transaction failed. Rollback done.");
   }
 

--- a/t/summary.t
+++ b/t/summary.t
@@ -93,22 +93,19 @@ sub create_tasks {
 
 sub test_summary {
   my (%expected) = @_;
+  my @expected_summary;
 
   $Rex::TaskList::task_list = undef;
 
   create_tasks();
 
-  my @summary;
-  my @expected_summary;
-  my $test_description;
-
   for my $task_name ( Rex::TaskList->create->get_tasks ) {
     Rex::TaskList->run($task_name);
-    @summary = Rex::TaskList->create->get_summary;
+    my @summary = Rex::TaskList->create->get_summary;
 
     push @expected_summary, $expected{$task_name};
 
-    $test_description =
+    my $test_description =
       $expected{$task_name}->{exit_code} == 0
       ? "$task_name succeeded"
       : "$task_name failed";
@@ -119,11 +116,7 @@ sub test_summary {
   my $distributor = Rex::Config->get_distributor;
   no warnings;
 
-  @Rex::Fork::Task::SUMMARY = ()
-    if $distributor eq 'Base';
-
-  @Rex::TaskList::Parallel_ForkManager::SUMMARY = ()
-    if $distributor eq 'Parallel_ForkManager';
+  @Rex::TaskList::Base::SUMMARY = ();
 }
 
 sub parallel_forkmanager_not_installed {


### PR DESCRIPTION
I'm trying to clean up the code to make way for new functionality.  This pr is purely a refactor and there should be no functional changes introduced.  Summary of the changes:

 - Moved `$forked_sub` out of `Rex::TaskList->run()` and into its own function.  
 - This function is now shared between Rex::TaskList::Base and Rex::TaskList::Parallel_ForkManager.
 - Removed functions from Rex::TaskList::Parallel_Forkmanager which are already in Rex::TaskList::Base.