### PR TITLE
Give the kernel time to get informed of partition changes

### DIFF
--- a/lib/Rex/Commands/Partition.pm
+++ b/lib/Rex/Commands/Partition.pm
@@ -56,7 +56,7 @@ Clear partitions on drive `sda`:
  clearpart "sda";
 
 Create a new GPT disk label (partition table) on drive `sda`:
- 
+
  clearpart "sda",
   initialize => "gpt";
 
@@ -159,13 +159,13 @@ Examples:
    size   => 15000,
    ondisk => "sda",
    type   => "primary";
- 
+
  partition "none",
    type   => "extended",
    ondisk => "sda",
    grow   => 1,
    mount  => TRUE,
- 
+
  partition "swap",
    fstype => "swap",
    type   => "logical",
@@ -227,7 +227,16 @@ sub partition {
     die("Error creating partition.");
   }
 
-  i_run "partprobe";
+  my $partprobe_error;
+
+  for ( 1 .. 5 ) {
+    eval { run "partprobe"; };
+    $partprobe_error = $@;
+    last unless $partprobe_error;
+    sleep 5;
+  }
+
+  die $partprobe_error if $partprobe_error;
 
   # get the partition id
   my @partitions = grep { /$disk\d+$/ } split /\n/, cat "/proc/partitions";


### PR DESCRIPTION
Fix #1095 

For example hardware raid controllers may need some time to commit
changes. If we manage to inform the kernel immediately, behavior is
the same. If it fails, it retries a few times after a sleep.