### PR TITLE
Fix fatal errors when running debconf

### DIFF
--- a/lib/Rex/PkgConf/Debian.pm
+++ b/lib/Rex/PkgConf/Debian.pm
@@ -86,7 +86,6 @@ sub set_options {
       next;
     }
 
-    push @updated, $question;
     Rex::Logger::debug("Will set option $question: $value (type $type)");
     push @updated, "$pkg $question $type $value";
   }


### PR DESCRIPTION
PkgConf::Debian incorrectly writes 2 lines for each configuration, which
results in fatal errors by debconf-set-selections. According to the
debconf-set-selections man page, each configuration should consist of
one line only.

What I do not understand is I apparently contributed the original patch
some time ago, but have never had any problems running it up until now.
Yet I cannot find any reason why I would have included that additional
line. All I can think is that it may have been a mistake, and
debconf-set-selections has only started borking on it recently.