### PR TITLE
Reopen STDERR after loading Rexfile

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -748,10 +748,10 @@ sub load_rexfile {
     # update %INC so that we can later use it to find the rexfile
     $INC{"__Rexfile__.pm"} = $rexfile;
 
-    if ($stderr) {
-      local *STDERR;
-      open STDERR, ">&", $default_stderr;
+    # reopen STDERR
+    open STDERR, ">&", $default_stderr;
 
+    if ($stderr) {
       my @lines = split( $/, $stderr );
       Rex::Logger::info( "You have some code warnings:", 'warn' );
       Rex::Logger::info( "\t$_", 'warn' ) for @lines;


### PR DESCRIPTION
Keeping STDERR closed after loading Rexfile cause problems in modules that opens STDERR on compile time (for example [DDP](https://metacpan.org/pod/DDP)). Patch just reopen STDERR after Rexfile loading.