### PR TITLE
callback and options can both be used

### DIFF
--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -58,7 +58,7 @@ use base qw(Rex::Exporter);
 
 @EXPORT = qw(run can_run sudo);
 
-=head2 run($command [, $callback])
+=head2 run($command [, $callback], %options)
 
 =head2 run($command, $arguments, %options)
 


### PR DESCRIPTION
This code works:

```
  sudo sub {
    run 'cpanm --installdeps .', sub {
        my ($stdout, $stderr) = @_;
        if ($stderr) {
          say "ERROR: $stderr";
        }
        if ($stdout) {
          say "NOTE: $stdout";
        }
      },
      cwd => '/home/freddy/git/myapp';
  };

```

[IGNORE THE FOLLOWING... I was running against 1.4.0]
but all attempts at putting the arguments in an arrayref like ['--installdeps', '.'] failed with:

 `Odd number of elements in anonymous hash at /usr/local/share/perl/5.18.2/Rex/Commands/Run.pm line 161.
`