### PR TITLE
set_auth used before creating the task object

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -226,7 +226,6 @@ CHECK_OVERWRITE: {
       Rex::Commands::private_key( $opts{'P'} );
 
       for my $task ( Rex::TaskList->create()->get_tasks ) {
-        $task->set_auth( "private_key", $opts{'P'} );
         Rex::TaskList->create()->get_task($task)
           ->set_auth( "private_key", $opts{'P'} );
       }


### PR DESCRIPTION
Can't locate object method "set_auth" via package "install" (perhaps you forgot to load "install"?) at /usr/local/share/perl5/Rex/CLI.pm line 231.

 I was getting the above error message, while using -P argument.