### PR TITLE
Warn instead of dying when delete_user called on non existing user

### DIFF
--- a/lib/Rex/User/FreeBSD.pm
+++ b/lib/Rex/User/FreeBSD.pm
@@ -165,9 +165,11 @@ sub rm_user {
     $cmd .= " -r ";
   }
 
-  i_run $cmd . " -n " . $user;
-  if ( $? != 0 ) {
-    die("Error deleting user $user");
+  my $output = i_run $cmd . " -n " . $user;
+  if ( $? == 67 ) {
+    Rex::Logger::info("Cannot delete user $user (no such user)", "warn");
+  } elsif ( $? != 0 ) {
+    die("Error deleting user $user ($output)");
   }
 
 }

--- a/lib/Rex/User/Linux.pm
+++ b/lib/Rex/User/Linux.pm
@@ -251,9 +251,11 @@ sub rm_user {
     $cmd .= " --force";
   }
 
-  i_run $cmd . " " . $user;
-  if ( $? != 0 ) {
-    die("Error deleting user $user");
+  my $output = i_run $cmd . " " . $user;
+  if ( $? == 6 ) {
+    Rex::Logger::info("Cannot delete user $user (no such user)", "warn");
+  } elsif ( $? != 0 ) {
+    die("Error deleting user $user ($output)");
   }
 
 }

--- a/lib/Rex/User/NetBSD.pm
+++ b/lib/Rex/User/NetBSD.pm
@@ -189,16 +189,21 @@ sub rm_user {
     $cmd .= " -r";
   }
 
-  i_run $cmd . " " . $user;
+  my $output = i_run $cmd . " " . $user;
+  if ( $? == 67 ) {
+    Rex::Logger::info("Cannot delete user $user (no such user)", "warn");
+  } elsif ( $? != 0 ) {
+    die("Error deleting user $user ($output)");
+  }
 
   if ( exists $data->{delete_home} && is_dir( $user_info{home} ) ) {
     Rex::Logger::debug(
-      "userdel doesn't deleted home. removing it now by hand...");
+      "userdel doesn't delete home directory. removing it now by hand...");
     rmdir $user_info{home};
   }
 
   if ( $? != 0 ) {
-    die("Error deleting user $user");
+    die("Error removing " . $user_info{home});
   }
 
 }


### PR DESCRIPTION
Original issue here: https://github.com/RexOps/Rex/issues/943

I thought it would also be useful to know the reason the user deletion failed (in exceptional cases), so added it to the original dying message.

First time contributor, so let me know if there is anything I should do differently 😄 