### PR TITLE
Adds 64bit module path to @INC for linux

### DIFF
--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -109,6 +109,9 @@ sub push_lib_to_inc {
   if ( -d "$path/lib" ) {
     push( @INC, "$path/lib" );
     push( @INC, "$path/lib/perl/lib/perl5" );
+    if ( $^O eq "linux" ) {
+      push( @INC, "$path/lib/perl/lib/perl5/x86_64-linux" );
+    }
     if ( $^O =~ m/^MSWin/ ) {
       my ($special_win_path) = grep { m/\/MSWin32\-/ } @INC;
       if ( defined $special_win_path ) {


### PR DESCRIPTION
I'm using rex 1.4.0 on Fedora 24.

If you use `rexify --resolve-deps` to install 64-bit modules into your project's tree, rex will not load them because that path does not exist in @INC.

For example, on Fedora 24, adding **DateTime** as a dependency and running `rexify --resolve-deps` downloads DateTime.pm to:
lib/perl/lib/perl5/x86_64-linux/DateTime.pm

This patch adds  "lib/perl/lib/perl5/x86_64-linux/" to @INC for linux hosts.
