### PR TITLE
Use fail_ok in cron

### DIFF
--- a/lib/Rex/Cron/Base.pm
+++ b/lib/Rex/Cron/Base.pm
@@ -196,7 +196,7 @@ sub read_user_cron {
   $command .= " -u $user" if defined $user;
   $command .= ' 2> /dev/null';
 
-  my @lines = i_run $command;
+  my @lines = i_run $command, fail_ok => 1;
   $self->parse_cron(@lines);
 }
 


### PR DESCRIPTION
If cron list is empty ret_val is 1, triggering an error in i_run
Probably this was missed in #1123