### PR TITLE
* Replace dynamic loading through 'eval()' with Module::Runtime

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -48,6 +48,7 @@ Net::SSH2 = 0
 [Prereqs]
 perl = 5.008008
 YAML = != 1.25
+Module::Runtime = 0
 
 [Prereqs / BuildRequires]
 Test::Pod = 0

--- a/lib/Rex/Args.pm
+++ b/lib/Rex/Args.pm
@@ -14,6 +14,7 @@ use warnings;
 use vars qw(%rex_opts);
 use Rex::Logger;
 use Data::Dumper;
+use Module::Runtime qw(use_module);
 
 our $CLEANUP = 1;
 
@@ -111,10 +112,8 @@ sub parse_rex_opts {
         }
 
         my $c = "Rex::Args::\u$type";
-        eval "use $c";
-        if ($@) {
-          die("No Argumentclass $type found!");
-        }
+        eval { use_module($c) }
+            or die("No Argumentclass $type found!");
 
         if ( exists $rex_opts{$name_param} && $type eq "Single" ) {
           $rex_opts{$name_param}++;

--- a/lib/Rex/Box.pm
+++ b/lib/Rex/Box.pm
@@ -13,6 +13,7 @@ use warnings;
 
 use Rex::Config;
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 my %BOX_PROVIDER;
 
@@ -35,12 +36,11 @@ sub create {
   }
 
   Rex::Logger::debug("Using $klass as box provider");
-  eval "use $klass;";
-
-  if ($@) {
+  eval { use_module( $klass ) }
+      or do {
     Rex::Logger::info("Box Class $klass not found.");
     die("Box Class $klass not found.");
-  }
+  };
 
   return $klass->new( @opts, options => $options );
 }

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -30,14 +30,13 @@ use Rex::Logger;
 use YAML;
 
 use Data::Dumper;
+use Module::Runtime qw(use_module);
 
 my $no_color = 0;
-eval "use Term::ANSIColor";
-if ($@) { $no_color = 1; }
+eval { use_module( "Term::ANSIColor" ) } or do { $no_color = 1; };
 
 if ( $^O =~ m/MSWin/ ) {
-  eval "use Win32::Console::ANSI";
-  if ($@) { $no_color = 1; }
+    eval { use_module( "Win32::Console::ANSI") } or do { $no_color = 1; };
 }
 
 # preload some modules

--- a/lib/Rex/CMDB.pm
+++ b/lib/Rex/CMDB.pm
@@ -41,6 +41,7 @@ use warnings;
 
 # VERSION
 
+use Module::Runtime qw(use_module);
 use Rex::Commands;
 use Rex::Value;
 
@@ -143,10 +144,8 @@ sub cmdb {
     $klass = "Rex::CMDB::$klass";
   }
 
-  eval "use $klass";
-  if ($@) {
-    die("CMDB provider ($klass) not found: $@");
-  }
+  eval { use_module( $klass ) }
+      or die("CMDB provider ($klass) not found: $@");
 
   my $cmdb = $klass->new( %{$CMDB_PROVIDER} );
   return Rex::Value->new( value => ( $cmdb->get( $item, $server ) || undef ) );

--- a/lib/Rex/Cloud.pm
+++ b/lib/Rex/Cloud.pm
@@ -16,6 +16,7 @@ use base qw(Exporter);
 use vars qw(@EXPORT);
 
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 @EXPORT = qw(get_cloud_service);
 
@@ -37,19 +38,18 @@ sub get_cloud_service {
   my ($service) = @_;
 
   if ( exists $CLOUD_SERVICE{"\L$service"} ) {
-    eval "use " . $CLOUD_SERVICE{"\L$service"};
+    use_module $CLOUD_SERVICE{"\L$service"};
 
     my $mod = $CLOUD_SERVICE{"\L$service"};
     return $mod->new;
   }
   else {
-    eval "use Rex::Cloud::$service";
-
-    if ($@) {
+    eval { use_module( "Rex::Cloud::$service") }
+      or do {
       Rex::Logger::info("Cloud Service $service not supported.");
       Rex::Logger::info($@);
       return 0;
-    }
+    };
 
     my $mod = "Rex::Cloud::$service";
     return $mod->new;

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -33,6 +33,7 @@ use warnings;
 require Rex::Exporter;
 use Net::OpenSSH::ShellQuoter;
 use Data::Dumper;
+use Module::Runtime qw(use_module);
 use Rex;
 use Rex::Logger;
 use Rex::Helper::SSH2;
@@ -44,7 +45,7 @@ use Rex::Interface::Fs;
 
 BEGIN {
   if ( $^O !~ m/^MSWin/ ) {
-    eval "use Expect";
+    eval { use_module "Expect"; };
   }
   else {
     # this fails sometimes on windows...

--- a/lib/Rex/Commands/SCM.pm
+++ b/lib/Rex/Commands/SCM.pm
@@ -59,6 +59,7 @@ use warnings;
 
 # VERSION
 
+use Module::Runtime qw(use_module);
 use Rex::Logger;
 use Rex::Config;
 
@@ -93,11 +94,11 @@ sub checkout {
     delete $data{"path"};
   }
 
-  eval "use $class;";
-  if ($@) {
+  eval { use_module( $class) }
+      or do {
     Rex::Logger::info( "Error loading SCM: $@\n", "warn" );
     die("Error loading SCM: $@");
-  }
+  };
 
   my $scm = $class->new;
 

--- a/lib/Rex/Cron.pm
+++ b/lib/Rex/Cron.pm
@@ -13,6 +13,7 @@ use warnings;
 
 use Rex::Commands::Gather;
 use List::Util qw'first';
+use Module::Runtime qw(use_module);
 
 sub create {
   my ($class) = @_;
@@ -33,10 +34,8 @@ sub create {
   }
 
   my $klass = "Rex::Cron::$type";
-  eval "use $klass;";
-  if ($@) {
-    die("Error creating cron class: $klass\n$@");
-  }
+  eval { use_module( $klass ) }
+      or die("Error creating cron class: $klass\n$@");
 
   return $klass->new;
 }

--- a/lib/Rex/Hardware.pm
+++ b/lib/Rex/Hardware.pm
@@ -31,6 +31,7 @@ use warnings;
 # VERSION
 
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 require Rex::Args;
 
@@ -98,13 +99,12 @@ sub get {
     }
 
     Rex::Logger::debug("Loading $mod");
-    eval "use $mod";
-
-    if ($@) {
+    eval { use_module( $mod ) }
+        or do {
       Rex::Logger::info("$mod not found.");
       Rex::Logger::debug("$@");
       next;
-    }
+    };
 
     $hardware_information{$mod_string} = $mod->get();
 

--- a/lib/Rex/Hardware/Network.pm
+++ b/lib/Rex/Hardware/Network.pm
@@ -15,6 +15,7 @@ use Data::Dumper;
 
 use Rex::Commands::Gather;
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 require Rex::Hardware;
 
@@ -64,12 +65,11 @@ sub _get_class {
   $os_type = "Solaris" if Rex::Commands::Gather::is_solaris();
 
   my $hw_class = "Rex::Hardware::Network::$os_type";
-  eval "use $hw_class;";
-
-  if ($@) {
+  eval { use_module($hw_class) }
+      or do {
     Rex::Logger::debug("No network information on $os_type");
     return;
-  }
+  };
 
   return $hw_class;
 }

--- a/lib/Rex/Interface/Cache.pm
+++ b/lib/Rex/Interface/Cache.pm
@@ -9,6 +9,8 @@ package Rex::Interface::Cache;
 use strict;
 use warnings;
 
+use Module::Runtime qw(use_module);
+
 # VERSION
 
 sub create {
@@ -19,8 +21,8 @@ sub create {
   }
 
   my $class_name = "Rex::Interface::Cache::$type";
-  eval "use $class_name;";
-  if ($@) { die("Error loading connection interface $type.\n$@"); }
+  eval { use_module( $class_name) }
+      or die("Error loading connection interface $type.\n$@");
 
   return $class_name->new;
 }

--- a/lib/Rex/Interface/Connection.pm
+++ b/lib/Rex/Interface/Connection.pm
@@ -9,6 +9,8 @@ package Rex::Interface::Connection;
 use strict;
 use warnings;
 
+use Module::Runtime qw(use_module);
+
 # VERSION
 
 sub create {
@@ -19,8 +21,8 @@ sub create {
   }
 
   my $class_name = "Rex::Interface::Connection::$type";
-  eval "use $class_name;";
-  if ($@) { die("Error loading connection interface $type.\n$@"); }
+  eval { use_module( $class_name ) }
+      or die("Error loading connection interface $type.\n$@");
 
   return $class_name->new;
 }

--- a/lib/Rex/Interface/Exec.pm
+++ b/lib/Rex/Interface/Exec.pm
@@ -12,6 +12,7 @@ use warnings;
 # VERSION
 
 use Rex;
+use Module::Runtime qw(use_module);
 
 sub create {
   my ( $class, $type ) = @_;
@@ -23,8 +24,8 @@ sub create {
   }
 
   my $class_name = "Rex::Interface::Exec::$type";
-  eval "use $class_name;";
-  if ($@) { die("Error loading exec interface $type.\n$@"); }
+  eval { use_module( $class_name ) }
+      or die("Error loading exec interface $type.\n$@");
 
   return $class_name->new;
 }

--- a/lib/Rex/Interface/Executor.pm
+++ b/lib/Rex/Interface/Executor.pm
@@ -12,6 +12,7 @@ use warnings;
 # VERSION
 
 use Data::Dumper;
+use Module::Runtime qw(use_module);
 
 sub create {
   my ( $class, $type ) = @_;
@@ -21,8 +22,8 @@ sub create {
   }
 
   my $class_name = "Rex::Interface::Executor::$type";
-  eval "use $class_name;";
-  if ($@) { die("Error loading file interface $type.\n$@"); }
+  eval { use_module( $class_name ) }
+      or die("Error loading file interface $type.\n$@");
 
   return $class_name->new;
 

--- a/lib/Rex/Interface/File.pm
+++ b/lib/Rex/Interface/File.pm
@@ -12,6 +12,7 @@ use warnings;
 # VERSION
 
 use Rex;
+use Module::Runtime qw(use_module);
 
 sub create {
   my ( $class, $type ) = @_;
@@ -34,8 +35,8 @@ sub create {
   }
 
   my $class_name = "Rex::Interface::File::$type";
-  eval "use $class_name;";
-  if ($@) { die("Error loading file interface $type.\n$@"); }
+  eval { use_module( $class_name ) }
+      or die("Error loading file interface $type.\n$@");
 
   return $class_name->new;
 }

--- a/lib/Rex/Interface/Fs.pm
+++ b/lib/Rex/Interface/Fs.pm
@@ -13,6 +13,7 @@ use warnings;
 
 use Rex;
 use Data::Dumper;
+use Module::Runtime qw(use_module);
 
 sub create {
   my ( $class, $type ) = @_;
@@ -35,8 +36,8 @@ sub create {
   }
 
   my $class_name = "Rex::Interface::Fs::$type";
-  eval "use $class_name;";
-  if ($@) { die("Error loading Fs interface $type.\n$@"); }
+  eval { use_module( $class_name ) }
+      or die("Error loading Fs interface $type.\n$@");
 
   return $class_name->new;
 }

--- a/lib/Rex/Interface/Shell.pm
+++ b/lib/Rex/Interface/Shell.pm
@@ -12,6 +12,7 @@ use warnings;
 # VERSION
 
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 my %SHELL_PROVIDER = (
   ash   => "Rex::Interface::Shell::Ash",
@@ -40,8 +41,8 @@ sub create {
   $shell =~ s/[\r\n]//gms; # sometimes there are some wired things...
 
   my $klass = "Rex::Interface::Shell::\u$shell";
-  eval "use $klass";
-  if ($@) {
+  eval { use_module( $klass ) }
+      or do {
     Rex::Logger::info(
       "Can't load wanted shell: '$shell' ('$klass'). Using default shell.",
       "warn" );
@@ -50,8 +51,8 @@ sub create {
       "warn"
     );
     $klass = "Rex::Interface::Shell::Default";
-    eval "use $klass";
-  }
+    use_module( $klass );
+  };
 
   return $klass->new;
 }

--- a/lib/Rex/Inventory/Hal.pm
+++ b/lib/Rex/Inventory/Hal.pm
@@ -14,6 +14,7 @@ use Rex::Commands::Run;
 use Rex::Helper::Run;
 use Rex::Commands::Gather;
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 # VERSION
 
@@ -98,12 +99,12 @@ sub get_object_by_cat_and_udi {
   $rex_class ||= $cat;
 
   my $class_name = "Rex::Inventory::Hal::Object::\u$rex_class";
-  eval "use $class_name";
-  if ($@) {
+  eval { use_module( $class_name ) }
+      or do {
     Rex::Logger::debug(
       "This Hal Object isn't supported yet. Falling back to Base Object.");
     $class_name = "Rex::Inventory::Hal::Object";
-  }
+  };
 
   return $class_name->new( %{ $self->{'__hal'}->{$cat}->{$udi} },
     hal => $self );

--- a/lib/Rex/Logger.pm
+++ b/lib/Rex/Logger.pm
@@ -33,17 +33,19 @@ package Rex::Logger;
 use strict;
 use warnings;
 
+use Module::Runtime qw(use_module);
+
 # VERSION
 
 #use Rex;
 
 our $no_color = 0;
-eval "use Term::ANSIColor";
-if ($@) { $no_color = 1; }
+eval { use_module( "Term::ANSIColor" ) }
+    or do { $no_color = 1; };
 
 if ( $^O =~ m/MSWin/ ) {
-  eval "use Win32::Console::ANSI";
-  if ($@) { $no_color = 1; }
+    eval { use_module( "Win32::Console::ANSI" ) }
+        or do { $no_color = 1; };
 }
 
 my $has_syslog = 0;

--- a/lib/Rex/Output.pm
+++ b/lib/Rex/Output.pm
@@ -16,7 +16,7 @@ BEGIN { IPC::Shareable->use; }
 END   { IPC::Shareable->clean_up_all; }
 
 use base 'Rex::Output::Base';
-
+use Module::Runtime qw(use_module);
 # VERSION
 
 sub get {
@@ -29,10 +29,8 @@ sub get {
   $handle = tie $output_object, 'IPC::Shareable', undef, { destroy => 1 }
     unless $handle;
 
-  eval "use Rex::Output::$output_module;";
-  if ($@) {
-    die("Output Module ,,$output_module'' not found.");
-  }
+  eval { use_module( "Rex::Output::$output_module") }
+      or die("Output Module ,,$output_module'' not found.");
 
   my $output_class = "Rex::Output::$output_module";
   $output_object = $output_class->new;

--- a/lib/Rex/Pkg.pm
+++ b/lib/Rex/Pkg.pm
@@ -18,6 +18,7 @@ use Rex::Hardware::Host;
 use Rex::Logger;
 
 use Data::Dumper;
+use Module::Runtime qw(use_module);
 
 my %PKG_PROVIDER;
 
@@ -59,9 +60,8 @@ sub get {
   }
 
   Rex::Logger::debug("Using $class for package management");
-  eval "use $class";
-
-  if ($@) {
+  eval { use_module( $class ) }
+      or do {
 
     if ($provider) {
       Rex::Logger::info( "Provider not supported (" . $provider . ")" );
@@ -72,7 +72,7 @@ sub get {
     }
     die("OS/Provider not supported");
 
-  }
+  };
 
   return $class->new;
 

--- a/lib/Rex/PkgConf.pm
+++ b/lib/Rex/PkgConf.pm
@@ -16,6 +16,7 @@ use Rex::Commands::Gather;
 use Rex::Hardware;
 use Rex::Hardware::Host;
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 my %PKG_PROVIDER;
 
@@ -54,9 +55,8 @@ sub get {
   }
 
   Rex::Logger::debug("Using $class for package management");
-  eval "use $class";
-
-  if ($@) {
+  eval { use_module( $class ) }
+      or do {
 
     if ($provider) {
       Rex::Logger::info( "Provider not supported (" . $provider . ")" );
@@ -67,7 +67,7 @@ sub get {
     }
     die("OS/Provider not supported");
 
-  }
+  };
 
   return $class->new;
 

--- a/lib/Rex/Report.pm
+++ b/lib/Rex/Report.pm
@@ -9,6 +9,7 @@ package Rex::Report;
 use strict;
 use warnings;
 use Data::Dumper;
+use Module::Runtime qw(use_module);
 
 # VERSION
 
@@ -21,11 +22,8 @@ sub create {
   $type ||= "Base";
 
   my $c = "Rex::Report::$type";
-  eval "use $c";
-
-  if ($@) {
-    die("No reporting class $type found.");
-  }
+  eval { use_module( $c ) }
+      or die("No reporting class $type found.");
 
   $report = $c->new;
   return $report;

--- a/lib/Rex/Service.pm
+++ b/lib/Rex/Service.pm
@@ -17,6 +17,7 @@ use Rex::Hardware;
 use Rex::Hardware::Host;
 use Rex::Helper::Run;
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 my %SERVICE_PROVIDER;
 
@@ -83,14 +84,11 @@ sub get {
   }
 
   Rex::Logger::debug("service using class: $class");
-  eval "use $class";
-
-  if ($@) {
-
+  eval { use_module($class) }
+      or do {
     Rex::Logger::info("OS ($operatingsystem) not supported");
     exit 1;
-
-  }
+  };
 
   return $class->new;
 

--- a/lib/Rex/Shared/Var.pm
+++ b/lib/Rex/Shared/Var.pm
@@ -33,6 +33,7 @@ use warnings;
 require Exporter;
 use base qw(Exporter);
 use vars qw(@EXPORT);
+use Module::Runtime qw(use_module);
 
 @EXPORT = qw(share);
 
@@ -66,17 +67,17 @@ sub share {
       $sym = "${package}::$sym";
 
       if ( $sigil eq "\$" ) {
-        eval "use Rex::Shared::Var::Scalar;";
+        eval { use_module "Rex::Shared::Var::Scalar"; };
         tie $$sym, "Rex::Shared::Var::Scalar", $sym;
         *$sym = \$$sym;
       }
       elsif ( $sigil eq "\@" ) {
-        eval "use Rex::Shared::Var::Array;";
+        eval { use_module "Rex::Shared::Var::Array"; };
         tie @$sym, "Rex::Shared::Var::Array", $sym;
         *$sym = \@$sym;
       }
       elsif ( $sigil eq "\%" ) {
-        eval "use Rex::Shared::Var::Hash;";
+        eval { use_module "Rex::Shared::Var::Hash"; };
         tie %$sym, "Rex::Shared::Var::Hash", $sym;
         *$sym = \%$sym;
       }

--- a/lib/Rex/TaskList.pm
+++ b/lib/Rex/TaskList.pm
@@ -15,6 +15,7 @@ use Data::Dumper;
 use Rex::Config;
 use Rex::Logger;
 use Rex::Interface::Executor;
+use Module::Runtime qw(use_module);
 
 use vars qw(%tasks);
 
@@ -36,10 +37,8 @@ sub create {
 
   my $class_name = "Rex::TaskList::$type";
 
-  eval "use $class_name";
-  if ($@) {
-    die("TaskList module not found: $@");
-  }
+  eval { use_module( $class_name ) }
+      or die("TaskList module not found: $@");
 
   $task_list = $class_name->new;
 

--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -63,6 +63,7 @@ require Rex::Commands;
 use Rex::Commands::Box;
 use Data::Dumper;
 use Carp;
+use Module::Runtime qw(use_module);
 
 require Exporter;
 use base qw(Exporter);
@@ -306,10 +307,8 @@ sub AUTOLOAD {
   }
 
   my $pkg = __PACKAGE__ . "::$real_method";
-  eval "use $pkg";
-  if ($@) {
-    confess "Error loading $pkg. No such test method.";
-  }
+  eval { use_module( $pkg ) }
+      or confess "Error loading $pkg. No such test method.";
 
   my $p = $pkg->new;
   if ($is_not) {

--- a/lib/Rex/User.pm
+++ b/lib/Rex/User.pm
@@ -13,6 +13,7 @@ use warnings;
 
 use Rex::Commands::Gather;
 use Rex::Logger;
+use Module::Runtime qw(use_module);
 
 sub get {
 
@@ -34,14 +35,13 @@ sub get {
   }
 
   my $class = "Rex::User::" . $user_o;
-  eval "use $class";
-
-  if ($@) {
+  eval { use_module( $class ) }
+      or do {
 
     Rex::Logger::info("OS not supported");
     die("OS not supported");
 
-  }
+  };
 
   return $class->new;
 

--- a/lib/Rex/Virtualization.pm
+++ b/lib/Rex/Virtualization.pm
@@ -13,6 +13,7 @@ use warnings;
 
 use Rex::Logger;
 use Rex::Config;
+use Module::Runtime qw(use_module);
 
 my %VM_PROVIDER;
 
@@ -58,12 +59,9 @@ sub create {
     $klass = $VM_PROVIDER{$wanted_provider};
   }
 
-  eval "use $klass";
-
-  if ($@) {
-    die
+  eval { use_module( $klass ) }
+      or die
       "Failed loading given virtualization module.\nTried to load <$klass>.\nError: $@\n";
-  }
 
   Rex::Logger::debug("Using $klass for virtualization");
 

--- a/lib/Rex/Virtualization/Base.pm
+++ b/lib/Rex/Virtualization/Base.pm
@@ -9,6 +9,8 @@ package Rex::Virtualization::Base;
 use strict;
 use warnings;
 
+use Module::Runtime qw(use_module);
+
 # VERSION
 
 sub new {
@@ -25,12 +27,11 @@ sub execute {
   my ( $self, $action, $vmname, @opt ) = @_;
 
   my $mod = ref($self) . "::$action";
-  eval "use $mod;";
-
-  if ($@) {
+  eval { use_module( $mod ) }
+      or do {
     Rex::Logger::info("No action $action available.");
     die("No action $action available.");
-  }
+  };
 
   return $mod->execute( $vmname, @opt );
 


### PR DESCRIPTION
Module::Runtime does error checking and input sanitizing,
which be better make use of than try to do ourselves.

Besides, the pattern using eval() warns on critic tests,
which we're resolving through this commit too.