### PR TITLE
create_host: drop useless get_host invocation

### DIFF
--- a/lib/Rex/Commands/Host.pm
+++ b/lib/Rex/Commands/Host.pm
@@ -137,10 +137,9 @@ sub create_host {
     $fh->close;
   }
   else {
-    my @host = get_host( $host, { file => $data->{file} } );
-    if ( $data->{"ip"} eq $host[0]->{"ip"}
+    if ( $data->{"ip"} eq $cur_host[0]->{"ip"}
       && join( " ", @{ $data->{"aliases"} || [] } ) eq
-      join( " ", @{ $host[0]->{"aliases"} } ) )
+      join( " ", @{ $cur_host[0]->{"aliases"} } ) )
     {
 
       Rex::Logger::debug("Nothing to update for host $host");


### PR DESCRIPTION
The get_host call earlier sets `cur_host` so there's no point in
recalling `get_host` as the contents of the the hosts file has not
changed in the meantime.

As a side affect this seems to fix readding host entries already present
in the hosts file with different data (ip, aliases)