### PR TITLE
clearpart: fix partition regex for nvme

### DIFF
--- a/lib/Rex/Commands/Partition.pm
+++ b/lib/Rex/Commands/Partition.pm
@@ -96,7 +96,7 @@ sub clearpart {
     }
   }
   else {
-    my @partitions = grep { /$o_disk\d+$/ } split /\n/, cat "/proc/partitions";
+    my @partitions = grep { /\Q$o_disk\Ep?\d+$/ } split /\n/, cat "/proc/partitions";
 
     for my $part_line (@partitions) {
       my ( $num, $part ) = ( $part_line =~ m/\d+\s+(\d+)\s+\d+\s(.*)$/ );


### PR DESCRIPTION
Given /proc/partitions with content:
```
major minor  #blocks  name

 259        0  250059096 nvme0n1
 259        1     524288 nvme0n1p1
 259        2    1048576 nvme0n1p2
 259        3  248485191 nvme0n1p3
```

`clearpart nvme0n1` will fail to detect partitions due to the additional letter
`p` prior to the partition number. This change fixes the regular expression to
respect an optional `p` before the partition number.

Note: The same problem exists for partition() function in Rex-1.4.1
which was silently fixed by 063a7120a

Signed-off-by: Ali Polatel <alip@adjust.com>