### PR TITLE
Backport task existence check for do_task from #1010 (fix #992)

### DIFF
--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -691,16 +691,11 @@ sub do_task {
   my $task   = shift;
   my $params = shift;
 
-  if ( ref($task) eq "ARRAY" ) {
-    for my $t ( @{$task} ) {
-      Rex::TaskList->create()->get_task($t) || die "Task $t not found.";
-      Rex::TaskList->run( $t, ( $params ? ( params => $params ) : () ) );
-    }
-  }
-  else {
-    Rex::TaskList->create()->get_task($task) || die "Task $task not found.";
-    return Rex::TaskList->run( $task,
-      ( $params ? ( params => $params ) : () ) );
+  my @tasks = ref($task) eq "ARRAY" ? @{$task} : ($task);
+
+  foreach (@tasks) {
+    Rex::TaskList->create()->get_task($_) || die "Task $_ not found.";
+    Rex::TaskList->run( $_, ( $params ? ( params => $params ) : () ) );
   }
 }
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -693,10 +693,12 @@ sub do_task {
 
   if ( ref($task) eq "ARRAY" ) {
     for my $t ( @{$task} ) {
+      Rex::TaskList->create()->get_task($t) || die "Task $t not found.";
       Rex::TaskList->run( $t, ( $params ? ( params => $params ) : () ) );
     }
   }
   else {
+    Rex::TaskList->create()->get_task($task) || die "Task $task not found.";
     return Rex::TaskList->run( $task,
       ( $params ? ( params => $params ) : () ) );
   }

--- a/t/do_task.t
+++ b/t/do_task.t
@@ -1,0 +1,25 @@
+use strict;
+use warnings;
+
+use Rex::Commands;
+use Test::More tests => 4;
+
+eval { Rex::Commands::do_task("non_existing_task"); };
+my $result = $@;
+
+isnt( $result, undef, 'exception for do_task non-existing task' );
+like(
+  $result,
+  qr/Task non_existing_task not found\./,
+  'do_task non-existing task'
+);
+
+eval { Rex::Commands::do_task( ["non_existing_task"] ); };
+$result = $@;
+
+isnt( $result, undef, 'exception for do_task non-existing task as arrayref' );
+like(
+  $result,
+  qr/Task non_existing_task not found\./,
+  'do_task non-existing task as arrayref'
+);


### PR DESCRIPTION
As #1010 is quite a huge change, I backported the parts related to fixing #992 into this PR.

I also added some quick tests for proper exception messages for `do_task()`, and refactored it to avoid duplication.