### PR TITLE
Fix Pkgconf for Debian

### DIFF
--- a/lib/Rex/PkgConf/Debian.pm
+++ b/lib/Rex/PkgConf/Debian.pm
@@ -86,7 +86,6 @@ sub set_options {
       next;
     }
 
-    push @updated, $question;
     Rex::Logger::debug("Will set option $question: $value (type $type)");
     push @updated, "$pkg $question $type $value";
   }


### PR DESCRIPTION
For reasons I do not understand, PkgConf for Debian adds 2 lines for each question, which causes errors with debconf-set-selections and is not as per the manual. It was me that wrote that line in originally, and I don't know why I did it or why it didn't fail before.

Anyway, this patch removes it, and allows it to function correctly.