### PR TITLE
Throw an exception if i_run encounters problems (fix #1016)

### DIFF
--- a/lib/Rex/Helper/Run.pm
+++ b/lib/Rex/Helper/Run.pm
@@ -19,6 +19,7 @@ use Net::OpenSSH::ShellQuoter;
 use Rex::Interface::File;
 use Rex::Interface::Fs;
 use Rex::Helper::Path;
+use Carp;
 require Rex::Commands;
 require Rex::Config;
 
@@ -87,6 +88,15 @@ sub i_run {
 
   $out ||= "";
   $err ||= "";
+
+  if ( $ret_val != 0 ) {
+    Rex::Logger::debug("Error executing `$cmd`: ");
+    Rex::Logger::debug("STDOUT:");
+    Rex::Logger::debug($out);
+    Rex::Logger::debug("STDERR:");
+    Rex::Logger::debug($err);
+    confess("Error during `i_run`");
+  }
 
   if ($code) {
     return &$code( $out, $err );

--- a/lib/Rex/Helper/Run.pm
+++ b/lib/Rex/Helper/Run.pm
@@ -78,10 +78,10 @@ sub i_run {
 
   my $exec = Rex::Interface::Exec->create;
   my ( $out, $err ) = $exec->exec( $cmd, $path, $option );
+  my $ret_val = $?;
+
   chomp $out if $out;
   chomp $err if $err;
-
-  my $ret_val = $?;
 
   $Rex::Commands::Run::LAST_OUTPUT = [ $out, $err ];
 

--- a/lib/Rex/Interface/Exec/Base.pm
+++ b/lib/Rex/Interface/Exec/Base.pm
@@ -57,9 +57,11 @@ sub can_run {
   $check_with_command ||= "which";
 
   for my $command ( @{$commands_to_check} ) {
-    my @output = Rex::Helper::Run::i_run "$check_with_command $command";
+    my @output;
 
-    next if ( $? != 0 );
+    eval { @output = Rex::Helper::Run::i_run "$check_with_command $command"; };
+
+    next if ($@);
     next if ( grep { /^no $command in/ } @output ); # for solaris
 
     return $output[0];

--- a/lib/Rex/Inventory/DMIDecode.pm
+++ b/lib/Rex/Inventory/DMIDecode.pm
@@ -132,7 +132,12 @@ sub _read_dmidecode {
       return;
     }
 
-    @lines = i_run "dmidecode";
+    eval { @lines = i_run "dmidecode"; };
+
+    if ($@) {
+      Rex::Logger::debug("Error running dmidecode");
+      return;
+    }
   }
   chomp @lines;
 

--- a/lib/Rex/Service.pm
+++ b/lib/Rex/Service.pm
@@ -30,8 +30,8 @@ sub get {
 
   my $operatingsystem = Rex::Hardware::Host->get_operating_system();
 
-  i_run "systemctl --no-pager > /dev/null";
-  my $can_run_systemctl = $? == 0 ? 1 : 0;
+  eval { i_run "systemctl --no-pager > /dev/null"; };
+  my $can_run_systemctl = defined $@ ? 0 : 1;
 
   my $class;
 


### PR DESCRIPTION
This is the right thing to do, but this most probably will break code where `i_run` was used to mask execution failures while using `exec_autodie`. I believe that is a misuse, and proper error checking should be implemented in those cases instead.

This might expose some corner cases we missed earlier, but at least now we can catch the exception and handle them properly. And more importantly, some execution glitches (like around service handling in some cases) can't go undetected.
I already fixed some of those problematic points, like in `can_run()`, dmidecode, and for systemctl detection (see commits). I quickly went through all `i_run` usage, but didn't found anything else obvious at first glance. Plus, most of the internal `i_run` usage were run up until the previous release, and it didn't really died unexpectedly even with `exec_autodie` in effect.

That being said, feel free to report any breakage, so we can include a fix for that.
