### PR TITLE
Trying to fix #791

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -679,7 +679,12 @@ sub get_ssh_config_hostname {
     && exists $SSH_CONFIG_FOR{ $param->{server} }
     && exists $SSH_CONFIG_FOR{ $param->{server} }->{hostname} )
   {
-    return $SSH_CONFIG_FOR{ $param->{server} }->{hostname};
+    if ( $SSH_CONFIG_FOR{ $param->{server} }->{hostname} =~ m/^\%h\.(.*)/ ) {
+      return $param->{server} . "." . $1;
+    }
+    else {
+      return $SSH_CONFIG_FOR{ $param->{server} }->{hostname};
+    }
   }
 
   return 0;


### PR DESCRIPTION
#791 
Now get_ssh_config_hostname sub returns a good hosntame.

If one has a config on ssh_config like:

<pre>
Host server1 web0* db*
    Hostname %h.mydomain.com
    User foo
    IdentityFile ~/.ssh/my_key
</pre>

`%SSH_CONFIG_FOR` on `Config.pm` has something like this:

<pre>
      {
          'server1' => {
                           'identityfile' => '~/.ssh/my_key',
                           'user' => 'foo',
                           'hostname' => '%h.mydomain.com'
                         },
          'web*' => {
                           'identityfile' => '~/.ssh/my_key',
                           'user' => 'foo',
                           'hostname' => '%h.mydomain.com'
                         },
          'db*' => {
                           'identityfile' => '~/.ssh/my_key',
                           'user' => 'foo',
                           'hostname' => '%h.mydomain.com'
                         }
        };
</pre>
That means that when you call for `web01` for instance, on `lib/Rex/Interface/Connection/SSH.pm` (line 69) or `lib/Rex/Interface/Connection/OpenSSH.pm` (line 65) you'll get `web01` because there's no matching entry on `%SSH_CONFIG_FOR` but you'll get `%h.mydomain.com` for `server1` because there's a matching entry.

I try to fix this with minimal changes (maybe is not the right approach).

Tested with Net::OpenSSH and Net:SSH2. The later has some cases that don't work but are not related with the patch (they don't work either without the patch applied).