### PR TITLE
exit rex with an exitcode of 1 if some tests failed. fix #989

### DIFF
--- a/lib/Rex/Test.pm
+++ b/lib/Rex/Test.pm
@@ -11,8 +11,26 @@ use warnings;
 use Rex -base;
 use Data::Dumper;
 use Rex::Commands::Box;
+require Rex::CLI;
 
 # VERSION
+
+BEGIN {
+  use Rex::Shared::Var;
+  share qw(@exit);
+}
+
+Rex::CLI->add_exit(
+  sub {
+    if ( scalar @exit > 0 ) {
+      CORE::exit(1);
+    }
+  }
+);
+
+sub push_exit {
+  push @exit, shift;
+}
 
 desc 'Run tests specified with --test=testfile (default: t/*.t)';
 task run => make {

--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -228,7 +228,11 @@ sub finish {
   $tb->is_passing()
     ? print "PASS\n"
     : print "FAIL\n";
+  if ( !$tb->is_passing() ) {
+    Rex::Test::push_exit("FAIL");
+  }
   $tb->reset();
+
   Rex::pop_connection();
 }
 


### PR DESCRIPTION
this will make rex to exit with an exitcode of 1 if some tests are failing.