### PR TITLE
Fix some perlcritic warnings

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,3 +1,8 @@
+theme = core
 severity = 5
-[BuiltinFunctions::ProhibitStringyEval]
+[-BuiltinFunctions::ProhibitStringyEval]
 allow_includes = 1
+[TestingAndDebugging::ProhibitNoStrict]
+allow = refs vars
+[-Subroutines::ProhibitSubroutinePrototypes]
+[-Subroutines::ProhibitExplicitReturnUndef]

--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ include_dotfiles = 1
 
 [PruneCruft]
 except = \.perltidyrc
+except = \.perlcriticrc
 
 [AutoPrereqs]
 skip = __Rexfile__
@@ -57,4 +58,5 @@ Test::Pod = 0
 [Test::MinimumVersion]
 max_target_perl = 5.8.8
 
-;[Test::Perl::Critic]
+[Test::Perl::Critic]
+critic_config = .perlcriticrc

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -363,7 +363,8 @@ CHECK_OVERWRITE: {
     Rex::Logger::debug( "Loading Rex-Module: " . $opts{'M'} );
     my $mod = $opts{'M'};
     $mod =~ s{::}{/}g;
-    require "$mod.pm";
+    $mod .= ".pm";
+    require $mod;
   }
 
   my $run_list = Rex::RunList->instance;

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -252,7 +252,7 @@ sub run {
 
     if ( $args && ref($args) eq "ARRAY" ) {
       my $quoter = Net::OpenSSH::ShellQuoter->quoter( $exec->shell->name );
-      $cmd = "$cmd " . join( " ", map { $_ = $quoter->quote($_) } @{$args} );
+      $cmd = "$cmd " . join( " ", map { $quoter->quote($_) } @{$args} );
     }
 
     if ( exists $option->{timeout} && $option->{timeout} > 0 ) {

--- a/lib/Rex/Fork/Manager.pm
+++ b/lib/Rex/Fork/Manager.pm
@@ -12,6 +12,7 @@ use warnings;
 # VERSION
 
 use Rex::Fork::Task;
+use Time::HiRes qw(sleep);
 
 sub new {
   my $that  = shift;
@@ -85,7 +86,7 @@ sub wait_for {
 
         return 1 unless $all;
       }
-      select undef, undef, undef, .1;
+      sleep 0.1;
     }
   } until $self->{'running'} == 0;
 }

--- a/lib/Rex/Helper/File/Stat.pm
+++ b/lib/Rex/Helper/File/Stat.pm
@@ -49,6 +49,11 @@ sub S_ISSOCK {
   _fcntl()->S_ISSOCK(@_);
 }
 
+sub S_IMODE {
+  shift;
+  _fcntl()->S_IMODE(@_);
+}
+
 sub _fcntl {
   if ( $^O =~ m/^MSWin/ ) {
     return "Rex::Helper::File::Stat::Win32";

--- a/lib/Rex/Helper/File/Stat/Unix.pm
+++ b/lib/Rex/Helper/File/Stat/Unix.pm
@@ -50,4 +50,9 @@ sub S_ISSOCK {
   Fcntl::S_ISSOCK(@_);
 }
 
+sub S_IMODE {
+  shift;
+  Fcntl::S_IMODE(@_);
+}
+
 1;

--- a/lib/Rex/Helper/File/Stat/Win32.pm
+++ b/lib/Rex/Helper/File/Stat/Win32.pm
@@ -67,4 +67,9 @@ sub S_ISSOCK {
   }
 }
 
+sub S_IMODE {
+  shift;
+  Fcntl::S_IMODE(@_);
+}
+
 1;

--- a/lib/Rex/Helper/Run.pm
+++ b/lib/Rex/Helper/Run.pm
@@ -110,7 +110,7 @@ sub i_exec {
   my $exec   = Rex::Interface::Exec->create;
   my $quoter = Net::OpenSSH::ShellQuoter->quoter( $exec->shell->name );
 
-  my $_cmd_str = "$cmd " . join( " ", map { $_ = $quoter->quote($_) } @args );
+  my $_cmd_str = "$cmd " . join( " ", map { $quoter->quote($_) } @args );
 
   i_run $_cmd_str;
 }
@@ -121,7 +121,7 @@ sub i_exec_nohup {
   my $exec   = Rex::Interface::Exec->create;
   my $quoter = Net::OpenSSH::ShellQuoter->quoter( $exec->shell->name );
 
-  my $_cmd_str = "$cmd " . join( " ", map { $_ = $quoter->quote($_) } @args );
+  my $_cmd_str = "$cmd " . join( " ", map { $quoter->quote($_) } @args );
   i_run $_cmd_str, nohup => 1;
 }
 

--- a/lib/Rex/Interface/Fs/Local.pm
+++ b/lib/Rex/Interface/Fs/Local.pm
@@ -13,6 +13,7 @@ use warnings;
 
 use Rex::Interface::Fs::Base;
 use base qw(Rex::Interface::Fs::Base);
+use Rex::Helper::File::Stat;
 
 sub new {
   my $that  = shift;
@@ -121,7 +122,7 @@ sub stat {
 
     my %ret;
 
-    $ret{'mode'}  = sprintf( "%04o", $mode & 07777 );
+    $ret{'mode'}  = sprintf( "%04o", Rex::Helper::File::Stat->S_IMODE($mode) );
     $ret{'size'}  = $size;
     $ret{'uid'}   = $uid;
     $ret{'gid'}   = $gid;

--- a/lib/Rex/Interface/Fs/OpenSSH.pm
+++ b/lib/Rex/Interface/Fs/OpenSSH.pm
@@ -122,7 +122,7 @@ sub stat {
   if ( !$ret ) { return undef; }
 
   my %ret = (
-    mode  => sprintf( "%04o", $ret->perm & 07777 ),
+    mode  => sprintf( "%04o", Rex::Helper::File::Stat->S_IMODE( $ret->perm ) ),
     size  => $ret->size,
     uid   => $ret->uid,
     gid   => $ret->gid,

--- a/lib/Rex/Interface/Fs/SSH.pm
+++ b/lib/Rex/Interface/Fs/SSH.pm
@@ -138,7 +138,8 @@ sub stat {
 
   if ( !%ret ) { return undef; }
 
-  $ret{'mode'} = sprintf( "%04o", $ret{'mode'} & 07777 );
+  $ret{'mode'} =
+    sprintf( "%04o", Rex::Helper::File::Stat->S_IMODE( $ret{'mode'} ) );
 
   Rex::Commands::profiler()->end("stat: $file");
 

--- a/lib/Rex/Resource/kernel/Provider/netbsd.pm
+++ b/lib/Rex/Resource/kernel/Provider/netbsd.pm
@@ -50,7 +50,7 @@ Unload the module if module is loaded and ensure that the module isn't loaded on
 
 =cut
 
-package Rex::Resource::kernel::Provider::linux::netbsd;
+package Rex::Resource::kernel::Provider::netbsd;
 
 use strict;
 use warnings;

--- a/lib/Rex/Task.pm
+++ b/lib/Rex/Task.pm
@@ -516,6 +516,7 @@ This method is used internally to execute the specified hooks.
 
 sub run_hook {
   my ( $self, $server, $hook, @more_args ) = @_;
+  my $old_server;
 
   for my $code ( @{ $self->{$hook} } ) {
     if ( $hook eq "after" ) { # special case for after hooks
@@ -526,7 +527,7 @@ sub run_hook {
       );
     }
     else {
-      my $old_server = $$server if $server;
+      $old_server = $$server if $server;
       $code->( $$server, $server, { $self->get_opts }, @more_args );
       if ( $old_server && $old_server ne $$server ) {
         $self->{current_server} = $$server;


### PR DESCRIPTION
These commits are fixing 10 perlcritic warnings of various kinds.

They can already be merged after review (but more fixes fill come later, separately).