### PR TITLE
Remove purge package action on arch (fix #867)

### DIFF
--- a/lib/Rex/Pkg/Arch.pm
+++ b/lib/Rex/Pkg/Arch.pm
@@ -31,7 +31,6 @@ sub new {
     install_version => 'pacman --noprogressbar --noconfirm --needed -S %s', # makes no sense to specify the package version
     update_system   => 'pacman --noprogressbar --noconfirm -Syu',
     remove          => 'pacman --noprogressbar --noconfirm -Rs %s',
-    purge           => 'pacman --noprogressbar --noconfirm -Rns %s',
     update_package_db => 'pacman --noprogressbar -Sy',
   };
 


### PR DESCRIPTION
It does a slightly different thing than what purge means in rex
currently. We agreed on removing it for initial Arch Linux support with
original author @stingA0815.