### PR TITLE
Recognize Virtuozzo as Red Hat clone

### DIFF
--- a/lib/Rex/Commands/Gather.pm
+++ b/lib/Rex/Commands/Gather.pm
@@ -267,6 +267,7 @@ sub is_redhat {
     "RedHatEnterpriseWorkstation", "RedHatEnterpriseWS",
     "Amazon",                      "ROSAEnterpriseServer",
     "CloudLinuxServer",            "XenServer",
+    "Virtuozzo",
   );
 
   if ( grep { /$os/i } @redhat_clones ) {


### PR DESCRIPTION
Parallels provide OpenVZ 7 as OS.

Additional OS info:
```
# lsb_release -s -i
Virtuozzo
```

```
# lsb_release -a
LSB Version:	:core-4.1-amd64:core-4.1-noarch
Distributor ID:	Virtuozzo
Description:	Virtuozzo Linux release 7.4
Release:	7.4
Codename:	n/a
```

```
# cat /etc/redhat-release
Virtuozzo Linux release 7.4
```

```
# cat /etc/virtuozzo-release
OpenVZ release 7.0.7 (27)
```
