### PR TITLE
only source ~/.profile if it really exists

### DIFF
--- a/lib/Rex/Interface/Shell/Bash.pm
+++ b/lib/Rex/Interface/Shell/Bash.pm
@@ -85,7 +85,7 @@ sub exec {
   }
 
   if ( $self->{source_profile} ) {
-    $complete_cmd = ". ~/.profile >/dev/null 2>&1 ; $complete_cmd";
+    $complete_cmd = "[ \\! -r ~/.profile ] || . ~/.profile >/dev/null 2>&1 ; $complete_cmd";
   }
 
   if ( $self->{source_global_profile} ) {


### PR DESCRIPTION
Usually it is no problem to activate profile sourcing for users that don't have ~/.profile, because one can create ~/.profile. But for servers with sudo => TRUE and /root/.profile not present, all commands that should create or copy this file will fail. This is slightly annoying.