### PR TITLE
mkfs for lvm volumes optional

### DIFF
--- a/lib/Rex/Commands/LVM.pm
+++ b/lib/Rex/Commands/LVM.pm
@@ -252,7 +252,7 @@ sub lvcreate {
 
   my $lv_path = $option{onvg} . "/" . $lvname;
 
-  mkfs "$lv_path", fstype => $option{fstype};
+  mkfs "$lv_path", fstype => $option{fstype} if ( $option{fstype} );
 
   return $lv_path;
 }


### PR DESCRIPTION
Don't format lvm volumes if not explicitly requested using the fstype option.