### PR TITLE
make some optional dependencies to hard dependencies

### DIFF
--- a/lib/Rex/Cloud/Amazon.pm
+++ b/lib/Rex/Cloud/Amazon.pm
@@ -19,16 +19,15 @@ use Rex::Logger;
 use Rex::Cloud::Base;
 use AWS::Signature4;
 use HTTP::Request::Common;
-
+use Digest::HMAC_SHA1;
 use base qw(Rex::Cloud::Base);
+use LWP::UserAgent;
+use XML::Simple;
 
 BEGIN {
   use Rex::Require;
-  LWP::UserAgent->use;
-  Digest::HMAC_SHA1->use;
   HTTP::Date->use(qw(time2isoz));
   MIME::Base64->use(qw(encode_base64 decode_base64));
-  XML::Simple->require;
 }
 
 use Data::Dumper;

--- a/lib/Rex/Group/Lookup/XML.pm
+++ b/lib/Rex/Group/Lookup/XML.pm
@@ -33,7 +33,7 @@ use Rex -base;
 require Exporter;
 use base qw(Exporter);
 use vars qw(@EXPORT);
-XML::LibXML->require;
+use XML::LibXML;
 
 @EXPORT = qw(groups_xml);
 

--- a/lib/Rex/Helper/INI.pm
+++ b/lib/Rex/Helper/INI.pm
@@ -8,10 +8,9 @@ package Rex::Helper::INI;
 
 use strict;
 use warnings;
+use String::Escape qw/string2hash/;
 
 # VERSION
-
-BEGIN { String::Escape->use('string2hash'); }
 
 sub parse {
   my (@lines) = @_;

--- a/lib/Rex/TaskList/Parallel_ForkManager.pm
+++ b/lib/Rex/TaskList/Parallel_ForkManager.pm
@@ -19,11 +19,7 @@ use Rex::Interface::Executor;
 use Rex::TaskList::Base;
 use Rex::Report;
 use Time::HiRes qw(time);
-
-BEGIN {
-  use Rex::Require;
-  Parallel::ForkManager->require;
-}
+use Parallel::ForkManager;
 
 use base qw(Rex::TaskList::Base);
 

--- a/t/base.t
+++ b/t/base.t
@@ -6,14 +6,10 @@ use Test::UseAllModules;
 
 BEGIN {
   all_uses_ok except => qw(
-    Rex::Cloud::Amazon
     Rex::Commands::DB
     Rex::Commands::Rsync
     Rex::Group::Lookup::DBI
-    Rex::Group::Lookup::INI
-    Rex::Group::Lookup::XML
     Rex::Helper::DBI
-    Rex::Helper::INI
     Rex::Interface::Connection::OpenSSH
     Rex::Interface::Connection::SSH
     Rex::Interface::Exec::OpenSSH
@@ -24,6 +20,5 @@ BEGIN {
     Rex::Interface::Fs::SSH
     Rex::Output
     Rex::Output::JUnit
-    Rex::TaskList::Parallel_ForkManager
   );
 }

--- a/t/ini.t
+++ b/t/ini.t
@@ -3,108 +3,101 @@ use warnings;
 
 use Test::More tests => 34;
 
-SKIP: {
+require Rex::Group::Lookup::INI;
+Rex::Group::Lookup::INI->import;
 
-  eval { require String::Escape };
+use Rex::Group;
+use Rex::Commands;
+use Rex::Commands::Task;
 
-  skip 'Missing String::Escape for INI file support.', 34 if $@;
+no warnings 'once';
 
-  require Rex::Group::Lookup::INI;
-  Rex::Group::Lookup::INI->import;
+$::QUIET = 1;
 
-  use Rex::Group;
-  use Rex::Commands;
-  use Rex::Commands::Task;
+groups_file("t/test.ini");
 
-  no warnings 'once';
+my %groups = Rex::Group->get_groups;
 
-  $::QUIET = 1;
+is( scalar( @{ $groups{frontends} } ), 5, "frontends 5 servers" );
+is( scalar( @{ $groups{backends} } ),  3, "backends 3 servers" );
+ok( grep { $_ eq "fe01" } @{ $groups{frontends} }, "got fe01" );
+ok( grep { $_ eq "fe02" } @{ $groups{frontends} }, "got fe02" );
+ok( grep { $_ eq "fe03" } @{ $groups{frontends} }, "got fe03" );
+ok( grep { $_ eq "fe04" } @{ $groups{frontends} }, "got fe04" );
+ok( grep { $_ eq "fe05" } @{ $groups{frontends} }, "got fe05" );
 
-  groups_file("t/test.ini");
+ok( grep { $_ eq "be01" } @{ $groups{backends} }, "got be01" );
+ok( grep { $_ eq "be02" } @{ $groups{backends} }, "got be02" );
+ok( grep { $_ eq "be04" } @{ $groups{backends} }, "got be04" );
 
-  my %groups = Rex::Group->get_groups;
+ok( grep { $_ eq "db[01..02]" } @{ $groups{db} }, "got db[01..02]" );
 
-  is( scalar( @{ $groups{frontends} } ), 5, "frontends 5 servers" );
-  is( scalar( @{ $groups{backends} } ),  3, "backends 3 servers" );
-  ok( grep { $_ eq "fe01" } @{ $groups{frontends} }, "got fe01" );
-  ok( grep { $_ eq "fe02" } @{ $groups{frontends} }, "got fe02" );
-  ok( grep { $_ eq "fe03" } @{ $groups{frontends} }, "got fe03" );
-  ok( grep { $_ eq "fe04" } @{ $groups{frontends} }, "got fe04" );
-  ok( grep { $_ eq "fe05" } @{ $groups{frontends} }, "got fe05" );
+ok( grep { $_ eq "[01..02]-cassandra" } @{ $groups{cassandra} },
+  "got [01..02]-cassandra]" );
 
-  ok( grep { $_ eq "be01" } @{ $groups{backends} }, "got be01" );
-  ok( grep { $_ eq "be02" } @{ $groups{backends} }, "got be02" );
-  ok( grep { $_ eq "be04" } @{ $groups{backends} }, "got be04" );
+ok( grep { $_ eq "[111..133/11]-voldemort" } @{ $groups{voldemort} },
+  "got [111..133/11]-voldemort" );
 
-  ok( grep { $_ eq "db[01..02]" } @{ $groups{db} }, "got db[01..02]" );
+ok( grep { $_ eq "[1,3,7,01]-kiokudb" } @{ $groups{kiokudb} },
+  "got [1,3,7,01]-kiokudb" );
 
-  ok( grep { $_ eq "[01..02]-cassandra" } @{ $groups{cassandra} },
-    "got [01..02]-cassandra]" );
+ok( grep { $_ eq "[1..3,5,9..21/3]-riak" } @{ $groups{riak} },
+  "got [1..3,5,9..21/3]-riak" );
 
-  ok( grep { $_ eq "[111..133/11]-voldemort" } @{ $groups{voldemort} },
-    "got [111..133/11]-voldemort" );
+ok( grep { $_ eq "redis01" } @{ $groups{redis} }, "got redis01" );
+ok( grep { $_ eq "redis02" } @{ $groups{redis} }, "got redis02" );
+ok( grep { $_ eq "be01" } @{ $groups{redis} },    "got be01 in redis" );
+ok( grep { $_ eq "be02" } @{ $groups{redis} },    "got be01 in redis" );
+ok( grep { $_ eq "be04" } @{ $groups{redis} },    "got be01 in redis" );
 
-  ok( grep { $_ eq "[1,3,7,01]-kiokudb" } @{ $groups{kiokudb} },
-    "got [1,3,7,01]-kiokudb" );
+ok( grep { $_ eq "redis01" } @{ $groups{memcache} },
+  "got redis01 in memcache" );
+ok( grep { $_ eq "redis02" } @{ $groups{memcache} },
+  "got redis02 in memcache" );
+ok( grep { $_ eq "be01" } @{ $groups{memcache} },
+  "got be01 in redis in memcache" );
+ok( grep { $_ eq "be02" } @{ $groups{memcache} },
+  "got be01 in redis in memcache" );
+ok( grep { $_ eq "be04" } @{ $groups{memcache} },
+  "got be01 in redis in memcache" );
+ok( grep { $_ eq "memcache01" } @{ $groups{memcache} }, "got memcache01" );
+ok( grep { $_ eq "memcache02" } @{ $groups{memcache} }, "got memcache02" );
 
-  ok( grep { $_ eq "[1..3,5,9..21/3]-riak" } @{ $groups{riak} },
-    "got [1..3,5,9..21/3]-riak" );
+delete $ENV{REX_USER};
 
-  ok( grep { $_ eq "redis01" } @{ $groups{redis} }, "got redis01" );
-  ok( grep { $_ eq "redis02" } @{ $groups{redis} }, "got redis02" );
-  ok( grep { $_ eq "be01" } @{ $groups{redis} },    "got be01 in redis" );
-  ok( grep { $_ eq "be02" } @{ $groups{redis} },    "got be01 in redis" );
-  ok( grep { $_ eq "be04" } @{ $groups{redis} },    "got be01 in redis" );
+user("krimdomu");
+password("foo");
+pass_auth();
 
-  ok( grep { $_ eq "redis01" } @{ $groups{memcache} },
-    "got redis01 in memcache" );
-  ok( grep { $_ eq "redis02" } @{ $groups{memcache} },
-    "got redis02 in memcache" );
-  ok( grep { $_ eq "be01" } @{ $groups{memcache} },
-    "got be01 in redis in memcache" );
-  ok( grep { $_ eq "be02" } @{ $groups{memcache} },
-    "got be01 in redis in memcache" );
-  ok( grep { $_ eq "be04" } @{ $groups{memcache} },
-    "got be01 in redis in memcache" );
-  ok( grep { $_ eq "memcache01" } @{ $groups{memcache} }, "got memcache01" );
-  ok( grep { $_ eq "memcache02" } @{ $groups{memcache} }, "got memcache02" );
+my ($server) = grep { $_ eq "memcache02" } @{ $groups{memcache} };
 
-  delete $ENV{REX_USER};
+no_ssh(
+  task(
+    "mytask", $server,
+    sub {
+      is( connection()->server->option("services"),
+        "apache,memcache", "got services inside task" );
+    }
+  )
+);
 
-  user("krimdomu");
-  password("foo");
-  pass_auth();
+my $task = Rex::TaskList->create()->get_task("mytask");
 
-  my ($server) = grep { $_ eq "memcache02" } @{ $groups{memcache} };
+my $auth = $task->merge_auth($server);
+is( $auth->{user},     "krimdomu", "got krimdomu user for memcache02" );
+is( $auth->{password}, "foo",      "got foo password for memcache02" );
 
-  no_ssh(
-    task(
-      "mytask", $server,
-      sub {
-        is( connection()->server->option("services"),
-          "apache,memcache", "got services inside task" );
-      }
-    )
-  );
+Rex::Config->set_use_server_auth(1);
 
-  my $task = Rex::TaskList->create()->get_task("mytask");
+$auth = $task->merge_auth($server);
+is( $auth->{user},     "root",   "got root user for memcache02" );
+is( $auth->{password}, "foob4r", "got foob4r password for memcache02" );
+ok( $auth->{sudo}, "got sudo for memcache02" );
 
-  my $auth = $task->merge_auth($server);
-  is( $auth->{user},     "krimdomu", "got krimdomu user for memcache02" );
-  is( $auth->{password}, "foo",      "got foo password for memcache02" );
+is( $server->option("services"), "apache,memcache", "got services of server" );
 
-  Rex::Config->set_use_server_auth(1);
+# don't fork the task
+Rex::TaskList->create()->set_in_transaction(1);
+Rex::Commands::Task::do_task("mytask");
+Rex::TaskList->create()->set_in_transaction(0);
 
-  $auth = $task->merge_auth($server);
-  is( $auth->{user},     "root",   "got root user for memcache02" );
-  is( $auth->{password}, "foob4r", "got foob4r password for memcache02" );
-  ok( $auth->{sudo}, "got sudo for memcache02" );
-
-  is( $server->option("services"), "apache,memcache",
-    "got services of server" );
-
-  # don't fork the task
-  Rex::TaskList->create()->set_in_transaction(1);
-  Rex::Commands::Task::do_task("mytask");
-  Rex::TaskList->create()->set_in_transaction(0);
-}

--- a/t/summary.t
+++ b/t/summary.t
@@ -42,38 +42,33 @@ subtest "distributor => 'Base'" => sub {
   };
 };
 
-SKIP: {
-  skip "Parallel::ForkManager is not installed", 1
-    if parallel_forkmanager_not_installed();
-
-  subtest "distributor => 'Parallel_ForkManager'" => sub {
-    subtest 'exec_autodie => 0' => sub {
-      Rex::Config->set_exec_autodie(0);
-      Rex::Config->set_distributor('Parallel_ForkManager');
-      test_summary(
-        task0 => { server => '<local>', task => 'task0', exit_code => 1 },
-        task1 => { server => '<local>', task => 'task1', exit_code => 0 },
-        task2 => { server => '<local>', task => 'task2', exit_code => 0 },
-        task3 => { server => '<local>', task => 'task3', exit_code => 1 },
-      );
-    };
-
-    subtest 'exec_autodie => 1' => sub {
-      Rex::Config->set_exec_autodie(1);
-      Rex::Config->set_distributor('Parallel_ForkManager');
-      test_summary(
-        task0 => { server => '<local>', task => 'task0', exit_code => 1 },
-        task1 => {
-          server    => '<local>',
-          task      => 'task1',
-          exit_code => ( $^O =~ m/^(MSWin|freebsd|darwin)/ ? 1 : 2 )
-        },
-        task2 => { server => '<local>', task => 'task2', exit_code => 0 },
-        task3 => { server => '<local>', task => 'task3', exit_code => 1 },
-      );
-    };
+subtest "distributor => 'Parallel_ForkManager'" => sub {
+  subtest 'exec_autodie => 0' => sub {
+    Rex::Config->set_exec_autodie(0);
+    Rex::Config->set_distributor('Parallel_ForkManager');
+    test_summary(
+      task0 => { server => '<local>', task => 'task0', exit_code => 1 },
+      task1 => { server => '<local>', task => 'task1', exit_code => 0 },
+      task2 => { server => '<local>', task => 'task2', exit_code => 0 },
+      task3 => { server => '<local>', task => 'task3', exit_code => 1 },
+    );
   };
-}
+
+  subtest 'exec_autodie => 1' => sub {
+    Rex::Config->set_exec_autodie(1);
+    Rex::Config->set_distributor('Parallel_ForkManager');
+    test_summary(
+      task0 => { server => '<local>', task => 'task0', exit_code => 1 },
+      task1 => {
+        server    => '<local>',
+        task      => 'task1',
+        exit_code => ( $^O =~ m/^(MSWin|freebsd|darwin)/ ? 1 : 2 )
+      },
+      task2 => { server => '<local>', task => 'task2', exit_code => 0 },
+      task3 => { server => '<local>', task => 'task3', exit_code => 1 },
+    );
+  };
+};
 
 sub create_tasks {
   desc "desc 0";
@@ -132,10 +127,4 @@ sub test_summary {
   no warnings;
 
   @Rex::TaskList::Base::SUMMARY = ();
-}
-
-sub parallel_forkmanager_not_installed {
-  eval { require Parallel::ForkManager };
-  return 1 if $@;
-  return 0;
 }

--- a/t/xml.t
+++ b/t/xml.t
@@ -1,64 +1,57 @@
 use Test::More tests => 6;
 use FindBin qw($Bin);
 
-SKIP: {
+require Rex::Group::Lookup::XML;
+Rex::Group::Lookup::XML->import;
 
-  eval { require XML::LibXML };
-  skip 'Missing XML::LibXML for XML file support.', 6 if $@;
+use Rex::Group;
+use Rex::Commands;
+use Rex::Commands::Task;
 
-  require Rex::Group::Lookup::XML;
-  Rex::Group::Lookup::XML->import;
+no warnings 'once';
 
-  use Rex::Group;
-  use Rex::Commands;
-  use Rex::Commands::Task;
+$::QUIET = 1;
 
-  no warnings 'once';
+groups_xml("$Bin/test.xml");
+my %groups = Rex::Group->get_groups;
 
-  $::QUIET = 1;
+# stringification needed for is_deeply string comparison
+my @application_server = map { "$_" } @{ $groups{application} };
 
-  groups_xml("$Bin/test.xml");
-  my %groups = Rex::Group->get_groups;
+is( scalar( @{ $groups{application} } ), 2, "2 application servers" );
+is_deeply(
+  [ sort @application_server ],
+  [qw/machine01 machine02/],
+  "got machine02,machine01"
+);
+is( scalar( @{ $groups{profiler} } ), 2, "2 profiler servers 2" );
 
-  # stringification needed for is_deeply string comparison
-  my @application_server = map { "$_" } @{ $groups{application} };
+my ($server1) = grep { m/\bmachine07\b/ } @{ $groups{profiler} };
+my ($server2) = grep { m/\bmachine01\b/ } @{ $groups{application} };
 
-  is( scalar( @{ $groups{application} } ), 2, "2 application servers" );
-  is_deeply(
-    [ sort @application_server ],
-    [qw/machine01 machine02/],
-    "got machine02,machine01"
-  );
-  is( scalar( @{ $groups{profiler} } ), 2, "2 profiler servers 2" );
+Rex::TaskList->create()->set_in_transaction(1);
+no_ssh(
+  task(
+    "xml_task1",
+    $server1,
+    sub {
+      is( connection()->server->option("services"),
+        "nginx,docker", "got services inside task" );
+    }
+  )
+);
+Rex::Commands::Task::do_task("xml_task1");
 
-  my ($server1) = grep { m/\bmachine07\b/ } @{ $groups{profiler} };
-  my ($server2) = grep { m/\bmachine01\b/ } @{ $groups{application} };
-
-  Rex::TaskList->create()->set_in_transaction(1);
-  no_ssh(
-    task(
-      "xml_task1",
-      $server1,
-      sub {
-        is( connection()->server->option("services"),
-          "nginx,docker", "got services inside task" );
-      }
-    )
-  );
-  Rex::Commands::Task::do_task("xml_task1");
-
-  no_ssh(
-    task(
-      "xml_task2",
-      $server2,
-      sub {
-        is( connection()->server->get_user(),
-          'root', "$server2 user is 'root'" );
-        is( connection()->server->get_password(),
-          'foob4r', "$server2 password is 'foob4r'" );
-      }
-    )
-  );
-  Rex::Commands::Task::do_task("xml_task2");
-  Rex::TaskList->create()->set_in_transaction(0);
-}
+no_ssh(
+  task(
+    "xml_task2",
+    $server2,
+    sub {
+      is( connection()->server->get_user(), 'root', "$server2 user is 'root'" );
+      is( connection()->server->get_password(),
+        'foob4r', "$server2 password is 'foob4r'" );
+    }
+  )
+);
+Rex::Commands::Task::do_task("xml_task2");
+Rex::TaskList->create()->set_in_transaction(0);


### PR DESCRIPTION
This is a fix for #971 making some optional dependencies to hard dependencies.

This is also to minimize the confusions for users which get error message for missing perl modules.