### PR TITLE
Using OpenBSD rcctl tool for managing services

### DIFF
--- a/lib/Rex/Service/OpenBSD.pm
+++ b/lib/Rex/Service/OpenBSD.pm
@@ -24,34 +24,17 @@ sub new {
   bless( $self, $proto );
 
   $self->{commands} = {
-    start   => '/etc/rc.d/%s start',
-    restart => '/etc/rc.d/%s restart',
-    stop    => '/etc/rc.d/%s stop',
-    reload  => '/etc/rc.d/%s reload',
-    status  => '/etc/rc.d/%s status',
-    action  => '/etc/rc.d/%s %s',
+    start        => '/usr/sbin/rcctl start %s',
+    restart      => '/usr/sbin/rcctl restart %s',
+    stop         => '/usr/sbin/rcctl stop %s',
+    reload       => '/usr/sbin/rcctl reload %s',
+    status       => '/usr/sbin/rcctl check %s',
+    ensure_start => '/usr/sbin/rcctl enable %s',
+    ensure_stop  => '/usr/sbin/rcctl disable %s',
+    action       => '/usr/sbin/rcctl action %s',
   };
 
   return $self;
-}
-
-sub ensure {
-  my ( $self, $service, $options ) = @_;
-
-  my $what = $options->{ensure};
-
-  if ( $what =~ /^stop/ ) {
-    $self->stop( $service, $options );
-    delete_lines_matching "/etc/rc.conf",
-      matching => qr/rc_scripts="\${rc_scripts} ${service}"/;
-  }
-  elsif ( $what =~ /^start/ || $what =~ m/^run/ ) {
-    $self->start( $service, $options );
-    append_if_no_such_line "/etc/rc.conf",
-      "rc_scripts=\"\${rc_scripts} ${service}\"\n";
-  }
-
-  return 1;
 }
 
 1;


### PR DESCRIPTION
OpenBSD as a tool to manage services since 5.8, this commit let use rcctl for managing services from Rex now.