### PR TITLE
Sysctl saving

### DIFF
--- a/lib/Rex/Commands/Sysctl.pm
+++ b/lib/Rex/Commands/Sysctl.pm
@@ -94,11 +94,9 @@ sub sysctl {
       Rex::Logger::debug("$key has already value $val");
     }
 
-    if ( defined %options ) {
-      if ( exists $options{persistent} && $options{persistent} eq "true" ) {
-        Rex::Logger::debug("Writing $key=$val to sysctl.conf");
-        sysctl_save $key, $val;
-      }
+    if ( exists $options{persistent} && $options{persistent} eq "true" ) {
+      Rex::Logger::debug("Writing $key=$val to sysctl.conf");
+      sysctl_save $key, $val;
     }
 
   }

--- a/lib/Rex/Commands/Sysctl.pm
+++ b/lib/Rex/Commands/Sysctl.pm
@@ -38,6 +38,7 @@ use warnings;
 
 use Rex::Logger;
 use Rex::Helper::Run;
+use Rex::Commands::File;
 
 require Rex::Exporter;
 
@@ -46,7 +47,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(sysctl);
 
-=head2 sysctl($key [, $val])
+=head2 sysctl($key [, $val [, %options]])
 
 This function will read the sysctl key $key.
 
@@ -58,11 +59,25 @@ If $val is given, then this function will set the sysctl key $key.
    }
  };
 
+If both $val and option persistent => "true" are passed the sysctl key and value are stored in /etc/sysctl.conf.
+If the key already exists in the file, it will be updated to the new value.
+
+ task "forwarding", "server01", sub {
+   sysctl "net.ipv4.ip_forward" => 1, persistent => "true";
+ }
+
 =cut
+
+sub sysctl_save {
+  my ( $key, $value ) = @_;
+  append_or_amend_line "/etc/sysctl.conf",
+    line   => "$key=$value",
+    regexp => qr{\Q$key=};
+}
 
 sub sysctl {
 
-  my ( $key, $val ) = @_;
+  my ( $key, $val, %options ) = @_;
 
   if ( defined $val ) {
 
@@ -77,6 +92,13 @@ sub sysctl {
     }
     else {
       Rex::Logger::debug("$key has already value $val");
+    }
+
+    if ( defined %options ) {
+      if ( exists $options{persistent} && $options{persistent} eq "true" ) {
+        Rex::Logger::debug("Writing $key=$val to sysctl.conf");
+        sysctl_save $key, $val;
+      }
     }
 
   }


### PR DESCRIPTION
This commit permit the following :

sysctl "net.ipv4.ip_forward" => 1, persistent => "true";

so net.ipv4.ip_forward will be set to 1 and net.ipv4.ip_forward=1 will be added/updated in /etc/sysctl.conf