### PR TITLE
bug with get_cloud_instances_as_group

### DIFF
--- a/lib/Rex/Commands/Cloud.pm
+++ b/lib/Rex/Commands/Cloud.pm
@@ -272,9 +272,6 @@ Get a list of all running instances of a cloud service. This can be used for a I
 
 sub get_cloud_instances_as_group {
 
-  # return funcRef
-  # without return sub evenrything works as expected
-  #return sub {
   my @list = cloud_object()->list_running_instances();
 
   my @ret;
@@ -284,8 +281,6 @@ sub get_cloud_instances_as_group {
   }
 
   return @ret;
-  #};
-
 }
 
 =head2 cloud_instance($action, $data)

--- a/lib/Rex/Commands/Cloud.pm
+++ b/lib/Rex/Commands/Cloud.pm
@@ -273,17 +273,18 @@ Get a list of all running instances of a cloud service. This can be used for a I
 sub get_cloud_instances_as_group {
 
   # return funcRef
-  return sub {
-    my @list = cloud_object()->list_running_instances();
+  # without return sub evenrything works as expected
+  #return sub {
+  my @list = cloud_object()->list_running_instances();
 
-    my @ret;
+  my @ret;
 
-    for my $instance (@list) {
-      push( @ret, Rex::Group::Entry::Server->new( name => $instance->{"ip"} ) );
-    }
+  for my $instance (@list) {
+    push( @ret, Rex::Group::Entry::Server->new( name => $instance->{"ip"} ) );
+  }
 
-    return @ret;
-  };
+  return @ret;
+  #};
 
 }
 


### PR DESCRIPTION
I have to made this change to be able to use the get_could_instances_as_group in my Rexfile with Amazon EC2.
I dont know  if it may cause issue with others clouds providers.