### PR TITLE
* Fix critic 'select-as-sleep' failure

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -47,6 +47,7 @@ Net::SSH2 = 0
 
 [Prereqs]
 perl = 5.008008
+Time::HiRes = 0
 YAML = != 1.25
 
 [Prereqs / BuildRequires]

--- a/lib/Rex/Helper/SSH2.pm
+++ b/lib/Rex/Helper/SSH2.pm
@@ -14,6 +14,7 @@ use warnings;
 require Exporter;
 use Data::Dumper;
 require Rex::Commands;
+use Time::HiRes qw(sleep);
 
 use base qw(Exporter);
 
@@ -95,7 +96,7 @@ END_READ:
   my $wait_max = $rex_int_conf->{ssh2_channel_closewait_max} || 500;
   while ( !$chan->eof ) {
     Rex::Logger::debug("Waiting for eof on ssh channel.");
-    select undef, undef, undef, 0.002; # wait a little for retry
+    sleep 0.002;
     $wait_c++;
     if ( $wait_c >= $wait_max ) {
 


### PR DESCRIPTION
In an effort to remove Critic complaints (and to clean up the code base),
use modules readily available for the specific purposes.