### PR TITLE
Increase timeout for read_buffer test (fix #954)

### DIFF
--- a/t/read_buffers.t
+++ b/t/read_buffers.t
@@ -22,11 +22,13 @@ my $command =
   ? qq{perl -e "my \$count = 500_000; while ( \$count-- ) { if ( \$count % 2) { print STDERR 'x'} else { print STDOUT 'x'} }"}
   : qq{perl -e 'my \$count = 500_000; while ( \$count-- ) { if ( \$count % 2) { print STDERR "x"} else { print STDOUT "x"} }'};
 
-alarm 5;
+alarm 30;
 
 $SIG{ALRM} = sub { BAIL_OUT 'Reading from buffer timed out'; };
 
 my ( $out, $err ) = $exec->exec($command);
+
+alarm 0;
 
 if ( $^O =~ m/^MSWin/i ) {
   is length($out), 500_000, 'output length on Windows';


### PR DESCRIPTION
To make slower CPAN Tester boxes happy. Also cancels the `alarm` as early as possible to avoid untimely bailout.