### PR TITLE
Fix placeholder matching for %h in ssh config

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -679,8 +679,8 @@ sub get_ssh_config_hostname {
     && exists $SSH_CONFIG_FOR{ $param->{server} }
     && exists $SSH_CONFIG_FOR{ $param->{server} }->{hostname} )
   {
-    if ( $SSH_CONFIG_FOR{ $param->{server} }->{hostname} =~ m/^\%h\.(.*)/ ) {
-      return $param->{server} . "." . $1;
+    if ( $SSH_CONFIG_FOR{ $param->{server} }->{hostname} =~ m/^\%h(\.(.*))?/ ) {
+      return $param->{server} . $1;
     }
     else {
       return $SSH_CONFIG_FOR{ $param->{server} }->{hostname};


### PR DESCRIPTION
Minor change to how hostnames with placeholders are matched in ssh config. Instead of relying on the assumption that this will always be in the format of `%h.` allows a plain `%h` (which is a valid entry, of course) by including the period in the regex.

Previously `Hostname %h` would be matched as a literal hostname.