### PR TITLE
Report all packages, even with `bulk_install` (fix #838)

### DIFF
--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -122,6 +122,9 @@ sub pkg {
 
   foreach my $candidate ( reverse sort @package_list ) {
     if ( my ($change) = grep { $candidate eq $_->{name} } @modifications ) {
+      if ( exists $option{on_change} && ref $option{on_change} eq "CODE" ) {
+        $option{on_change}->( $change->{name}, %option );
+      }
 
       my ($old_package) = grep { $_->{name} eq $change->{name} } @old_installed;
       my ($new_package) = grep { $_->{name} eq $change->{name} } @new_installed;
@@ -130,10 +133,6 @@ sub pkg {
         && $new_package
         && $old_package->{version} ne $new_package->{version} )
       {
-        if ( exists $option{on_change} && ref $option{on_change} eq "CODE" ) {
-          $option{on_change}->( $change->{name}, %option );
-        }
-
         Rex::get_current_connection()->{reporter}->report(
           changed => 1,
           message =>
@@ -146,20 +145,12 @@ sub pkg {
           message =>
             "Package $change->{name} installed in version $new_package->{version}"
         );
-
-        if ( exists $option{on_change} && ref $option{on_change} eq "CODE" ) {
-          $option{on_change}->( $change->{name}, %option );
-        }
       }
       elsif ( $old_package && !$new_package ) {
         Rex::get_current_connection()->{reporter}->report(
           changed => 1,
           message => "Package $change->{name} removed."
         );
-
-        if ( exists $option{on_change} && ref $option{on_change} eq "CODE" ) {
-          $option{on_change}->( $change->{name}, %option );
-        }
       }
     }
     else {

--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -82,13 +82,6 @@ Use this resource to install or update a package. This resource will generate re
 sub pkg {
   my ( $res_package, %option ) = @_;
 
-  if ( ref $res_package eq "ARRAY" ) {
-    for my $p ( @{$res_package} ) {
-      &pkg( $p, %option );
-    }
-    return;
-  }
-
   my $package = $res_package;
 
   if ( exists $option{package} ) {

--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -121,35 +121,31 @@ sub pkg {
     $pkg->diff_package_list( \@old_installed, \@new_installed );
 
   foreach my $candidate ( reverse sort @package_list ) {
+    my %report_args = ( changed => 0 );
+
     if ( my ($change) = grep { $candidate eq $_->{name} } @modifications ) {
+      $report_args{changed} = 1;
       if ( exists $option{on_change} && ref $option{on_change} eq "CODE" ) {
         $option{on_change}->( $change->{name}, %option );
       }
 
       my ($old_package) = grep { $_->{name} eq $change->{name} } @old_installed;
       my ($new_package) = grep { $_->{name} eq $change->{name} } @new_installed;
-      my $message;
 
       if ( $change->{action} eq "updated" ) {
-        $message =
+        $report_args{message} =
           "Package $change->{name} updated $old_package->{version} -> $new_package->{version}";
       }
       elsif ( $change->{action} eq "installed" ) {
-        $message =
+        $report_args{message} =
           "Package $change->{name} installed in version $new_package->{version}";
       }
       elsif ( $change->{action} eq "removed" ) {
-        $message = "Package $change->{name} removed.";
+        $report_args{message} = "Package $change->{name} removed.";
       }
+    }
 
-      Rex::get_current_connection()->{reporter}->report(
-        changed => 1,
-        message => $message,
-      );
-    }
-    else {
-      Rex::get_current_connection()->{reporter}->report( changed => 0, );
-    }
+    Rex::get_current_connection()->{reporter}->report(%report_args);
 
     Rex::get_current_connection()->{reporter}
       ->report_resource_end( type => "pkg", name => $candidate );

--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -129,24 +129,21 @@ sub pkg {
       my ($old_package) = grep { $_->{name} eq $change->{name} } @old_installed;
       my ($new_package) = grep { $_->{name} eq $change->{name} } @new_installed;
 
-      if ( $old_package
-        && $new_package
-        && $old_package->{version} ne $new_package->{version} )
-      {
+      if ( $change->{action} eq "updated" ) {
         Rex::get_current_connection()->{reporter}->report(
           changed => 1,
           message =>
             "Package $change->{name} updated $old_package->{version} -> $new_package->{version}"
         );
       }
-      elsif ( !$old_package && $new_package ) {
+      elsif ( $change->{action} eq "installed" ) {
         Rex::get_current_connection()->{reporter}->report(
           changed => 1,
           message =>
             "Package $change->{name} installed in version $new_package->{version}"
         );
       }
-      elsif ( $old_package && !$new_package ) {
+      elsif ( $change->{action} eq "removed" ) {
         Rex::get_current_connection()->{reporter}->report(
           changed => 1,
           message => "Package $change->{name} removed."

--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -128,27 +128,24 @@ sub pkg {
 
       my ($old_package) = grep { $_->{name} eq $change->{name} } @old_installed;
       my ($new_package) = grep { $_->{name} eq $change->{name} } @new_installed;
+      my $message;
 
       if ( $change->{action} eq "updated" ) {
-        Rex::get_current_connection()->{reporter}->report(
-          changed => 1,
-          message =>
-            "Package $change->{name} updated $old_package->{version} -> $new_package->{version}"
-        );
+        $message =
+          "Package $change->{name} updated $old_package->{version} -> $new_package->{version}";
       }
       elsif ( $change->{action} eq "installed" ) {
-        Rex::get_current_connection()->{reporter}->report(
-          changed => 1,
-          message =>
-            "Package $change->{name} installed in version $new_package->{version}"
-        );
+        $message =
+          "Package $change->{name} installed in version $new_package->{version}";
       }
       elsif ( $change->{action} eq "removed" ) {
-        Rex::get_current_connection()->{reporter}->report(
-          changed => 1,
-          message => "Package $change->{name} removed."
-        );
+        $message = "Package $change->{name} removed.";
       }
+
+      Rex::get_current_connection()->{reporter}->report(
+        changed => 1,
+        message => $message,
+      );
     }
     else {
       Rex::get_current_connection()->{reporter}->report( changed => 0, );


### PR DESCRIPTION
This PR reports every change (or non-change) for all packages that were passed to `pkg`.
It even works with `bulk_install`, which is now re-enabled.

I have a variation that creates only a single entry for all packages, with comma separated package names, and then reports all change (or non-change) inside that single report entry. I believe the variation presented here is more useful, but I'm up to fine tune.

On top of that, there are a bunch of refactoring commits to make it simpler to understand.