### PR TITLE
Gentoo/layman: check repo exists for add_repo & add readd option

### DIFF
--- a/lib/Rex/Pkg/Gentoo.pm
+++ b/lib/Rex/Pkg/Gentoo.pm
@@ -180,9 +180,22 @@ sub add_repository {
   my ( $self, %data ) = @_;
 
   my $name = $data{"name"};
+  my $readd = $data{"readd"} // 0;
 
   if ( can_run("layman") ) {
-    i_run "layman -a $name";
+    my $op;
+
+    i_run "layman -lqnN | grep -q '$name'", fail_ok => 1;
+    if ($? == 0) {
+      if ($readd) {
+        $op = 'r'; # --readd
+      } else {
+        Rex::Logger::info("Repository $name is present, use `readd' option to re-add from scratch.");
+      }
+    } else {
+      $op = 'a'; # --add
+    }
+    i_run "layman -$op $name" if defined $op;
   }
   else {
     Rex::Logger::debug("You have to install layman, git and subversion.");


### PR DESCRIPTION
Issue: add_repository fails if the repository is already added so check beforehand.
Convenience: Add support to pass --readd to layman to delete & add existing repository.