### PR TITLE
fixed path bug in git scm checkout

### DIFF
--- a/lib/Rex/SCM/Git.pm
+++ b/lib/Rex/SCM/Git.pm
@@ -31,8 +31,8 @@ sub checkout {
 
   if ( !is_dir($checkout_to) ) {
     my $clone_cmd =
-      sprintf( $CLONE_COMMAND, $repo_info->{"url"}, $checkout_to );
-    Rex::Logger::debug("clone_cmd: $clone_cmd");
+      sprintf( $CLONE_COMMAND, $repo_info->{"url"}, basename($checkout_to) );
+    Rex::Logger::debug("clone_cmd: $clone_cmd (cwd: " . dirname($checkout_to). ")");
 
     Rex::Logger::info( "Cloning "
         . $repo_info->{"url"} . " to "

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -369,7 +369,7 @@ sub modify {
   my ( $self, $type, $task, $code, $package, $file, $line ) = @_;
 
   if ( $package ne "main" && $package ne "Rex::CLI" ) {
-    if ( $task !~ m/:/ ) {
+    if ( $task =~ m/:/ ) {
 
       #do we need to detect for base -Rex ?
       $package =~ s/^Rex:://;

--- a/t/before_all_tasks.t
+++ b/t/before_all_tasks.t
@@ -9,24 +9,18 @@ use Rex::Commands;
 use Rex::Commands::Run;
 
 use t::tasks::cowbefore;
-use Data::Dumper;
 
 $::QUIET = 1;
 
 my $task_list = Rex::TaskList->create;
 
-task 'eat' => sub { return 'delicious cows' };
-
-before ALL => sub { return 'yo' };
-
 my @task_names = $task_list->get_tasks;
 cmp_deeply
   \@task_names,
-  [qw/eat t:tasks:cowbefore:roundup/],
-  "found visible task";
+  [qw/t:tasks:cowbefore:roundup/],
+  "found task";
 
 for my $tn (@task_names) {
-
   my $before = $task_list->get_task($tn)->get_data->{before};
   ok($before);
   is( ( scalar @$before ), 1, $tn );

--- a/t/before_all_tasks.t
+++ b/t/before_all_tasks.t
@@ -1,0 +1,36 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::More;
+use Test::Deep;
+
+use Rex::Commands;
+use Rex::Commands::Run;
+
+use t::tasks::cowbefore;
+use Data::Dumper;
+
+$::QUIET = 1;
+
+my $task_list = Rex::TaskList->create;
+
+task 'eat' => sub { return 'delicious cows' };
+
+before ALL => sub { return 'yo' };
+
+my @task_names = $task_list->get_tasks;
+cmp_deeply
+  \@task_names,
+  [qw/eat t:tasks:cowbefore:roundup/],
+  "found visible task";
+
+for my $tn (@task_names) {
+
+  my $before = $task_list->get_task($tn)->get_data->{before};
+  ok($before);
+  is( ( scalar @$before ), 1, $tn );
+  is( $before->[0]->(), 'yo', $tn ) if (@$before);
+}
+
+done_testing();

--- a/t/lib/t/tasks/cowbefore.pm
+++ b/t/lib/t/tasks/cowbefore.pm
@@ -1,0 +1,8 @@
+package t::tasks::cowbefore;
+use Rex -base;
+
+desc "bring in the cattle";
+task "roundup" => sub { return 1 };
+
+before ALL => sub { return 'yo' };
+1;


### PR DESCRIPTION
The SCM package to handle git repos created repos in the wrong dir, if
confronted with path attribute consisting of multiple dirs. E.g. the
call in the  Rexfile:

  checkout 'my-repo', path => 'app/my-repo'

would result in a git repo that is checked out into

  app/app/my-repo

instead of

  app/my-repo

on the remote machine.