### PR TITLE
Clean up connection-time debug messages

### DIFF
--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -38,8 +38,6 @@ sub connect {
     $port, $timeout, $auth_type,   $is_sudo
   );
 
-  Rex::Logger::debug("Using Net::OpenSSH for connection");
-
   $user        = $option{user};
   $pass        = $option{password};
   $server      = $option{server};
@@ -50,15 +48,14 @@ sub connect {
   $auth_type   = $option{auth_type};
   $is_sudo     = $option{sudo};
 
-  $self->{is_sudo} = $is_sudo;
-
+  $self->{server}        = $server;
+  $self->{is_sudo}       = $is_sudo;
   $self->{__auth_info__} = \%option;
 
+  Rex::Logger::debug("Using Net::OpenSSH for connection");
   Rex::Logger::debug( "Using user: " . $user );
   Rex::Logger::debug(
     Rex::Logger::masq( "Using password: %s", ( $pass || "" ) ) );
-
-  $self->{server} = $server;
 
   my $proxy_command = Rex::Config->get_proxy_command( server => $server );
 

--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -54,8 +54,8 @@ sub connect {
 
   Rex::Logger::debug("Using Net::OpenSSH for connection");
   Rex::Logger::debug( "Using user: " . $user );
-  Rex::Logger::debug(
-    Rex::Logger::masq( "Using password: %s", ( $pass || "" ) ) );
+  Rex::Logger::debug( Rex::Logger::masq( "Using password: %s", $pass ) )
+    if defined $pass;
 
   my $proxy_command = Rex::Config->get_proxy_command( server => $server );
 

--- a/lib/Rex/Interface/Connection/SSH.pm
+++ b/lib/Rex/Interface/Connection/SSH.pm
@@ -38,8 +38,6 @@ sub connect {
     $port, $timeout, $auth_type,   $is_sudo
   );
 
-  Rex::Logger::debug("Using Net::SSH2 for connection");
-
   $user        = $option{user};
   $pass        = $option{password};
   $server      = $option{server};
@@ -50,15 +48,14 @@ sub connect {
   $auth_type   = $option{auth_type};
   $is_sudo     = $option{sudo};
 
-  $self->{is_sudo} = $is_sudo;
-
+  $self->{server}        = $server;
+  $self->{is_sudo}       = $is_sudo;
   $self->{__auth_info__} = \%option;
 
+  Rex::Logger::debug("Using Net::SSH2 for connection");
   Rex::Logger::debug( "Using user: " . $user );
   Rex::Logger::debug(
     Rex::Logger::masq( "Using password: %s", ( $pass || "" ) ) );
-
-  $self->{server} = $server;
 
   $self->{ssh} = Net::SSH2->new;
 

--- a/lib/Rex/Interface/Connection/SSH.pm
+++ b/lib/Rex/Interface/Connection/SSH.pm
@@ -54,8 +54,8 @@ sub connect {
 
   Rex::Logger::debug("Using Net::SSH2 for connection");
   Rex::Logger::debug( "Using user: " . $user );
-  Rex::Logger::debug(
-    Rex::Logger::masq( "Using password: %s", ( $pass || "" ) ) );
+  Rex::Logger::debug( Rex::Logger::masq( "Using password: %s", $pass ) )
+    if defined $pass;
 
   $self->{ssh} = Net::SSH2->new;
 


### PR DESCRIPTION
- avoid logging undefined host during connection
- only log masked password if one is being used