### PR TITLE
When the user doesn't exist yet, the $user_info{"uid"} variable

### DIFF
--- a/lib/Rex/User/OpenBSD.pm
+++ b/lib/Rex/User/OpenBSD.pm
@@ -72,12 +72,18 @@ sub create_user {
     $cmd = "usermod ";
   }
 
-  if ( exists $data->{uid} ) {
+  if ( defined $user_info{uid} ) {
+    if ( exists $data->{uid} ) {
 
-    # On OpenBSD, "usermod -u n login" fails when the user login
-    # has already n as userid. So skip it from the command arg
-    # when the uid is already correct.
-    $cmd .= " -u " . $data->{uid} unless $data->{uid} == $user_info{uid};
+      # On OpenBSD, "usermod -u n login" fails when the user login
+      # has already n as userid. So skip it from the command arg
+      # when the uid is already correct.
+      $cmd .= " -u " . $data->{uid} unless $data->{uid} == $user_info{uid};
+    }
+  }
+  else {
+      # the user does not exist yet.
+      $cmd .= " -u " . $data->{uid};
   }
 
   if ( exists $data->{home} ) {


### PR DESCRIPTION
Hi,

I'm sorry but I introduced a small «non initialised variable use» problem in the last pull request.  Could you please merge this fix ?
«
When the user doesn't exist yet, the $user_info{"uid"} variable doesn't exist and triggers an error. Add this test clause for this case.
»

Thank you,
Best
Olivier