### PR TITLE
VirtInfo: check dmi sys_vendor for qemu

### DIFF
--- a/lib/Rex/Hardware/VirtInfo.pm
+++ b/lib/Rex/Hardware/VirtInfo.pm
@@ -96,6 +96,11 @@ sub get {
       $virtualization_role = "guest";
     }
 
+    elsif ( $sys_vendor =~ /QEMU/ ) {
+      $virtualization_type = "kvm";
+      $virtualization_role = "guest";
+    }
+
     elsif ( $self_status =~ /VxID: \d+/ ) {
       $virtualization_type = "linux_vserver";
       $virtualization_role = "guest";


### PR DESCRIPTION
This is necessary if KVM is used with cpu host passthrough in which case
`/proc/cpuinfo` does not give a hint on KVM/QEMU usage.

Signed-off-by: Ali Polatel <alip@adjust.com>