### PR TITLE
Fix `needs` with nested namespaces (fix #1188)

### DIFF
--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1035,6 +1035,8 @@ sub needs {
 
   Rex::Logger::debug("need to call tasks from $self");
 
+  $self =~ s/::/:/g;
+
   my @tasks_to_run;
   if($self) {
     @tasks_to_run = $tl->get_all_tasks(qr{^\Q$self\E:[A-Za-z0-9_\-]+$});

--- a/t/needs.t
+++ b/t/needs.t
@@ -23,6 +23,20 @@ use Rex::Commands;
   1;
 }
 
+{
+  package Nested::Module;
+
+  use strict;
+  use warnings;
+
+  use Rex::Commands;
+
+  task "test", sub {
+    open( my $fh, ">", "test.txt" );
+    close($fh);
+  };
+}
+
 task "test", sub {
   needs MyTest;
 
@@ -62,9 +76,20 @@ task "test4", sub {
   close($fh);
 };
 
+task "test5", sub {
+  needs Nested::Module "test";
+
+  if ( -f "test.txt" ) {
+    unlink("test.txt");
+    return 1;
+  }
+
+  die;
+};
+
 my $task_list = Rex::TaskList->create;
 my $run_list  = Rex::RunList->instance;
-$run_list->parse_opts(qw/test test2 test3/);
+$run_list->parse_opts(qw/test test2 test3 test5/);
 
 for my $task ( $run_list->tasks ) {
   $task_list->run($task);


### PR DESCRIPTION
This PR fixes #1188 by converting any Perl module namespace separators into Rex task namespace separators.

@alip: could you try this and see if it solves your use case, please? I'm considering to include this in 1.6.0 as a last minute patch, so I thought some extra feedback would be nice :)