### PR TITLE
Use Travis CI for testing (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: perl
+perl:
+  - "5.30"
+env:
+  - AUTHOR_TESTING=1 RELEASE_TESTING=1 PERL_CPANM_OPT="--quiet --notest"
+cache:
+  directories:
+    - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/lib
+    - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/bin
+before_install:
+  - dzil authordeps --missing | cpanm
+  - dzil listdeps --missing | cpanm
+  - cpanm DBI IPC::Shareable Parallel::ForkManager Digest::HMAC_SHA1
+  - cpanm String::Escape XML::LibXML Net::SFTP::Foreign IO::Pty Test::mysqld
+install:
+  - dzil build --in build --notgz
+script:
+  - cd build && prove --timer --lib --recurse --jobs $(nproc) --shuffle t/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rex [![Build Status](http://build.rexify.org/buildStatus/icon?job=Master%20branch&a=1)](https://build.rexify.org/view/Local%20Tests/job/Master%20branch/)
+# Rex [![Build Status](https://travis-ci.org/RexOps/Rex.svg?branch=master)](https://travis-ci.org/RexOps/Rex)
 
 With (R)?ex you can manage all your boxes from a central point through the complete process of configuration management and software deployment.
 

--- a/dist.ini
+++ b/dist.ini
@@ -46,13 +46,13 @@ Net::SSH2 = 0
 [PodSyntaxTests]
 
 [Prereqs]
-perl = 5.008008
+perl = 5.010001
 YAML = != 1.25
 
 [Prereqs / BuildRequires]
 Test::Pod = 0
 
 [Test::MinimumVersion]
-max_target_perl = 5.8.8
+max_target_perl = 5.10.1
 
 ; [Test::Perl::Critic]

--- a/dist.ini
+++ b/dist.ini
@@ -55,5 +55,4 @@ Test::Pod = 0
 [Test::MinimumVersion]
 max_target_perl = 5.8.8
 
-[Test::Perl::Critic]
-critic_config = ../../.perlcriticrc
+; [Test::Perl::Critic]


### PR DESCRIPTION
This PR is salvaging parts of previous work done on #1005, and also recent work done by @ehuelsmann on #1221.

After exploring the current state and previous approach, I believe this is the minimum amount of change that is needed to start testing with Travis CI.

The goal was to start running the existing tests with Travis CI, and use that as a base to add further tests. We decided to disable author tests for perlcritic violations for now, in order to get automated feedback as soon as possible. We can enable them again with fixes in a separate PR soon after this.

This PR also finally and officially bumps the minimum required perl to 5.10.1 in order to make the related tests happy again.

I tried to update all the Travis config to their current day requirement and best practices too.