### PR TITLE
Escape backquotes when run command via sudo in the remote host, fix 1076

### DIFF
--- a/lib/Rex/Interface/Shell/Bash.pm
+++ b/lib/Rex/Interface/Shell/Bash.pm
@@ -130,6 +130,7 @@ sub exec {
     $complete_cmd =~ s/\\/\\\\/gms;
     $complete_cmd =~ s/"/\\"/gms;
     $complete_cmd =~ s/\$/\\\$/gms;
+    $complete_cmd =~ s/\`/\\\`/gms;
 
     $complete_cmd = "sh -c \"$complete_cmd\"";
   }


### PR DESCRIPTION
Adding regex to escape ` like " , $ and \ symbols when preparing command 
line to run in the inner shell.
