### PR TITLE
Don't confess upon failure of a non-resource (fix #936)

### DIFF
--- a/lib/Rex/Report/Base.pm
+++ b/lib/Rex/Report/Base.pm
@@ -81,7 +81,7 @@ sub report_resource_end {
 sub report_resource_failed {
   my ( $self, %opt ) = @_;
 
-  confess "not inside a resource." if ( !$self->{__current_resource__}->[-1] );
+  return if ( !$self->{__current_resource__}->[-1] );
 
   # update all stacked resources
   for my $res ( @{ $self->{__current_resource__} } ) {


### PR DESCRIPTION
It lets the rest of the task-failure handling code to be run and finish normally, ultimately leading to nicer error output in the summary too.