### PR TITLE
Migration of Rex::Commands::Kernel to Resource api

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name = Rex
-version = 1.4.0
-release_status = stable
+version = 1.4.0_01
+release_status = testing
 author = Jan Gehring <jfried@rexify.org>
 license = Apache_2_0
 copyright_holder = Jan Gehring

--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -538,9 +538,6 @@ sub import {
     require Rex::Commands::Gather;
     Rex::Commands::Gather->import( register_in => $register_to );
 
-    require Rex::Commands::Kernel;
-    Rex::Commands::Kernel->import( register_in => $register_to );
-
     require Rex::Commands::Pkg;
     Rex::Commands::Pkg->import( register_in => $register_to );
 
@@ -570,6 +567,14 @@ sub import {
 
     require Rex::Resource::firewall;
     Rex::Resource::firewall->import( register_in => $register_to );
+
+  }
+
+  if ( $what eq "-base" || $what eq "base" ) {
+
+    # only base, no active features
+    require Rex::Commands::Kernel;
+    Rex::Commands::Kernel->import( register_in => $register_to );
   }
 
   if ( $what eq "-feature" || $what eq "feature" ) {
@@ -603,6 +608,18 @@ sub import {
           );
           exit 1;
         }
+      }
+
+      if ( $add =~ m/^\d+\.\d+$/ && $add < 1.5 ) {
+
+        # feature lower than 1.5, so we load all commands module.
+        require Rex::Commands::Kernel;
+        Rex::Commands::Kernel->import( register_in => $register_to );
+      }
+
+      if ( $add =~ m/^\d+\.\d+$/ && $add >= 1.5 ) {
+        require Rex::Resource::kernel;
+        Rex::Resource::kernel->import( register_in => $register_to );
       }
 
       if ( $add =~ m/^\d+\.\d+$/ && $add >= 1.4 ) {

--- a/lib/Rex/Commands/Gather.pm
+++ b/lib/Rex/Commands/Gather.pm
@@ -46,7 +46,7 @@ use vars qw(@EXPORT);
 @EXPORT = qw(operating_system_is network_interfaces memory
   get_operating_system operating_system operating_system_version operating_system_release
   is_freebsd is_netbsd is_openbsd is_redhat is_linux is_bsd is_solaris is_suse is_debian is_mageia is_windows is_alt is_openwrt is_gentoo is_fedora is_arch
-  get_system_information dump_system_information);
+  get_system_information dump_system_information kernelname);
 
 =head2 get_operating_system
 
@@ -76,6 +76,17 @@ Alias for get_operating_system()
 
 sub operating_system {
   return get_operating_system();
+}
+
+=head2 kernelname
+
+Will return the kernel name of the operating system. For example on a linux system it will return I<Linux>.
+
+=cut
+
+sub kernelname {
+  my $host = Rex::Hardware::Host->get();
+  return $host->{kernelname};
 }
 
 =head2 get_system_information

--- a/lib/Rex/Resource.pm
+++ b/lib/Rex/Resource.pm
@@ -68,6 +68,7 @@ sub call {
       name   => $name
     );
 
+    # TODO add dry-run feature
     $provider_o->process;
 
     Rex::Resource::Common::emit( $provider_o->status(),

--- a/lib/Rex/Resource/Provider.pm
+++ b/lib/Rex/Resource/Provider.pm
@@ -1,0 +1,41 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Resource::Provider;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+has name => (
+  is       => 'ro',
+  isa      => 'Str',
+  required => 1,
+);
+
+has config => (
+  is       => 'ro',
+  isa      => 'HashRef',
+  required => 1,
+);
+
+has type => (
+  is       => 'ro',
+  isa      => 'Str',
+  required => 1,
+);
+
+has status => (
+  is      => 'ro',
+  isa     => 'Str',
+  writer  => '_set_status',
+  default => sub { 'unchanged' },
+);
+
+1;

--- a/lib/Rex/Resource/Role/Ensureable.pm
+++ b/lib/Rex/Resource/Role/Ensureable.pm
@@ -1,0 +1,40 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Resource::Role::Ensureable;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moo::Role;
+use List::Util qw(first);
+use Rex::Resource::Common;
+
+requires qw(present absent);
+
+has ensure_options => (
+  is      => 'ro',
+  default => sub {[qw/present absent/]},
+);
+
+sub process {
+  my ($self, $mod_config, $res_type, $res_name) = @_;
+  
+  my $okay = first { $_ eq $mod_config->{ensure} } @{ $self->ensure_options };
+  
+  if(! $okay) {
+    die "Error: $mod_config->{ensure} not a valid option for 'ensure'.";
+  }
+  
+  if ( $self->$okay($mod_config) ) {
+    emit created, "$res_type" . "[$res_name] is now $okay.";
+  }
+
+}
+
+1;

--- a/lib/Rex/Resource/Role/Persistable.pm
+++ b/lib/Rex/Resource/Role/Persistable.pm
@@ -11,17 +11,16 @@ use warnings;
 
 # VERSION
 
-use Moo::Role;
+use Moose::Role;
 
 with qw(Rex::Resource::Role::Ensureable);
 
-has '+ensure_options' => (
+has ensure_options => (
   is      => 'ro',
-  default => sub {[qw/present absent enabled disabled/]},
+  isa     => 'ArrayRef[Str]',
+  default => sub { [qw/present absent enabled disabled/] },
 );
 
-
 requires qw(enabled disabled);
-
 
 1;

--- a/lib/Rex/Resource/Role/Persistable.pm
+++ b/lib/Rex/Resource/Role/Persistable.pm
@@ -1,0 +1,27 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Resource::Role::Persistable;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moo::Role;
+
+with qw(Rex::Resource::Role::Ensureable);
+
+has '+ensure_options' => (
+  is      => 'ro',
+  default => sub {[qw/present absent enabled disabled/]},
+);
+
+
+requires qw(enabled disabled);
+
+
+1;

--- a/lib/Rex/Resource/Role/Testable.pm
+++ b/lib/Rex/Resource/Role/Testable.pm
@@ -1,0 +1,18 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Resource::Role::Testable;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose::Role;
+
+requires qw(test);
+
+1;

--- a/lib/Rex/Resource/kernel.pm
+++ b/lib/Rex/Resource/kernel.pm
@@ -1,0 +1,62 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel - Kernel functions
+
+=head1 DESCRIPTION
+
+With this module it is possible to manage system kernel like loading/unloading of modules.
+
+=head1 SYNOPSIS
+
+ # Load a kernel module
+ task "configure_kernel", "server01", sub {
+   kmod "module-name",
+     entry  => "foo",
+     ensure => "present";
+
+   kmod "module-name",
+     ensure   => "present",
+     provider => "linux";
+ };
+
+=cut
+
+package Rex::Resource::kernel;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Rex -minimal;
+
+use Rex::Commands::Gather;
+use Rex::Resource::Common;
+
+use Carp;
+
+resource "kmod", { export => 1 }, sub {
+  my $mod_name = resource_name;
+
+  my $mod_config = {
+    ensure => param_lookup( "ensure", "present" ),
+    name   => $mod_name,
+  };
+
+  my $provider =
+    param_lookup( "provider",
+    get_resource_provider( kernelname(), operating_system() ) );
+
+  Rex::Logger::debug("Get kernel provider: $provider");
+
+  return ( $provider, $mod_config );
+};
+
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/base.pm
+++ b/lib/Rex/Resource/kernel/Provider/base.pm
@@ -1,0 +1,48 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Resource::kernel::Provider::base;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Helper::Run;
+
+extends qw(Rex::Resource::Provider);
+
+sub test {
+  my ($self) = @_;
+
+  my $mod = $self->name;
+
+  my $count = grep { $_ =~ m/^\Q$mod\E\s+/ } $self->_list_loaded_modules;
+
+  if ( $self->config->{ensure} eq "present" && $count ) {
+    return 1;
+  }
+  elsif ( $self->config->{ensure} eq "enabled" && $self->_is_enabled && $count )
+  {
+    return 1;
+  }
+  elsif ( $self->config->{ensure} eq "absent" && !$count ) {
+    return 1;
+  }
+  elsif ( $self->config->{ensure} eq "disabled"
+    && !$self->_is_enabled
+    && !$count )
+  {
+    return 1;
+  }
+
+  # we have to do something
+  return 0;
+}
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/freebsd.pm
+++ b/lib/Rex/Resource/kernel/Provider/freebsd.pm
@@ -1,0 +1,145 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::freebsd - Kernel functions for FreeBSD
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under FreeBSD.
+
+=head1 PARAMETER
+
+=over 4
+
+=item entry 
+
+Entrypoint for module loading.
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add a line in I</boot/loader.conf>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::freebsd;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Resource::Common;
+use Rex::Helper::Run;
+use Data::Dumper;
+require Rex::Commands::File;
+
+extends qw(Rex::Resource::kernel::Provider::base);
+with qw(Rex::Resource::Role::Persistable);
+
+sub present {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $output = i_run "kldload $mod_name 2>&1";
+  if ( $? != 0 ) {
+    die "Error loading module $mod_name:\n$output.";
+  }
+
+  $self->_set_status(created);
+
+  return 1;
+}
+
+sub absent {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $output = i_run "kldunload $mod_name 2>&1";
+  if ( $? != 0 ) {
+    die "Error unloading module $mod_name:\n$output.";
+  }
+
+  $self->_set_status(removed);
+
+  return 1;
+}
+
+sub enabled {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->present;
+
+  Rex::Commands::File::append_if_no_such_line( "/boot/loader.conf",
+    "${mod_name}_load=\"YES\"", on_change => sub { $changed = 1; } );
+
+  $self->_set_status(created);
+
+  return $changed;
+}
+
+sub disabled {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->absent;
+
+  Rex::Commands::File::delete_lines_according_to(
+    qr{^\Q$mod_name\E_load="YES"$},
+    "/boot/loader.conf", on_change => sub { $changed = 1; } );
+
+  $self->_set_status(removed);
+
+  return $changed;
+}
+
+sub _list_loaded_modules {
+  my ($self) = @_;
+  my @loaded;
+
+  @loaded = i_run "kldstat";
+  if ( $? != 0 ) {
+    die "Can't list loaded modules.\n" . join( "\n", @loaded );
+  }
+
+  chomp @loaded;
+
+  return @loaded;
+}
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux.pm
@@ -1,0 +1,102 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux - Kernel functions for Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under FreeBSD.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Resource::Common;
+use Rex::Helper::Run;
+use Data::Dumper;
+require Rex::Commands::File;
+
+extends qw(Rex::Resource::kernel::Provider::base);
+with qw(Rex::Resource::Role::Ensureable);
+
+sub present {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $output = i_run "modprobe -v $mod_name 2>&1";
+  if ( $? != 0 ) {
+    die "Error loading module $mod_name:\n$output.";
+  }
+
+  $self->_set_status(created);
+
+  return 1;
+}
+
+sub absent {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $output = i_run "rmmod $mod_name 2>&1";
+  if ( $? != 0 ) {
+    die "Error unloading module $mod_name:\n$output.";
+  }
+
+  $self->_set_status(removed);
+
+  return 1;
+}
+
+sub _list_loaded_modules {
+  my ($self) = @_;
+  my @loaded;
+
+  @loaded = i_run "lsmod";
+  if ( $? != 0 ) {
+    die "Can't list loaded modules.\n" . join( "\n", @loaded );
+  }
+
+  chomp @loaded;
+
+  return @loaded;
+}
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/alt.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/alt.pm
@@ -1,0 +1,61 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::alt - Kernel functions for ALT Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under ALT Linux.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::alt;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+extends qw(Rex::Resource::kernel::Provider::linux::systemd);
+with qw(Rex::Resource::Role::Persistable);
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/arch.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/arch.pm
@@ -1,0 +1,61 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::arch - Kernel functions for Arch Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under Arch Linux.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::arch;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+extends qw(Rex::Resource::kernel::Provider::linux::systemd);
+with qw(Rex::Resource::Role::Persistable);
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/debian.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/debian.pm
@@ -1,0 +1,125 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::debian - Kernel functions for Debian GNU/Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under Debian GNU/Linux.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add line to I</etc/modules>. 
+
+If the system has systemd it will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::debian;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Resource::Common;
+use Rex::Helper::Run;
+use Rex::Commands::Gather;
+use Data::Dumper;
+require Rex::Commands::File;
+require Rex::Commands::Fs;
+
+extends qw(Rex::Resource::kernel::Provider::linux::systemd);
+with qw(Rex::Resource::Role::Persistable);
+
+around enabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->present;
+
+  if ( !Rex::Commands::Fs::is_dir("/etc/modules-load.d") ) {
+    Rex::Commands::File::append_if_no_such_line( "/etc/modules", $mod_name,
+      on_change => sub { $changed = 1; } );
+
+    $self->_set_status(created);
+  }
+  else {
+    $changed = $self->$orig();
+  }
+
+  return $changed;
+};
+
+around disabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->present;
+
+  if ( !Rex::Commands::Fs::is_dir("/etc/modules-load.d") ) {
+    Rex::Commands::File::delete_lines_according_to( qr{^\Q$mod_name\E$},
+      "/etc/modules", on_change => sub { $changed = 1; } );
+
+    $self->_set_status(removed);
+  }
+  else {
+    $changed = $self->$orig();
+  }
+
+  return $changed;
+};
+
+around _is_enabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+
+  if ( !Rex::Commands::Fs::is_dir("/etc/modules-load.d") ) {
+    my ($enabled) = grep { m/^\Q$mod_name\E$/ } i_run "cat /etc/modules";
+    return $enabled;
+  }
+  else {
+    return $self->$orig();
+  }
+
+};
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/gentoo.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/gentoo.pm
@@ -1,0 +1,126 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::gentoo - Kernel functions for Gentoo Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under Gentoo Linux.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add line to I</etc/conf.d/modules>. 
+
+If the system has systemd it will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::gentoo;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Resource::Common;
+use Rex::Helper::Run;
+use Rex::Commands::Gather;
+use Data::Dumper;
+require Rex::Commands::File;
+require Rex::Commands::Fs;
+
+extends qw(Rex::Resource::kernel::Provider::linux::systemd);
+with qw(Rex::Resource::Role::Persistable);
+
+around enabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->present;
+
+  if ( !Rex::Commands::Fs::is_dir("/etc/modules-load.d") ) {
+    Rex::Commands::File::append_if_no_such_line( "/etc/conf.d/modules",
+      $mod_name, on_change => sub { $changed = 1; } );
+
+    $self->_set_status(created);
+  }
+  else {
+    $changed = $self->$orig();
+  }
+
+  return $changed;
+};
+
+around disabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->present;
+
+  if ( !Rex::Commands::Fs::is_dir("/etc/modules-load.d") ) {
+    Rex::Commands::File::delete_lines_according_to( qr{^\Q$mod_name\E$},
+      "/etc/conf.d/modules", on_change => sub { $changed = 1; } );
+
+    $self->_set_status(removed);
+  }
+  else {
+    $changed = $self->$orig();
+  }
+
+  return $changed;
+};
+
+around _is_enabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+
+  if ( !Rex::Commands::Fs::is_dir("/etc/modules-load.d") ) {
+    my ($enabled) = grep { m/^\Q$mod_name\E$/ } i_run "cat /etc/conf.d/modules";
+    $self->_set_status(created);
+    return $enabled;
+  }
+  else {
+    return $self->$orig();
+  }
+
+};
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/mageia.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/mageia.pm
@@ -1,0 +1,61 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::mageia - Kernel functions for Mageia Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under Mageia Linux.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::mageia;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+extends qw(Rex::Resource::kernel::Provider::linux::systemd);
+with qw(Rex::Resource::Role::Persistable);
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/openwrt.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/openwrt.pm
@@ -1,0 +1,88 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::openwrt - Kernel functions for OpenWrt Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under OpenWrt Linux.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::openwrt;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Resource::Common;
+use Rex::Helper::Run;
+use Data::Dumper;
+require Rex::Commands::File;
+
+extends qw(Rex::Resource::kernel::Provider::linux);
+with qw(Rex::Resource::Role::Ensureable);
+
+override present => sub {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $output = i_run "insmod $mod_name 2>&1";
+  if ( $? != 0 ) {
+    die "Error loading module $mod_name:\n$output.";
+  }
+
+  $self->_set_status(created);
+
+  return 1;
+};
+
+override absent => sub {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $output = i_run "rmmod $mod_name 2>&1";
+  if ( $? != 0 ) {
+    die "Error unloading module $mod_name:\n$output.";
+  }
+
+  $self->_set_status(removed);
+
+  return 1;
+};
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/redhat.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/redhat.pm
@@ -1,0 +1,158 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::redhat - Kernel functions for Redhat Linux and clones.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under Redhat Linux and clones.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. 
+
+On Redhat 4 and 5 it will add line to I</etc/rc.modules>. 
+
+On Redhat 6 it will add a file into I</etc/sysconfig/modules/>.
+
+If the system has systemd it will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::redhat;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Resource::Common;
+use Rex::Helper::Run;
+use Rex::Commands::Gather;
+use Data::Dumper;
+require Rex::Commands::File;
+require Rex::Commands::Fs;
+
+extends qw(Rex::Resource::kernel::Provider::linux::systemd);
+with qw(Rex::Resource::Role::Persistable);
+
+around enabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->present;
+  my $os_ver  = operating_system_release();
+
+  if ( $os_ver =~ m/^[45]/ ) {
+    Rex::Commands::File::append_if_no_such_line( "/etc/rc.modules", $mod_name,
+      on_change => sub { $changed = 1; } );
+
+    $self->_set_status(created);
+  }
+  elsif ( $os_ver =~ m/^6/ ) {
+    Rex::Commands::File::file(
+      "/etc/sysconfig/modules/$mod_name.modules",
+      ensure    => "present",
+      content   => "#!/bin/sh\nexec /sbin/modprobe $mod_name",
+      user      => "root",
+      group     => "root",
+      mode      => "0700",
+      on_change => sub { $changed = 1; },
+    );
+
+    $self->_set_status(created);
+  }
+  else {
+    $changed = $self->$orig();
+  }
+
+  return $changed;
+};
+
+around disabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->present;
+  my $os_ver  = operating_system_release();
+
+  if ( $os_ver =~ m/^[45]/ ) {
+    Rex::Commands::File::delete_lines_according_to( qr{^\Q$mod_name\E$},
+      "/etc/rc.modules", on_change => sub { $changed = 1; } );
+
+    $self->_set_status(removed);
+  }
+  elsif ( $os_ver =~ m/^6/ ) {
+    Rex::Commands::File::file(
+      "/etc/sysconfig/modules/$mod_name.modules",
+      ensure    => "absent",
+      on_change => sub { $changed = 1; },
+    );
+
+    $self->_set_status(removed);
+  }
+  else {
+    $changed = $self->$orig();
+  }
+
+  return $changed;
+};
+
+around _is_enabled => sub {
+  my ( $orig, $self ) = @_;
+
+  my $mod_name = $self->name;
+  my $os_ver   = operating_system_release();
+
+  if ( $os_ver =~ m/^[45]/ ) {
+    my ($enabled) = grep { m/^\Q$mod_name\E$/ } i_run "cat /etc/rc.modules";
+    return $enabled;
+  }
+  elsif ( $os_ver =~ m/^6/ ) {
+    return Rex::Commands::Fs::is_file(
+      "/etc/sysconfig/modules/$mod_name.modules");
+  }
+  else {
+    return $self->$orig();
+  }
+
+};
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/suse.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/suse.pm
@@ -1,0 +1,61 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::suse - Kernel functions for SuSE Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under SuSE Linux.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::suse;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+extends qw(Rex::Resource::kernel::Provider::linux::systemd);
+with qw(Rex::Resource::Role::Persistable);
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/systemd.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/systemd.pm
@@ -1,0 +1,118 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::systemd - Kernel functions for systemd systems.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under systemd systems. This is a base class for distributions using systemd.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::systemd;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Resource::Common;
+use Rex::Helper::Run;
+use Rex::Commands::Gather;
+use Data::Dumper;
+require Rex::Commands::File;
+require Rex::Commands::Fs;
+
+extends qw(Rex::Resource::kernel::Provider::linux);
+with qw(Rex::Resource::Role::Persistable);
+
+sub enabled {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->present;
+  my $os_ver  = operating_system_release();
+
+  Rex::Commands::File::file(
+    "/etc/modules-load.d/$mod_name.conf",
+    ensure    => "present",
+    content   => $mod_name,
+    user      => "root",
+    group     => "root",
+    mode      => "0600",
+    on_change => sub { $changed = 1; },
+  );
+
+  $self->_set_status(created);
+
+  return $changed;
+}
+
+sub disabled {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $changed = $self->absent;
+  my $os_ver  = operating_system_release();
+
+  Rex::Commands::File::file(
+    "/etc/modules-load.d/$mod_name.conf",
+    ensure    => "absent",
+    on_change => sub { $changed = 1; },
+  );
+
+  $self->_set_status(removed);
+
+  return $changed;
+}
+
+sub _is_enabled {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  return Rex::Commands::Fs::is_file("/etc/modules-load.d/$mod_name.conf");
+}
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/linux/ubuntu.pm
+++ b/lib/Rex/Resource/kernel/Provider/linux/ubuntu.pm
@@ -1,0 +1,63 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::linux::ubuntu - Kernel functions for Ubuntu Linux.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under Ubuntu Linux.
+
+=head1 PARAMETER
+
+=over 4
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add line to I</etc/modules>. 
+
+If the system has systemd it will add a file to I</etc/modules-load.d/>.
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::linux::ubuntu;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+extends qw(Rex::Resource::kernel::Provider::linux::debian);
+with qw(Rex::Resource::Role::Persistable);
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/netbsd.pm
+++ b/lib/Rex/Resource/kernel/Provider/netbsd.pm
@@ -1,0 +1,66 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::netbsd - Kernel functions for NetBSD.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under NetBSD.
+
+=head1 PARAMETER
+
+=over 4
+
+=item entry 
+
+Entrypoint for module loading.
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add a line in **TODO**
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+
+package Rex::Resource::kernel::Provider::linux::netbsd;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+extends qw(Rex::Resource::kernel::Provider::openbsd);
+with qw(Rex::Resource::Role::Ensureable);
+
+1;

--- a/lib/Rex/Resource/kernel/Provider/openbsd.pm
+++ b/lib/Rex/Resource/kernel/Provider/openbsd.pm
@@ -1,0 +1,128 @@
+#
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+=head1 NAME
+
+Rex::Resource::kernel::Provider::openbsd - Kernel functions for OpenBSD.
+
+=head1 DESCRIPTION
+
+These are the parameters that are supported under OpenBSD.
+
+=head1 PARAMETER
+
+=over 4
+
+=item entry 
+
+Entrypoint for module loading.
+
+=item ensure
+
+What state the resource should be ensured. 
+
+Valid options:
+
+=over 4
+
+=item present
+
+Load the module if it is not loaded.
+
+=item absent
+
+Unload the module if module is loaded.
+
+=item enabled
+
+Load the module if it is not loaded and ensure that it is loaded on startup. This option will add a line in **TODO**
+
+=item disabled.
+
+Unload the module if module is loaded and ensure that the module isn't loaded on startup.
+
+=back
+
+=back
+
+=cut
+
+package Rex::Resource::kernel::Provider::openbsd;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Moose;
+
+use Rex::Resource::Common;
+use Rex::Helper::Run;
+use Data::Dumper;
+require Rex::Commands::File;
+
+extends qw(Rex::Resource::kernel::Provider::base);
+with qw(Rex::Resource::Role::Ensureable);
+
+sub present {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $entry = "";
+  if ( $self->config->{entry} ) {
+    $entry = " -e " . $self->config->{entry};
+  }
+
+  my $output = i_run "modload $mod_name $entry 2>&1";
+  if ( $? != 0 ) {
+    die "Error loading module $mod_name:\n$output.";
+  }
+
+  $self->_set_status(created);
+
+  return 1;
+}
+
+sub absent {
+  my ($self) = @_;
+
+  my $mod_name = $self->name;
+
+  my $entry = "";
+  if ( $self->config->{entry} ) {
+    $entry = " -e " . $self->config->{entry};
+  }
+
+  my $output = i_run "modunload $mod_name $entry 2>&1";
+  if ( $? != 0 ) {
+    die "Error unloading module $mod_name:\n$output.";
+  }
+
+  $self->_set_status(removed);
+
+  return 1;
+}
+
+sub _list_loaded_modules {
+  my ($self) = @_;
+  my @loaded;
+
+  #
+  # TODO how to list kernel modules in openbsd and netbsd?
+  #
+
+  @loaded = i_run "kldstat";
+  if ( $? != 0 ) {
+    die "Can't list loaded modules.\n" . join( "\n", @loaded );
+  }
+
+  chomp @loaded;
+
+  return @loaded;
+}
+
+1;

--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -567,7 +567,7 @@ sub merge_auth {
   my ( $self, $server ) = @_;
 
   # merge auth hashs
-  # task auth as precedence
+  # auth info of task has precedence
   my %auth = $server->merge_auth( $self->{auth} );
 
   return \%auth;
@@ -659,7 +659,7 @@ sub connect {
 
   my $profiler = Rex::Profiler->new;
 
-  # task specific auth rules over all
+  # auth rules of task over all
   my %connect_hash = %{$auth};
   $connect_hash{server} = $server;
 


### PR DESCRIPTION
This is the first migrated Commands module to the new resource api. #976 
There are also some general code changes for resource api, this is why not everything is squashed.