### PR TITLE
Fix draining parallel STDOUT and STDERR buffers without newlines

### DIFF
--- a/lib/Rex/Commands/Tail.pm
+++ b/lib/Rex/Commands/Tail.pm
@@ -79,25 +79,10 @@ sub tail {
 
   Rex::Logger::debug("Tailing: $file");
 
-  my $int =
-    Rex::Commands::get("rex_internals") || { read_buffer_size => 1024, };
-
-  my $old_buf_size = $int->{read_buffer_size} || 1024;
-
-  Rex::Commands::set(
-    "rex_internals",
-    {
-      read_buffer_size => 1,
-    }
-  );
-
   run "tail -f $file", continuous_read => sub {
     $callback->(@_);
     },
     ;
-
-  $int->{read_buffer_size} = $old_buf_size;
-  Rex::Commands::set( "rex_internals", $int );
 
 }
 

--- a/lib/Rex/Interface/Exec/IOReader.pm
+++ b/lib/Rex/Interface/Exec/IOReader.pm
@@ -14,8 +14,8 @@ use warnings;
 use IO::Select;
 
 sub io_read {
-  my ( $self, $out_fh, $err_fh, $option ) = @_;
-  my ( $out, $err, $pid );
+  my ( $self, $out_fh, $err_fh, $pid, $option ) = @_;
+  my ( $out, $err, $out_line, $err_line );
 
   my $selector = IO::Select->new();
   $selector->add($out_fh);
@@ -33,39 +33,35 @@ sub io_read {
     foreach my $fh (@ready) {
       my $buf = "";
 
-      my $len = 0;
-      my $concat_buf =
-        ( $fh == $out_fh ? $last_line_stdout : $last_line_stderr );
-
-      while ( $concat_buf !~ m/\n/ms ) {
-        my $read_len = sysread $fh, $buf, $buffer_size;
-        $len += $read_len;
-        $concat_buf .= $buf;
-        if ( !$read_len ) {
-          last;
-        }
-      }
-
+      my $len = sysread $fh, $buf, $buffer_size;
       $selector->remove($fh) unless $len;
 
-      my @lines = split( /(\r?\n)/, $concat_buf );
+      # append buffer to the proper overall output
+      $out .= $buf if $fh == $out_fh;
+      $err .= $buf if $fh == $err_fh;
 
-      $last_line_stdout = pop @lines
-        if ( $fh == $out_fh && $concat_buf !~ m/\n$/ms );
-      $last_line_stderr = pop @lines
-        if ( $fh == $err_fh && $concat_buf !~ m/\n$/ms );
+      if ( $buf =~ /\r?\n/ ) { # buffer has one or more newlines
+        $buf =~ s/\r?\n/\n/;   # normalize EOL characters
+        my @line_chunks = split /\n/, $buf;
 
-      for my $line (@lines) {
-
-        $out .= $line if $fh == $out_fh;
-        $err .= $line if $fh == $err_fh;
-
-        chomp $line;
-
-        if ($line) {
-          $self->execute_line_based_operation( $line, $option )
-            && do { kill( 'KILL', $pid ); goto END_OPEN };
+        foreach my $chunk (@line_chunks) {
+          if ( $fh == $out_fh ) {
+            $out_line .= $chunk;
+            $self->execute_line_based_operation( $out_line, $option )
+              && do { kill( 'KILL', $pid ); goto END_OPEN };
+            $out_line = '';
+          }
+          elsif ( $fh == $err_fh ) {
+            $err_line .= $chunk;
+            $self->execute_line_based_operation( $err_line, $option )
+              && do { kill( 'KILL', $pid ); goto END_OPEN };
+            $err_line = '';
+          }
         }
+      }
+      else { # buffer doesn't have any newlines
+        $out_line .= $buf if $fh == $out_fh;
+        $err_line .= $buf if $fh == $err_fh;
       }
     }
   }
@@ -76,7 +72,7 @@ sub io_read {
       && do { kill( 'KILL', $pid ); goto END_OPEN };
   }
 
-  unless ($out) {
+  unless ($err) {
     $err = $last_line_stderr;
     $self->execute_line_based_operation( $err, $option )
       && do { kill( 'KILL', $pid ); goto END_OPEN };

--- a/lib/Rex/Interface/Exec/IOReader.pm
+++ b/lib/Rex/Interface/Exec/IOReader.pm
@@ -42,7 +42,13 @@ sub io_read {
 
       if ( $buf =~ /\r?\n/ ) { # buffer has one or more newlines
         $buf =~ s/\r?\n/\n/;   # normalize EOL characters
+
         my @line_chunks = split /\n/, $buf;
+
+        my $partial_last_chunk = '';
+        if ( $buf !~ /\n$/ ) { # last chunk is partial
+          $partial_last_chunk = pop @line_chunks;
+        }
 
         foreach my $chunk (@line_chunks) {
           if ( $fh == $out_fh ) {
@@ -58,8 +64,14 @@ sub io_read {
             $err_line = '';
           }
         }
+
+        if ($partial_last_chunk) { # append partial chunk to line if present
+          $out_line .= $partial_last_chunk if $fh == $out_fh;
+          $err_line .= $partial_last_chunk if $fh == $err_fh;
+        }
+
       }
-      else { # buffer doesn't have any newlines
+      else {                       # buffer doesn't have any newlines
         $out_line .= $buf if $fh == $out_fh;
         $err_line .= $buf if $fh == $err_fh;
       }

--- a/lib/Rex/Interface/Exec/Local.pm
+++ b/lib/Rex/Interface/Exec/Local.pm
@@ -123,7 +123,7 @@ sub _exec {
   if ( Rex::Config->get_no_tty ) {
     $pid = open3( $writer, $reader, $error, $cmd );
 
-    ( $out, $err ) = $self->io_read( $reader, $error, $option );
+    ( $out, $err ) = $self->io_read( $reader, $error, $pid, $option );
 
     waitpid( $pid, 0 ) or die($!);
   }

--- a/lib/Rex/Interface/Exec/OpenSSH.pm
+++ b/lib/Rex/Interface/Exec/OpenSSH.pm
@@ -39,7 +39,7 @@ sub _exec {
 
   ( undef, $out_fh, $err_fh, $pid ) = $ssh->open3( { tty => $tty }, $exec );
 
-  ( $out, $err ) = $self->io_read( $out_fh, $err_fh, $option );
+  ( $out, $err ) = $self->io_read( $out_fh, $err_fh, $pid, $option );
 
   waitpid( $pid, 0 ) or die($!);
   if ( $ssh->error || $? ) {

--- a/t/read_buffers.t
+++ b/t/read_buffers.t
@@ -19,8 +19,8 @@ my $exec = Rex::Interface::Exec->create;
 
 my $command =
   ( $^O =~ m/^MSWin/i && Rex::is_local() )
-  ? qq{perl -e "my \$count = 2_000_000; while ( \$count-- ) { if ( \$count % 2) { print STDERR 'x'} else { print STDOUT 'x'} }"}
-  : qq{perl -e 'my \$count = 2_000_000; while ( \$count-- ) { if ( \$count % 2) { print STDERR "x"} else { print STDOUT "x"} }'};
+  ? qq{perl -e "my \$count = 500_000; while ( \$count-- ) { if ( \$count % 2) { print STDERR 'x'} else { print STDOUT 'x'} }"}
+  : qq{perl -e 'my \$count = 500_000; while ( \$count-- ) { if ( \$count % 2) { print STDERR "x"} else { print STDOUT "x"} }'};
 
 alarm 5;
 
@@ -29,9 +29,9 @@ $SIG{ALRM} = sub { BAIL_OUT 'Reading from buffer timed out'; };
 my ( $out, $err ) = $exec->exec($command);
 
 if ( $^O =~ m/^MSWin/i ) {
-  is length($out), 2_000_000, 'output length on Windows';
+  is length($out), 500_000, 'output length on Windows';
 }
 else {
-  is length($out), 1_000_000, 'STDOUT length';
-  is length($err), 1_000_000, 'STDERR length';
+  is length($out), 250_000, 'STDOUT length';
+  is length($err), 250_000, 'STDERR length';
 }

--- a/t/read_buffers.t
+++ b/t/read_buffers.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+use Rex::Interface::Exec;
+
+Rex::Config->set_no_tty(1);
+my $exec = Rex::Interface::Exec->create;
+
+my $command =
+  q{perl -e "my \$count = 2_000_000; while ( \$count-- ) { if ( \$count % 2) { print STDERR 'x'} else { print STDOUT 'x'} }"};
+
+alarm 5;
+
+$SIG{ALRM} = sub { BAIL_OUT 'Reading from buffer timed out'; };
+
+my ( $out, $err ) = $exec->exec($command);
+
+is length($out), 1_000_000, 'STDOUT length';
+is length($err), 1_000_000, 'STDERR length'


### PR DESCRIPTION
While keeping line based operations happy too. (Re)introduced on #952. Fixes #951.

ref #756