### PR TITLE
Handle different md5 styles on BSDs (fix #1099)

### DIFF
--- a/lib/Rex/Commands/MD5.pm
+++ b/lib/Rex/Commands/MD5.pm
@@ -74,7 +74,7 @@ sub md5 {
 
       my $os = $exec->exec("uname -s");
       if ( $os =~ /bsd/i ) {
-        $md5 = $exec->exec("/sbin/md5 -q '$file'");
+        ( undef, $md5 ) = split( / = /, $exec->exec("md5 '$file'") );
       }
       else {
         ($md5) = split( /\s/, $exec->exec("md5sum '$file'") );


### PR DESCRIPTION
- FreeBSD has /sbin/md5, while NetBSD has /usr/bin/md5
- they may or may not support -q CLI option