### PR TITLE
Add META.json to CPAN release

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -28,6 +28,8 @@ repository.type = git
 x_twitter       = https://twitter.com/RexOps
 x_IRC           = irc://irc.freenode.net/rex
 
+[MetaJSON]
+
 [OSPrereqs / !~MSWin]
 IO::Pty = 0
 Net::OpenSSH = 0


### PR DESCRIPTION
META.json is a much better communicator of metadata
as META.json by default uses META 2.0 Specification,
which, unlike META.yml + META 1.4, can actually differentiate
between "build" and "test" dependencies.

This means that the dependency graph for people who do
```
cpanm --notest Rex
```
Will be much smaller as a result.

There's naturally a slight amount of risk here if any of your
code inherently relies on dependencies but fails to declare them,
and they just *happened* to be pulled in as children of the "build"
requirements, but become missed as a consequence of being migrated to
children of "test" requirements.