### PR TITLE
Fix rendering of false values in templates

### DIFF
--- a/lib/Rex/Template/NG.pm
+++ b/lib/Rex/Template/NG.pm
@@ -177,7 +177,7 @@ sub parse {
 sub __out {
   my ( $self, $str ) = @_;
 
-  $self->{__output__} .= $str || "";
+  $self->{__output__} .= defined $str ? $str : "";
 }
 
 sub _parse {

--- a/t/template_ng.t
+++ b/t/template_ng.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 20;
+use Test::More tests => 21;
 use Rex::Template::NG;
 use Rex::Commands;
 use Rex::Config;
@@ -71,6 +71,12 @@ is( $t->parse( $content, { foo => "baz" } ), "Hello this is baz",
 $content = '<%= join(",", @{ $arr }) %>';
 is( $t->parse( $content, { arr => [qw/one two three/] } ),
   "one,two,three", "local var with array" );
+
+$content = 'This is a false value: <%= $value %>';
+
+$content_ok = 'This is a false value: 0';
+
+is( $t->parse( $content, value => 0 ), $content_ok, 'false value passed' );
 
 #
 # old variable style


### PR DESCRIPTION
Values like `0` were replaced by empty string. This PR fixes that and adds a test too.