### PR TITLE
Let service tests be silent

### DIFF
--- a/lib/Rex/Test/Base/has_service_running.pm
+++ b/lib/Rex/Test/Base/has_service_running.pm
@@ -28,6 +28,7 @@ sub new {
 
 sub run_test {
   my ( $self, $service ) = @_;
+  local $::QUIET = 1;
   $self->ok( service( $service, "status" ) == 1, "Service $service running." );
 }
 

--- a/lib/Rex/Test/Base/has_service_stopped.pm
+++ b/lib/Rex/Test/Base/has_service_stopped.pm
@@ -28,6 +28,7 @@ sub new {
 
 sub run_test {
   my ( $self, $service ) = @_;
+  local $::QUIET = 1;
   $self->ok( service( $service, "status" ) == 0, "Service $service stopped." );
 }
 


### PR DESCRIPTION
It makes the output much more readable. Do I need to restore the value of `$::QUIET` to its original value just before finishing? I think it's not needed, but I might be wrong.