### PR TITLE
Don't add duplicates env variable in crontab

### DIFF
--- a/lib/Rex/Commands/Sysctl.pm
+++ b/lib/Rex/Commands/Sysctl.pm
@@ -38,6 +38,7 @@ use warnings;
 
 use Rex::Logger;
 use Rex::Helper::Run;
+use Rex::Commands::File;
 
 require Rex::Exporter;
 
@@ -46,7 +47,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(sysctl);
 
-=head2 sysctl($key [, $val])
+=head2 sysctl($key [, $val [, %options]])
 
 This function will read the sysctl key $key.
 
@@ -58,11 +59,25 @@ If $val is given, then this function will set the sysctl key $key.
    }
  };
 
+If both $val and option persistent => "true" are passed the sysctl key and value are stored in /etc/sysctl.conf.
+If the key already exists in the file, it will be updated to the new value.
+
+ task "forwarding", "server01", sub {
+   sysctl "net.ipv4.ip_forward" => 1, persistent => "true";
+ }
+
 =cut
+
+sub sysctl_save {
+  my ( $key, $value ) = @_;
+  append_or_amend_line "/etc/sysctl.conf",
+    line   => "$key=$value",
+    regexp => qr{\Q$key=};
+}
 
 sub sysctl {
 
-  my ( $key, $val ) = @_;
+  my ( $key, $val, %options ) = @_;
 
   if ( defined $val ) {
 
@@ -77,6 +92,13 @@ sub sysctl {
     }
     else {
       Rex::Logger::debug("$key has already value $val");
+    }
+
+    if ( defined %options ) {
+      if ( exists $options{persistent} && $options{persistent} eq "true" ) {
+        Rex::Logger::debug("Writing $key=$val to sysctl.conf");
+        sysctl_save $key, $val;
+      }
     }
 
   }

--- a/lib/Rex/Cron/Base.pm
+++ b/lib/Rex/Cron/Base.pm
@@ -79,15 +79,34 @@ sub add {
 
 sub add_env {
   my ( $self, $name, $value ) = @_;
-  unshift(
-    @{ $self->{cron} },
-    {
-      type  => "env",
-      line  => "$name=\"$value\"",
-      name  => $name,
-      value => $value,
+
+  my $env_index = 0;
+  my $exists = 0;
+  for my $env ( $self->list_envs ) {
+    if($env->{name} eq "$name") {
+      if($env->{value} ne "\"$value\"") {
+        Rex::Logger::debug("Environment variable changed : $name");
+        $self->delete_env($env_index);
+      } else {
+        Rex::Logger::debug("Environment variable already exists with same value: $name=$value");
+        $exists = 1;
+      }
     }
-  );
+
+    $env_index++;
+  }
+
+  if($exists == 0) {
+    unshift(
+      @{ $self->{cron} },
+      {
+        type  => "env",
+        line  => "$name=\"$value\"",
+        name  => $name,
+        value => $value,
+           }
+    );
+  }
 }
 
 sub delete_job {

--- a/lib/Rex/Service/OpenBSD.pm
+++ b/lib/Rex/Service/OpenBSD.pm
@@ -24,34 +24,17 @@ sub new {
   bless( $self, $proto );
 
   $self->{commands} = {
-    start   => '/etc/rc.d/%s start',
-    restart => '/etc/rc.d/%s restart',
-    stop    => '/etc/rc.d/%s stop',
-    reload  => '/etc/rc.d/%s reload',
-    status  => '/etc/rc.d/%s status',
-    action  => '/etc/rc.d/%s %s',
+    start        => '/usr/sbin/rcctl start %s',
+    restart      => '/usr/sbin/rcctl restart %s',
+    stop         => '/usr/sbin/rcctl stop %s',
+    reload       => '/usr/sbin/rcctl reload %s',
+    status       => '/usr/sbin/rcctl check %s',
+    ensure_start => '/usr/sbin/rcctl enable %s',
+    ensure_stop  => '/usr/sbin/rcctl disable %s',
+    action       => '/usr/sbin/rcctl action %s',
   };
 
   return $self;
-}
-
-sub ensure {
-  my ( $self, $service, $options ) = @_;
-
-  my $what = $options->{ensure};
-
-  if ( $what =~ /^stop/ ) {
-    $self->stop( $service, $options );
-    delete_lines_matching "/etc/rc.conf",
-      matching => qr/rc_scripts="\${rc_scripts} ${service}"/;
-  }
-  elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
-    $self->start( $service, $options );
-    append_if_no_such_line "/etc/rc.conf",
-      "rc_scripts=\"\${rc_scripts} ${service}\"\n";
-  }
-
-  return 1;
 }
 
 1;


### PR DESCRIPTION
Actually if you add an env variable to a crontab it will be added even if it's already in the file.

With this commit, it checks if it exists and then
exists with same value as the new one => we do nothing
exists with a different value => we remove it using its index and we add the new one