### PR TITLE
delete_host: fix regex so it does not match on prefixes

### DIFF
--- a/lib/Rex/Commands/Host.pm
+++ b/lib/Rex/Commands/Host.pm
@@ -173,7 +173,7 @@ sub delete_host {
     my @content = $fh->read_all;
     $fh->close;
 
-    my @new_content = grep { !/\s$host\s?/ } @content;
+    my @new_content = grep { !/\s\Q$host\E\b/ } @content;
 
     $fh = file_write $file;
     $fh->write(@new_content);


### PR DESCRIPTION
Previously `delete_host` which is usually called by `host_entry` in case
the host entry is already present in the hosts file could end up
deleting more host entries than expected since the regular expression to
filter out the line to update in the hosts file matches on a prefix of
the hostname rather than the full hostname, e.g: with foo-11, foo-12,
foo-13 in hosts delete_host("foo-1") deletes all three host entries.

Change makes the regular expression stricter to match on a boundary and
applies escaping to the host variable.