### PR TITLE
Fixes virtualization type,role for Digital Ocean Droplets

### DIFF
--- a/lib/Rex/Hardware/VirtInfo.pm
+++ b/lib/Rex/Hardware/VirtInfo.pm
@@ -101,6 +101,11 @@ sub get {
       $virtualization_role = "guest";
     }
 
+    elsif ( $sys_vendor =~ /DigitalOcean/ ) {
+      $virtualization_type = "kvm";
+      $virtualization_role = "guest";
+    }
+
     elsif ( $self_status =~ /VxID: \d+/ ) {
       $virtualization_type = "linux_vserver";
       $virtualization_role = "guest";


### PR DESCRIPTION
Digital Ocean uses `KVM` for their virtualization technology as per this FAQ:
> What kind of Virtualization do you use?
We use KVM.

https://www.digitalocean.com/help/technical/general/


Currently `Rex::Hardware::VirtInfo->get()` reports empty role/type information for DigitalOcean droplets:
```
$ rex -v
(R)?ex 1.6.0

$ rex -q -H $some_digital_ocean_droplet -e 'use Rex::Hardware::VirtInfo; say Dumper(Rex::Hardware::VirtInfo->get);'
$VAR1 = {
          'virtualization_role' => '',
          'virtualization_type' => ''
        };
```

Here is the information a DigitalOcean droplet reports for `$bios_vendor`, `$product_name`, and `$sys_vendor`:
```
$ rex -q -E vagrant -g all -e 'my $x; $x->{product_name} = i_run "cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null", fail_ok => 1; $x->{bios_vendor} = i_run "cat /sys/devices
/virtual/dmi/id/bios_vendor 2>/dev/null", fail_ok => 1; $x->{sys_vendor} = i_run "cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null", fail_ok => 1; print Dumper($x);'                                        
rex -q -E vagrant -g all -e 'use Rex::Helper::Run; my $x; $x->{product_name} = i_run "cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null", fail_ok => 1; $x->{bios_vendor} = i_run "cat /sys/devices/virtual/dmi/id/bios_vendor 2>/dev/null", fail_ok => 1; $x->{sys_vendor} = i_run "cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null", fail_ok => 1; print Dumper($x);'
$VAR1 = {
          'bios_vendor' => 'DigitalOcean',
          'product_name' => 'Droplet',
          'sys_vendor' => 'DigitalOcean'
        };
```

This patch simply sets role=KVM, type=guest when `$sys_vendor =~ /DigitalOcean/`.

Let me know if you would like me to make it more specific by taking into account `$product_name =~ /Droplet/`.