### PR TITLE
Test for code tidyness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ cache:
     - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/lib
     - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/bin
 before_install:
+  - cpanm Perl::Critic
+  - perlcritic --quiet --single-policy=RequireTidyCode bin
   - dzil authordeps --missing | cpanm
-  - dzil listdeps --missing | cpanm
+  - dzil listdeps --author --missing | cpanm
   - cpanm DBI IPC::Shareable Parallel::ForkManager Digest::HMAC_SHA1
   - cpanm String::Escape XML::LibXML Net::SFTP::Foreign IO::Pty Test::mysqld
 install:

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -20,7 +20,6 @@ MYMETA.json
 MYMETA.yml
 .DS_Store
 screencasts
-.perltidyrc
 misc
 README.md
 vars\..*

--- a/bin/rexify
+++ b/bin/rexify
@@ -252,7 +252,7 @@ sub download_recipe_local_tar_gz {
 sub upload_rexfile {
   my (%option) = @_;
 
-  my $tmp_dir = File::Spec->tmpdir;
+  my $tmp_dir  = File::Spec->tmpdir;
   my $tmp_file = File::Spec->catfile( $tmp_dir, basename(getcwd) . ".tar.gz" );
 
   my $login_url = $option{server} . "/login";
@@ -491,7 +491,7 @@ sub resolve_deps {
         }
 
         my $curdir = getcwd;
-        my $path = File::Spec->catdir( File::Spec->tmpdir, "tmp-build-$$" );
+        my $path   = File::Spec->catdir( File::Spec->tmpdir, "tmp-build-$$" );
 
         my $lib_path =
           File::Spec->catdir( File::Spec->rel2abs( File::Spec->curdir() ),

--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,14 @@ copyright_holder = Jan Gehring
 [@Filter]
 -bundle = @Basic
 -remove = MakeMaker
+-remove = GatherDir
+-remove = PruneCruft
+
+[GatherDir]
+include_dotfiles = 1
+
+[PruneCruft]
+except = \.perltidyrc
 
 [AutoPrereqs]
 skip = __Rexfile__
@@ -51,6 +59,9 @@ YAML = != 1.25
 
 [Prereqs / BuildRequires]
 Test::Pod = 0
+
+[Prereqs / DevelopRequires]
+Test::PerlTidy = 0
 
 [Test::MinimumVersion]
 max_target_perl = 5.10.1

--- a/lib/Rex/Batch.pm
+++ b/lib/Rex/Batch.pm
@@ -50,7 +50,7 @@ sub get_desc {
 
 sub get_batchs {
   my $class = shift;
-  my @a = sort { $a cmp $b } keys %batchs;
+  my @a     = sort { $a cmp $b } keys %batchs;
 }
 
 sub is_batch {

--- a/lib/Rex/Box/Base.pm
+++ b/lib/Rex/Box/Base.pm
@@ -399,7 +399,7 @@ sub _download {
           print $fh $data;
 
           my $current_time = [ gettimeofday() ];
-          my $time_diff = tv_interval( $start_time, $current_time );
+          my $time_diff    = tv_interval( $start_time, $current_time );
 
           my $bytes_per_seconds = $current_size / $time_diff;
 

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -485,9 +485,10 @@ sub _list_tasks {
   Rex::Logger::debug("Listing Tasks");
 
   my @tasks;
-  if($opts{'a'}) {
+  if ( $opts{'a'} ) {
     @tasks = sort Rex::TaskList->create()->get_all_tasks(qr/.*/);
-  } else {
+  }
+  else {
     @tasks = Rex::TaskList->create()->get_tasks;
   }
 
@@ -543,7 +544,7 @@ sub _list_batches {
 
   _print_color( "Batches\n", 'yellow' );
   my $max_batch_len = max map { length } @batchs;
-  my $fmt = " %-" . $max_batch_len . "s  %s\n";
+  my $fmt           = " %-" . $max_batch_len . "s  %s\n";
 
   for my $batch ( sort @batchs ) {
     my $description = Rex::Batch->get_desc($batch);
@@ -569,7 +570,7 @@ sub _list_envs {
 
   _print_color( "Environments\n", "yellow" ) if scalar @envs;
   my $max_env_len = max map { length $_->{name} } @envs;
-  my $fmt = " %-" . $max_env_len . "s  %s\n";
+  my $fmt         = " %-" . $max_env_len . "s  %s\n";
 
   for my $e ( sort @envs ) {
     my $output = sprintf $fmt, $e->{name}, $e->{description};
@@ -588,10 +589,10 @@ sub _list_groups {
 
   _print_color( "Server Groups\n", "yellow" );
   my $max_group_len = max map { length } @group_names;
-  my $fmt = " %-" . $max_group_len . "s  %s\n";
+  my $fmt           = " %-" . $max_group_len . "s  %s\n";
 
   for my $group_name (@group_names) {
-    my $hosts = join( ", ", sort @{ $groups{$group_name} } );
+    my $hosts  = join( ", ", sort @{ $groups{$group_name} } );
     my $output = sprintf $fmt, $group_name, $hosts;
     my $indent = " " x $max_group_len . "   ";
     print wrap( "", $indent, $output );
@@ -765,7 +766,7 @@ sub load_rexfile {
     if ($stderr) {
       my @lines = split( $/, $stderr );
       Rex::Logger::info( "You have some code warnings:", 'warn' );
-      Rex::Logger::info( "\t$_", 'warn' ) for @lines;
+      Rex::Logger::info( "\t$_",                         'warn' ) for @lines;
     }
 
     1;
@@ -782,7 +783,7 @@ sub load_rexfile {
     my @lines = split( $/, $e );
 
     Rex::Logger::info( "Compile time errors:", 'error' );
-    Rex::Logger::info( "\t$_", 'error' ) for @lines;
+    Rex::Logger::info( "\t$_",                 'error' ) for @lines;
 
     exit 1;
   }

--- a/lib/Rex/CMDB/YAML.pm
+++ b/lib/Rex/CMDB/YAML.pm
@@ -113,7 +113,7 @@ sub get {
     if ( -f $file ) {
 
       my $content = eval { local ( @ARGV, $/ ) = ($file); <>; };
-      my $t = Rex::Config->get_template_function();
+      my $t       = Rex::Config->get_template_function();
       $content .= "\n"; # for safety
       $content = $t->( $content, \%template_vars );
 

--- a/lib/Rex/Cloud/Amazon.pm
+++ b/lib/Rex/Cloud/Amazon.pm
@@ -258,7 +258,7 @@ sub create_volume {
 
   my $xml = $self->_request(
     "CreateVolume",
-    "Size" => $data{"size"} || 1,
+    "Size"             => $data{"size"} || 1,
     "AvailabilityZone" => $data{"zone"},
   );
 

--- a/lib/Rex/Cloud/OpenStack.pm
+++ b/lib/Rex/Cloud/OpenStack.pm
@@ -73,7 +73,7 @@ sub _authenticate {
 
   my $auth_data = {
     auth => {
-      tenantName => $self->{auth}{tenant_name} || '',
+      tenantName          => $self->{auth}{tenant_name} || '',
       passwordCredentials => {
         username => $self->{auth}{username},
         password => $self->{auth}{password},
@@ -323,7 +323,7 @@ sub create_volume {
 
   my $request_data = {
     volume => {
-      size => $data{size} || 1,
+      size              => $data{size} || 1,
       availability_zone => $data{zone},
     }
   };

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -573,7 +573,7 @@ sub auth {
   if ( !$group ) {
     Rex::Logger::debug("No group $entity found, looking for a task.");
     if ( ref($entity) eq "Regexp" ) {
-      my @tasks = Rex::TaskList->create()->get_tasks;
+      my @tasks          = Rex::TaskList->create()->get_tasks;
       my @selected_tasks = grep { m/$entity/ } @tasks;
       for my $t (@selected_tasks) {
         auth( $_d, $t, %data );
@@ -1016,7 +1016,7 @@ sub needs {
 
   my $tl = Rex::TaskList->create();
   my @maybe_tasks_to_run;
-  if($self) {
+  if ($self) {
     @maybe_tasks_to_run = $tl->get_all_tasks(qr{^\Q$self\E:[A-Za-z0-9_\-]+$});
   }
   else {
@@ -1026,7 +1026,7 @@ sub needs {
   if ( !@args && !@maybe_tasks_to_run ) {
     @args = ($self);
     ($self) = caller;
-    $self = "" if($self =~ m/^(Rex::CLI|main)$/);
+    $self = "" if ( $self =~ m/^(Rex::CLI|main)$/ );
   }
 
   if ( ref( $args[0] ) eq "ARRAY" ) {
@@ -1039,7 +1039,7 @@ sub needs {
   $self =~ s/::/:/g;
 
   my @tasks_to_run;
-  if($self) {
+  if ($self) {
     @tasks_to_run = $tl->get_all_tasks(qr{^\Q$self\E:[A-Za-z0-9_\-]+$});
   }
   else {
@@ -1051,16 +1051,16 @@ sub needs {
   my %task_opts    = $current_task->get_opts;
   my @task_args    = $current_task->get_args;
 
-  if($self) {
+  if ($self) {
     my $suffix = $self;
     $suffix =~ s/::/:/g;
     @args = map { $_ = "$suffix:$_" } @args;
   }
 
   for my $task (@tasks_to_run) {
-    my $task_o = $tl->get_task($task);
+    my $task_o    = $tl->get_task($task);
     my $task_name = $task_o->name;
-    my $suffix = $self . ":";
+    my $suffix    = $self . ":";
     if ( @args && grep ( /^\Q$task_name\E$/, @args ) ) {
       Rex::Logger::debug( "Calling " . $task_o->name );
       $task_o->run( "<func>", params => \@task_args, args => \%task_opts );
@@ -1500,7 +1500,7 @@ sub profiler {
   my $c_profiler = Rex::get_current_connection()->{"profiler"};
   unless ($c_profiler) {
     $c_profiler = $profiler || Rex::Profiler->new;
-    $profiler = $c_profiler;
+    $profiler   = $c_profiler;
   }
 
   return $c_profiler;

--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -298,7 +298,7 @@ Check if an item exists.
     my $file = shift @options;
 
     my $aug_key = $file;
-    my $val = $options[0] || "";
+    my $val     = $options[0] || "";
 
     if ( $is_ssh || !$has_config_augeas ) {
       my @paths;

--- a/lib/Rex/Commands/Cron.pm
+++ b/lib/Rex/Commands/Cron.pm
@@ -107,7 +107,7 @@ sub cron_entry {
     %option = $c->_create_defaults(%option);
 
     my @crons = &cron( list => $user );
-    my $i = 0;
+    my $i     = 0;
     my $cron_id;
     for my $cron (@crons) {
       if ( $cron->{minute} eq $option{minute}

--- a/lib/Rex/Commands/Download.pm
+++ b/lib/Rex/Commands/Download.pm
@@ -103,7 +103,7 @@ sub download {
 
   Rex::Logger::debug("saving file to $local");
   $remote = resolv_path($remote);
-  $local = resolv_path( $local, 1 );
+  $local  = resolv_path( $local, 1 );
 
   if ( $remote =~ m/^(https?|ftp):\/\// ) {
     _http_download( $remote, $local, %option );
@@ -172,7 +172,7 @@ sub _get_http {
   }
   elsif ($has_lwp) {
     Rex::Logger::debug("Downloading via LWP::UserAgent");
-    my $ua = Rex::Helper::UserAgent->new;
+    my $ua   = Rex::Helper::UserAgent->new;
     my $resp = $ua->get( $url, %option );
     if ( $resp->is_success ) {
       $html = $resp->content;

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -407,7 +407,7 @@ sub file {
   Rex::get_current_connection()->{reporter}
     ->report_resource_start( type => "file", name => $file );
 
-  my $need_md5 = ( $option->{"on_change"} && !$is_directory ? 1 : 0 );
+  my $need_md5  = ( $option->{"on_change"} && !$is_directory ? 1 : 0 );
   my $on_change = $option->{"on_change"} || sub { };
 
   my $fs = Rex::Interface::Fs->create;
@@ -442,7 +442,7 @@ sub file {
       : $file_name
     );
 
-    my $fh = file_write($tmp_file_name);
+    my $fh    = file_write($tmp_file_name);
     my @lines = split( qr{$/}, $option->{"content"} );
     for my $line (@lines) {
       $fh->write( $line . $/ );
@@ -862,7 +862,7 @@ sub delete_lines_matching {
     die("$file not writable");
   }
 
-  my $nl = $/;
+  my $nl      = $/;
   my @content = split( /$nl/, cat($file) );
 
   my $old_md5 = "";
@@ -922,7 +922,7 @@ sub delete_lines_according_to {
   my ( $search, $file, @options ) = @_;
   $file = resolv_path($file);
 
-  my $option = {@options};
+  my $option    = {@options};
   my $on_change = $option->{on_change} || undef;
 
   my ( $old_md5, $new_md5 );

--- a/lib/Rex/Commands/Fs.pm
+++ b/lib/Rex/Commands/Fs.pm
@@ -1059,7 +1059,7 @@ sub mount {
         die("Can't open /etc/fstab for reading.");
       }
 
-      my $f = Rex::FS::File->new( fh => $fh );
+      my $f       = Rex::FS::File->new( fh => $fh );
       my @content = $f->read_all;
       $f->close;
 

--- a/lib/Rex/Commands/Iptables.pm
+++ b/lib/Rex/Commands/Iptables.pm
@@ -626,7 +626,7 @@ sub _get_executable {
   my $cache_key_name = "iptables.$ip_version.executable";
   return $cache->get($cache_key_name) if $cache->valid($cache_key_name);
 
-  my $binary = $ip_version == -6 ? "ip6tables" : "iptables";
+  my $binary     = $ip_version == -6 ? "ip6tables" : "iptables";
   my $executable = can_run($binary);
   die "Can't find $binary in PATH" if $executable eq '';
   $cache->set( $cache_key_name, $executable );
@@ -643,7 +643,7 @@ sub _iptables_version {
     if $cache->valid($cache_key_name);
 
   my $iptables = _get_executable( \@params );
-  my $out = i_run( "$iptables -V", fail_ok => 1 );
+  my $out      = i_run( "$iptables -V", fail_ok => 1 );
   if ( $out =~ /v([.\d]+)/ms ) {
     my $version = version->parse($1);
     $cache->set( $cache_key_name, "$version" );

--- a/lib/Rex/Commands/Kernel.pm
+++ b/lib/Rex/Commands/Kernel.pm
@@ -98,7 +98,7 @@ sub kmod {
 
     $unload_command = sub {
       my @mod_split = split( /\//, $module );
-      my $mod = $mod_split[-1];
+      my $mod       = $mod_split[-1];
 
       my ($mod_id) = map { /^\s*(\d+)\s+.*$mod/ } i_run "modinfo";
       my $cmd = "modunload -i $mod_id";

--- a/lib/Rex/Commands/Partition.pm
+++ b/lib/Rex/Commands/Partition.pm
@@ -96,7 +96,8 @@ sub clearpart {
     }
   }
   else {
-    my @partitions = grep { /\Q$o_disk\Ep?\d+$/ } split /\n/, cat "/proc/partitions";
+    my @partitions = grep { /\Q$o_disk\Ep?\d+$/ } split /\n/,
+      cat "/proc/partitions";
 
     for my $part_line (@partitions) {
       my ( $num, $part ) = ( $part_line =~ m/\d+\s+(\d+)\s+\d+\s(.*)$/ );

--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -337,7 +337,7 @@ sub install {
     }
     else {
 
-      my $source = Rex::Helper::Path::get_file_path( $source, caller() );
+      my $source  = Rex::Helper::Path::get_file_path( $source, caller() );
       my $content = eval { local ( @ARGV, $/ ) = ($source); <>; };
 
       my $local_md5 = "";

--- a/lib/Rex/Commands/SCM.pm
+++ b/lib/Rex/Commands/SCM.pm
@@ -83,7 +83,7 @@ With this function you can checkout a repository defined with I<set repository>.
 sub checkout {
   my ( $name, %data ) = @_;
 
-  my $type = $REPOS{"$name"}->{"type"} ? $REPOS{$name}->{"type"} : "git";
+  my $type  = $REPOS{"$name"}->{"type"} ? $REPOS{$name}->{"type"} : "git";
   my $class = "Rex::SCM::\u$type";
 
   my $co_to = exists $data{"path"} ? $data{"path"} : "";

--- a/lib/Rex/Commands/Service.pm
+++ b/lib/Rex/Commands/Service.pm
@@ -360,7 +360,7 @@ sub old_service {
 
     if ( $srvc->ensure( $service, { ensure => $options } ) ) {
       $changed = 0;
-      $return = 1 if !$is_multiple;
+      $return  = 1 if !$is_multiple;
     }
     else {
       $return = 0 if !$is_multiple;

--- a/lib/Rex/Commands/Upload.pm
+++ b/lib/Rex/Commands/Upload.pm
@@ -94,7 +94,7 @@ sub upload {
 
   my ( $local, $remote ) = @_;
 
-  $local = resolv_path( $local, 1 );
+  $local  = resolv_path( $local, 1 );
   $remote = resolv_path($remote);
 
   my $fs = Rex::Interface::Fs->create;

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -1006,7 +1006,7 @@ sub _parse_ssh_config {
 
     if ( $line =~ m/^Host(?:\s*=\s*|\s+)(.*)$/i ) {
       my $host_tmp = $1;
-      @host = split( /\s+/, $host_tmp );
+      @host    = split( /\s+/, $host_tmp );
       $in_host = 1;
       for my $h (@host) {
         $ret{$h} = {};

--- a/lib/Rex/Cron/Base.pm
+++ b/lib/Rex/Cron/Base.pm
@@ -44,8 +44,8 @@ sub list_jobs {
 
 sub list_envs {
   my ($self) = @_;
-  my @jobs = @{ $self->{cron} };
-  my @ret = grep { $_->{type} eq "env" } @jobs;
+  my @jobs   = @{ $self->{cron} };
+  my @ret    = grep { $_->{type} eq "env" } @jobs;
 }
 
 sub add {
@@ -253,8 +253,8 @@ sub parse_cron {
 
     elsif ( $line =~ m/=/ ) {
       my ( $name, $value ) = split( /=/, $line, 2 );
-      $name =~ s/^\s+//;
-      $name =~ s/\s+$//;
+      $name  =~ s/^\s+//;
+      $name  =~ s/\s+$//;
       $value =~ s/^\s+//;
       $value =~ s/\s+$//;
 

--- a/lib/Rex/Fork/Task.pm
+++ b/lib/Rex/Fork/Task.pm
@@ -28,7 +28,7 @@ sub start {
   my ($self) = @_;
 
   $self->{'running'} = 1;
-  $self->{pid} = fork;
+  $self->{pid}       = fork;
 
   if ( !$self->{pid} ) {
     $self->{coderef}->($self);

--- a/lib/Rex/Hardware/Host.pm
+++ b/lib/Rex/Hardware/Host.pm
@@ -271,18 +271,19 @@ sub get_operating_system_version {
     return [ split( /\s+/, $content ) ]->[-1];
   }
 
-elsif ( $op eq "SuSE" ) {
+  elsif ( $op eq "SuSE" ) {
 
     my ( $version, $release );
 
     my $release_file;
     if ( is_file("/etc/os-release") ) {
       $release_file = "/etc/os-release";
-    } else {
+    }
+    else {
       $release_file = "/etc/SuSE-release";
     }
 
-    my $fh = file_read($release_file);
+    my $fh      = file_read($release_file);
     my $content = $fh->read_all;
     $fh->close;
 

--- a/lib/Rex/Hardware/Memory.pm
+++ b/lib/Rex/Hardware/Memory.pm
@@ -77,7 +77,7 @@ sub get {
 
   }
   elsif ( $os eq "OpenBSD" ) {
-    my $mem_str = i_run "top -d1 | grep Memory:", fail_ok => 1;
+    my $mem_str   = i_run "top -d1 | grep Memory:", fail_ok => 1;
     my $total_mem = sysctl("hw.physmem");
 
     my ( $phys_mem, $p_m_ent, $virt_mem, $v_m_ent, $free, $f_ent ) =
@@ -95,7 +95,7 @@ sub get {
 
   }
   elsif ( $os eq "NetBSD" ) {
-    my $mem_str = i_run "top -d1 | grep Memory:", fail_ok => 1;
+    my $mem_str   = i_run "top -d1 | grep Memory:", fail_ok => 1;
     my $total_mem = sysctl("hw.physmem");
 
     my (
@@ -123,7 +123,7 @@ sub get {
 
   }
   elsif ( $os =~ /FreeBSD/ ) {
-    my $mem_str = i_run "top -d1 | grep Mem:", fail_ok => 1;
+    my $mem_str   = i_run "top -d1 | grep Mem:", fail_ok => 1;
     my $total_mem = sysctl("hw.physmem");
 
     my (

--- a/lib/Rex/Hardware/Network/FreeBSD.pm
+++ b/lib/Rex/Hardware/Network/FreeBSD.pm
@@ -35,14 +35,14 @@ sub get_network_configuration {
     my $ifconfig = i_run("ifconfig $dev");
 
     $device_info->{$dev} = {
-      ip => [ ( $ifconfig =~ m/inet (\d+\.\d+\.\d+\.\d+)/ ) ]->[0],
+      ip      => [ ( $ifconfig =~ m/inet (\d+\.\d+\.\d+\.\d+)/ ) ]->[0],
       netmask => $ifconfig =~ m/(?:netmask 0x|netmask )([a-f0-9]+)/
       ? sprintf( "%d.%d.%d.%d", unpack "C4", pack "H*", $1 )
       : undef,
       broadcast => [ ( $ifconfig =~ m/broadcast (\d+\.\d+\.\d+\.\d+)/ ) ]->[0],
-      mac => [
+      mac       => [
         ( $ifconfig =~ m/(ether|address:|lladdr) (..?:..?:..?:..?:..?:..?)/ )
-        ]->[1],
+      ]->[1],
       is_bridge => 0,
     };
 

--- a/lib/Rex/Hardware/Network/Linux.pm
+++ b/lib/Rex/Hardware/Network/Linux.pm
@@ -51,7 +51,7 @@ sub get_bridge_devices {
 sub get_network_devices {
 
   my $command = can_run('ip') ? 'ip addr show' : 'ifconfig -a';
-  my @output = i_run( "$command", fail_ok => 1 );
+  my @output  = i_run( "$command", fail_ok => 1 );
 
   my $devices =
     ( $command eq 'ip addr show' )
@@ -67,7 +67,7 @@ sub get_network_configuration {
   my $device_info = {};
 
   my $command = can_run('ip') ? 'ip addr show' : 'ifconfig -a';
-  my @output = i_run( "$command", fail_ok => 1 );
+  my @output  = i_run( "$command", fail_ok => 1 );
 
   my $br_data = get_bridge_devices();
 
@@ -387,7 +387,7 @@ sub netstat {
 
       $state =~ s/^\s|\s$//g if ($state);
       $flags =~ s/\s+$//     if ($flags);
-      $cmd =~ s/\s+$//;
+      $cmd   =~ s/\s+$//;
 
       my $data = {
         proto   => $proto,
@@ -414,7 +414,7 @@ sub _convert_cidr_prefix {
   my ($cidr_prefix) = @_;
 
   # convert CIDR prefix to dotted decimal notation
-  my $binary_mask = '1' x $cidr_prefix . '0' x ( 32 - $cidr_prefix );
+  my $binary_mask         = '1' x $cidr_prefix . '0' x ( 32 - $cidr_prefix );
   my $dotted_decimal_mask = join '.', unpack 'C4', pack 'B32', $binary_mask;
 
   return $dotted_decimal_mask;

--- a/lib/Rex/Hardware/Network/Solaris.pm
+++ b/lib/Rex/Hardware/Network/Solaris.pm
@@ -38,9 +38,9 @@ sub get_network_configuration {
       ip      => [ ( $ifconfig =~ m/inet (\d+\.\d+\.\d+\.\d+)/ ) ]->[0],
       netmask => [ ( $ifconfig =~ m/(netmask 0x|netmask )([a-f0-9]+)/ ) ]->[1],
       broadcast => [ ( $ifconfig =~ m/broadcast (\d+\.\d+\.\d+\.\d+)/ ) ]->[0],
-      mac => [
+      mac       => [
         ( $ifconfig =~ m/(ether|address:|lladdr) (..?:..?:..?:..?:..?:..?)/ )
-        ]->[1],
+      ]->[1],
       is_bridge => 0,
     };
 

--- a/lib/Rex/Helper/SSH2.pm
+++ b/lib/Rex/Helper/SSH2.pm
@@ -43,7 +43,7 @@ sub net_ssh2_exec {
   my $in_err = "";
 
   my $rex_int_conf = Rex::Commands::get("rex_internals") || {};
-  my $buffer_size = 1024;
+  my $buffer_size  = 1024;
   if ( exists $rex_int_conf->{read_buffer_size} ) {
     $buffer_size = $rex_int_conf->{read_buffer_size};
   }
@@ -91,7 +91,7 @@ sub net_ssh2_exec {
 END_READ:
   $chan->send_eof;
 
-  my $wait_c = 0;
+  my $wait_c   = 0;
   my $wait_max = $rex_int_conf->{ssh2_channel_closewait_max} || 500;
   while ( !$chan->eof ) {
     Rex::Logger::debug("Waiting for eof on ssh channel.");
@@ -112,7 +112,7 @@ END_READ:
 
   # if used with $chan->pty() we have to remove \r
   if ( !Rex::Config->get_no_tty ) {
-    $in =~ s/\r//g     if $in;
+    $in     =~ s/\r//g if $in;
     $in_err =~ s/\r//g if $in_err;
   }
 

--- a/lib/Rex/Helper/SSH2/Expect.pm
+++ b/lib/Rex/Helper/SSH2/Expect.pm
@@ -78,7 +78,7 @@ sub new {
   $self->{"__shell"}->shell;
 
   $self->{"__log_stdout"} = $Rex::Helper::SSH2::Expect::Log_Stdout;
-  $self->{"__log_to"} = sub { };
+  $self->{"__log_to"}     = sub { };
 
   return $self;
 }

--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -60,7 +60,7 @@ sub connect {
 
   my $proxy_command = Rex::Config->get_proxy_command( server => $server );
 
-  $port ||= Rex::Config->get_port( server => $server ) || 22;
+  $port    ||= Rex::Config->get_port( server => $server )    || 22;
   $timeout ||= Rex::Config->get_timeout( server => $server ) || 3;
 
   $server =

--- a/lib/Rex/Interface/Connection/SSH.pm
+++ b/lib/Rex/Interface/Connection/SSH.pm
@@ -63,7 +63,7 @@ sub connect {
   my $fail_connect = 0;
 
 CON_SSH:
-  $port ||= Rex::Config->get_port( server => $server ) || 22;
+  $port    ||= Rex::Config->get_port( server => $server )    || 22;
   $timeout ||= Rex::Config->get_timeout( server => $server ) || 3;
   $self->{ssh}->timeout( $timeout * 1000 );
 

--- a/lib/Rex/Interface/Exec/IOReader.pm
+++ b/lib/Rex/Interface/Exec/IOReader.pm
@@ -22,7 +22,7 @@ sub io_read {
   $selector->add($err_fh);
 
   my $rex_int_conf = Rex::Commands::get("rex_internals") || {};
-  my $buffer_size = 1024;
+  my $buffer_size  = 1024;
   if ( exists $rex_int_conf->{read_buffer_size} ) {
     $buffer_size = $rex_int_conf->{read_buffer_size};
   }

--- a/lib/Rex/Interface/Exec/Sudo.pm
+++ b/lib/Rex/Interface/Exec/Sudo.pm
@@ -75,7 +75,7 @@ sub exec {
 
   if ($sudo_password) {
     my $random_string = get_random( length($sudo_password), 'a' .. 'z' );
-    my $crypt = $sudo_password ^ $random_string;
+    my $crypt         = $sudo_password ^ $random_string;
 
     $random_file = get_tmp_file;
 

--- a/lib/Rex/Interface/File/OpenSSH.pm
+++ b/lib/Rex/Interface/File/OpenSSH.pm
@@ -59,7 +59,7 @@ sub read {
   my ( $self, $len ) = @_;
 
   my $sftp = Rex::get_sftp();
-  my $buf = $sftp->read( $self->{fh}, $len );
+  my $buf  = $sftp->read( $self->{fh}, $len );
   return $buf;
 }
 

--- a/lib/Rex/Interface/Shell/Base.pm
+++ b/lib/Rex/Interface/Shell/Base.pm
@@ -52,9 +52,9 @@ sub set_sudo_env {
 sub detect {
   my ( $self, $con ) = @_;
 
-  my $shell_class = ref $self || $self; # $self might be only the classname
-  my @parts = split /::/, $shell_class;
-  my $last_part = lc( $parts[-1] || "" );
+  my $shell_class = ref $self || $self;      # $self might be only the classname
+  my @parts       = split /::/, $shell_class;
+  my $last_part   = lc( $parts[-1] || "" );
 
   my ($shell_path) = $con->_exec("echo \$SHELL");
   if ( !$shell_path ) {

--- a/lib/Rex/Inventory.pm
+++ b/lib/Rex/Inventory.pm
@@ -110,7 +110,7 @@ sub get {
             push(
               @raid_logical_drives,
               {
-                status => ( $l_drive_data->{"status"} eq "OK" ? 1 : 0 ),
+                status     => ( $l_drive_data->{"status"} eq "OK" ? 1 : 0 ),
                 raid_level => $l_drive_data->{"fault_tolerance"},
                 size       => sprintf( "%i", $size * $multi ),
                 dev        => $l_drive_data->{"disk_name"},
@@ -152,8 +152,8 @@ sub get {
   }
 
   return {
-    base_board => ( $base_board ? $base_board->get_all() : {} ),
-    bios => $bios->get_all(),
+    base_board  => ( $base_board ? $base_board->get_all() : {} ),
+    bios        => $bios->get_all(),
     system_info => $sys_info->get_all(),
     cpus        => sub {
       my $ret = [];

--- a/lib/Rex/Inventory/DMIDecode.pm
+++ b/lib/Rex/Inventory/DMIDecode.pm
@@ -200,9 +200,9 @@ sub _read_dmidecode {
 
       my ( $key, $val ) = split( /: /, $line, 2 );
       if ( !$val ) { $key =~ s/:$//; }
-      $sub_section = $key;
+      $sub_section       = $key;
       $section{$section} = [ { $key => $val } ];
-      $new_section = 0;
+      $new_section       = 0;
     }
     elsif ( $l =~ m/^\t\t[a-zA-Z0-9]/ ) {
       my $href = $section{$section}->[-1];

--- a/lib/Rex/Pkg/Base.pm
+++ b/lib/Rex/Pkg/Base.pm
@@ -103,7 +103,7 @@ sub update_system {
 
   if ( $option{update_packages} ) {
     my $cmd = $self->{commands}->{update_system};
-    my $f = i_run $cmd, fail_ok => 1;
+    my $f   = i_run $cmd, fail_ok => 1;
 
     unless ( $? == 0 ) {
       Rex::Logger::debug($f);
@@ -117,7 +117,7 @@ sub update_system {
     }
     else {
       my $cmd = $self->{commands}->{dist_update_system};
-      my $f = i_run $cmd, fail_ok => 1;
+      my $f   = i_run $cmd, fail_ok => 1;
 
       unless ( $? == 0 ) {
         Rex::Logger::debug($f);

--- a/lib/Rex/Pkg/Gentoo.pm
+++ b/lib/Rex/Pkg/Gentoo.pm
@@ -56,22 +56,27 @@ sub is_installed {
   my $version = $option->{version};
 
   # Determine slot.
-  my $slot_idx = index($pkg, ':');
+  my $slot_idx = index( $pkg, ':' );
   if ( $slot_idx != -1 ) {
-    die "Illegal package spec. `$pkg-$version': Both package and version has SLOT" if $version && index($version, ':') != -1;
-    $slot = substr($pkg, $slot_idx + 1);
-    substr($pkg, $slot_idx) = '';
-  } elsif ( $version ) {
-    $slot_idx = index($version, ':');
+    die
+      "Illegal package spec. `$pkg-$version': Both package and version has SLOT"
+      if $version && index( $version, ':' ) != -1;
+    $slot = substr( $pkg, $slot_idx + 1 );
+    substr( $pkg, $slot_idx ) = '';
+  }
+  elsif ($version) {
+    $slot_idx = index( $version, ':' );
     if ( $slot_idx != -1 ) {
-      $slot = substr($version, $slot_idx + 1);
-      substr($version, $slot_idx) = '';
+      $slot = substr( $version, $slot_idx + 1 );
+      substr( $version, $slot_idx ) = '';
     }
   }
 
   $self->{short} = 0;
-  Rex::Logger::debug(
-    "Checking if $pkg" . ( $version ? "-$version" : "" ) . ( $slot ? ":$slot" : '') . " is installed" );
+  Rex::Logger::debug( "Checking if $pkg"
+      . ( $version ? "-$version" : "" )
+      . ( $slot    ? ":$slot"    : '' )
+      . " is installed" );
 
   my @pkg_info = grep { $_->{name} eq $pkg } $self->get_installed();
   @pkg_info = grep { $_->{version} eq $version } @pkg_info if defined $version;
@@ -87,8 +92,10 @@ sub is_installed {
   }
 
   unless (@pkg_info) {
-    Rex::Logger::debug(
-      "$pkg" . ( $version ? "-$version" : "" ) . ( $slot ? ":$slot" : '') . " is NOT installed." );
+    Rex::Logger::debug( "$pkg"
+        . ( $version ? "-$version" : "" )
+        . ( $slot    ? ":$slot"    : '' )
+        . " is NOT installed." );
     return 0;
   }
 
@@ -96,29 +103,34 @@ sub is_installed {
   my $pkg_atom;
 
   if ( defined $slot ) {
-      my $slot_ok;
+    my $slot_ok;
 
-      for my $info (@pkg_info) {
-          $pkg_atom = "$info->{name}-$info->{version}$info->{suffix}$info->{release}";
+    for my $info (@pkg_info) {
+      $pkg_atom =
+        "$info->{name}-$info->{version}$info->{suffix}$info->{release}";
 
-          my $fh = file_read("/var/db/pkg/$pkg_atom/SLOT");
-          chomp( my $slot_installed = $fh->read_all );
-          $fh->close;
+      my $fh = file_read("/var/db/pkg/$pkg_atom/SLOT");
+      chomp( my $slot_installed = $fh->read_all );
+      $fh->close;
 
-          if ( $slot eq $slot_installed ) {
-              $pkg_atom .= ":$slot";
-              $slot_ok = 1;
-              last;
-          }
+      if ( $slot eq $slot_installed ) {
+        $pkg_atom .= ":$slot";
+        $slot_ok = 1;
+        last;
       }
+    }
 
-      unless ( $slot_ok ) {
-        Rex::Logger::debug(
-          "$pkg" . ( $version ? "-$version" : "" ) . ( $slot ? ":$slot" : '') . " is NOT installed." );
-        return 0;
-      }
-  } else {
-      $pkg_atom = "$pkg_info[0]->{name}-$pkg_info[0]->{version}$pkg_info[0]->{suffix}$pkg_info[0]->{release}";
+    unless ($slot_ok) {
+      Rex::Logger::debug( "$pkg"
+          . ( $version ? "-$version" : "" )
+          . ( $slot    ? ":$slot"    : '' )
+          . " is NOT installed." );
+      return 0;
+    }
+  }
+  else {
+    $pkg_atom =
+      "$pkg_info[0]->{name}-$pkg_info[0]->{version}$pkg_info[0]->{suffix}$pkg_info[0]->{release}";
   }
 
   # Check for any USE flag changes.
@@ -130,13 +142,15 @@ sub is_installed {
 
     Rex::Logger::debug( "$pkg"
         . ( $version ? "-$version" : "" )
-        . ( $slot ? ":$slot" : '')
+        . ( $slot    ? ":$slot"    : '' )
         . " is installed but USE flags have changed." );
     return 0;
   }
 
-  Rex::Logger::debug(
-    "$pkg" . ( $version ? "-$version" : "" ) . ( $slot ? ":$slot" : '') . " is installed." );
+  Rex::Logger::debug( "$pkg"
+      . ( $version ? "-$version" : "" )
+      . ( $slot    ? ":$slot"    : '' )
+      . " is installed." );
   return 1;
 
 }
@@ -179,21 +193,25 @@ sub get_installed {
 sub add_repository {
   my ( $self, %data ) = @_;
 
-  my $name = $data{"name"};
+  my $name  = $data{"name"};
   my $readd = $data{"readd"} // 0;
 
   if ( can_run("layman") ) {
     my $op;
 
     i_run "layman -lqnN | grep -q '$name'", fail_ok => 1;
-    if ($? == 0) {
+    if ( $? == 0 ) {
       if ($readd) {
         $op = 'r'; # --readd
-      } else {
-        Rex::Logger::info("Repository $name is present, use `readd' option to re-add from scratch.");
       }
-    } else {
-      $op = 'a'; # --add
+      else {
+        Rex::Logger::info(
+          "Repository $name is present, use `readd' option to re-add from scratch."
+        );
+      }
+    }
+    else {
+      $op = 'a';   # --add
     }
     i_run "layman -$op $name" if defined $op;
   }

--- a/lib/Rex/PkgConf.pm
+++ b/lib/Rex/PkgConf.pm
@@ -36,7 +36,8 @@ sub get {
 
   if ( is_redhat() ) {
     $host->{"operatingsystem"} = "Redhat";
-  } elsif ( is_debian() ) {
+  }
+  elsif ( is_debian() ) {
     $host->{"operatingsystem"} = "Debian";
   }
 

--- a/lib/Rex/Profiler.pm
+++ b/lib/Rex/Profiler.pm
@@ -42,7 +42,7 @@ sub end {
   return unless ( $self->{__data}->{$info}->[-1] );
 
   my $data = $self->{__data}->{$info}->[-1];
-  $data->{end} = [gettimeofday];
+  $data->{end}      = [gettimeofday];
   $data->{duration} = tv_interval( $data->{start}, $data->{end} );
 
   $self->{__data}->{$info}->[-1] = $data;

--- a/lib/Rex/Resource.pm
+++ b/lib/Rex/Resource.pm
@@ -15,7 +15,7 @@ use Rex::Constants;
 
 our @CURRENT_RES;
 
-sub is_inside_resource { ref $CURRENT_RES[-1] ? 1 : 0 }
+sub is_inside_resource   { ref $CURRENT_RES[-1] ? 1 : 0 }
 sub get_current_resource { $CURRENT_RES[-1] }
 
 sub new {
@@ -51,7 +51,7 @@ sub call {
 
   $self->set_all_parameters(%params);
 
-  $self->{res_name} = $name;
+  $self->{res_name}   = $name;
   $self->{res_ensure} = $params{ensure} ||= present;
 
   Rex::get_current_connection()->{reporter}

--- a/lib/Rex/SCM/Git.pm
+++ b/lib/Rex/SCM/Git.pm
@@ -102,7 +102,7 @@ sub checkout {
         . ( $checkout_to ? $checkout_to : "." ) );
 
     my $rebase = $checkout_opt->{"rebase"} ? '--rebase' : '';
-    my $out = i_run "git pull $rebase origin $branch",
+    my $out    = i_run "git pull $rebase origin $branch",
       cwd     => $checkout_to,
       fail_ok => 1,
       %run_opt;
@@ -117,7 +117,7 @@ sub checkout {
     }
 
     if ( exists $checkout_opt->{"tag"} ) {
-      my $tag = $checkout_opt->{tag};
+      my $tag          = $checkout_opt->{tag};
       my $checkout_cmd = sprintf( $CHECKOUT_TAG_COMMAND, $tag, $tag );
       Rex::Logger::info( "Switching to tag " . $tag );
       $out = i_run "git fetch origin",

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -346,7 +346,7 @@ sub build_child_coderef {
       die $@ if $@;
     }
     else {
-      my $e = $@;
+      my $e         = $@;
       my $exit_code = $@ ? ( $? || 1 ) : 0;
 
       push @SUMMARY,
@@ -424,7 +424,7 @@ sub get_exit_codes {
 
 sub get_thread_count {
   my ( $self, $task ) = @_;
-  my $threads = $task->parallelism || Rex::Config->get_parallelism;
+  my $threads      = $task->parallelism || Rex::Config->get_parallelism;
   my $server_count = scalar @{ $task->server };
 
   return $1                                if $threads =~ /^(\d+)$/;

--- a/lib/Rex/Template.pm
+++ b/lib/Rex/Template.pm
@@ -78,7 +78,7 @@ sub parse {
       if ($code) {
         my $pcmd = substr( $text, -1 );
         if ( $pcmd eq "-" ) {
-          $text = substr( $text, 0, -1 );
+          $text     = substr( $text, 0, -1 );
           $do_chomp = 1;
         }
 

--- a/lib/Rex/Test/Base/has_cron.pm
+++ b/lib/Rex/Test/Base/has_cron.pm
@@ -31,7 +31,7 @@ sub new {
 sub run_test {
   my ( $self, $user, $key, $value, $count ) = @_;
 
-  my @crons = cron list => $user;
+  my @crons         = cron list => $user;
   my @matched_crons = grep { $_->{$key} eq $value } @crons;
 
   if ($count) {
@@ -46,7 +46,7 @@ sub run_test {
 sub run_not_test {
   my ( $self, $user, $key, $value, $count ) = @_;
 
-  my @crons = cron list => $user;
+  my @crons         = cron list => $user;
   my @matched_crons = grep { $_->{$key} eq $value } @crons;
 
   if ($count) {

--- a/lib/Rex/Test/Base/has_cron_env.pm
+++ b/lib/Rex/Test/Base/has_cron_env.pm
@@ -31,7 +31,7 @@ sub new {
 sub run_test {
   my ( $self, $user, $key, $value, $count ) = @_;
 
-  my @envs = cron env => $user => "list";
+  my @envs         = cron env => $user => "list";
   my @matched_envs = grep { $_->{name} eq $key && $_->{value} eq $value } @envs;
 
   if ($count) {
@@ -47,7 +47,7 @@ sub run_test {
 sub run_not_test {
   my ( $self, $user, $key, $value, $count ) = @_;
 
-  my @envs = cron env => $user => "list";
+  my @envs         = cron env => $user => "list";
   my @matched_envs = grep { $_->{name} eq $key && $_->{value} eq $value } @envs;
 
   if ($count) {

--- a/lib/Rex/Test/Base/has_stat.pm
+++ b/lib/Rex/Test/Base/has_stat.pm
@@ -41,7 +41,7 @@ sub run_test {
   }
 
   if ( defined( $stats->{'owner'} ) ) {
-    my $uid = get_uid( $stats->{'owner'} );
+    my $uid    = get_uid( $stats->{'owner'} );
     my $result = defined $uid ? $uid == $stat{'uid'} : 0;
 
     $self->ok( $result, "Owner of $path is $stats->{'owner'}" );
@@ -50,7 +50,7 @@ sub run_test {
   }
 
   if ( defined( $stats->{'group'} ) ) {
-    my $gid = get_gid( $stats->{'group'} );
+    my $gid    = get_gid( $stats->{'group'} );
     my $result = defined $gid ? $gid == $stat{'gid'} : 0;
 
     $self->ok( $result, "Group of $path is $stats->{'group'}" );

--- a/lib/Rex/User/FreeBSD.pm
+++ b/lib/Rex/User/FreeBSD.pm
@@ -166,8 +166,9 @@ sub rm_user {
 
   my $output = i_run $cmd . " -n " . $user, fail_ok => 1;
   if ( $? == 67 ) {
-    Rex::Logger::info("Cannot delete user $user (no such user)", "warn");
-  } elsif ( $? != 0 ) {
+    Rex::Logger::info( "Cannot delete user $user (no such user)", "warn" );
+  }
+  elsif ( $? != 0 ) {
     die("Error deleting user $user ($output)");
   }
 
@@ -245,7 +246,7 @@ sub create_group {
     if ( exists $data->{gid} ) {
       eval {
         my @content = split( /\n/, cat("/etc/group") );
-        my $gid = $data->{gid};
+        my $gid     = $data->{gid};
         for (@content) {
           s/^$group:([^:]+):(\d+):/$group:$1:$gid:/;
         }

--- a/lib/Rex/User/Linux.pm
+++ b/lib/Rex/User/Linux.pm
@@ -252,8 +252,9 @@ sub rm_user {
 
   my $output = i_run $cmd . " " . $user, fail_ok => 1;
   if ( $? == 6 ) {
-    Rex::Logger::info("Cannot delete user $user (no such user)", "warn");
-  } elsif ( $? != 0 ) {
+    Rex::Logger::info( "Cannot delete user $user (no such user)", "warn" );
+  }
+  elsif ( $? != 0 ) {
     die("Error deleting user $user ($output)");
   }
 

--- a/lib/Rex/User/NetBSD.pm
+++ b/lib/Rex/User/NetBSD.pm
@@ -190,8 +190,9 @@ sub rm_user {
 
   my $output = i_run $cmd . " " . $user, fail_ok => 1;
   if ( $? == 67 ) {
-    Rex::Logger::info("Cannot delete user $user (no such user)", "warn");
-  } elsif ( $? != 0 ) {
+    Rex::Logger::info( "Cannot delete user $user (no such user)", "warn" );
+  }
+  elsif ( $? != 0 ) {
     die("Error deleting user $user ($output)");
   }
 
@@ -202,7 +203,7 @@ sub rm_user {
   }
 
   if ( $? != 0 ) {
-    die("Error removing " . $user_info{home});
+    die( "Error removing " . $user_info{home} );
   }
 
 }

--- a/lib/Rex/Virtualization/LibVirt/create.pm
+++ b/lib/Rex/Virtualization/LibVirt/create.pm
@@ -68,10 +68,10 @@ sub execute {
     die("Hypervisor not supported.");
   }
 
-  my $fp = Rex::File::Parser::Data->new( data => \@data );
+  my $fp         = Rex::File::Parser::Data->new( data => \@data );
   my $create_xml = $fp->read("create-${virt_type}.xml");
 
-  my $template = Rex::Template->new;
+  my $template        = Rex::Template->new;
   my $parsed_template = $template->parse( $create_xml, $opts );
 
   Rex::Logger::debug($parsed_template);

--- a/lib/Rex/Virtualization/LibVirt/destroy.pm
+++ b/lib/Rex/Virtualization/LibVirt/destroy.pm
@@ -31,9 +31,9 @@ sub execute {
     die("VM $dom not found.");
   }
 
-  # virsh must distinguish between a not-running VM and failed to destroy via exit code!
+# virsh must distinguish between a not-running VM and failed to destroy via exit code!
   my $out = i_run "virsh -c $uri destroy '$dom' 2>&1", fail_ok => 1;
-  if ( $? != 0 && $out !~ /domain is not running/) {
+  if ( $? != 0 && $out !~ /domain is not running/ ) {
     die("Error destroying vm $dom");
   }
 

--- a/lib/Rex/Virtualization/LibVirt/import.pm
+++ b/lib/Rex/Virtualization/LibVirt/import.pm
@@ -98,7 +98,7 @@ sub execute {
 
   for (@network) {
     $_->{type} ||= "network";
-    $_->{type} = "bridge" if ( $_->{type} && $_->{type} eq "bridged" );
+    $_->{type} = "bridge"  if ( $_->{type} && $_->{type} eq "bridged" );
     $_->{type} = "network" if ( $_->{type} eq "nat" );
     if ( $_->{type} eq "network" && !exists $_->{network} ) {
       $_->{network} = "default";

--- a/lib/Rex/Virtualization/Lxc/info.pm
+++ b/lib/Rex/Virtualization/Lxc/info.pm
@@ -35,7 +35,7 @@ sub execute {
 
     # Trim white spaces.
     $column =~ s/^\s+|\s+$//g;
-    $value =~ s/^\s+|\s+$//g;
+    $value  =~ s/^\s+|\s+$//g;
 
     $ret{$column} = $value;
   }

--- a/lib/Rex/Virtualization/Lxc/list.pm
+++ b/lib/Rex/Virtualization/Lxc/list.pm
@@ -50,7 +50,7 @@ sub execute {
   }
 
   my @columns = split( ',', $format );
-  my @ret = ();
+  my @ret     = ();
   for my $line (@containers) {
     next
       if $line =~ m/NAME|AUTOSTART|STATE|IPV4|IPV6|AUTOSTART|PID|RAM|SWAP\s/;

--- a/lib/Rex/Virtualization/VBox/bridge.pm
+++ b/lib/Rex/Virtualization/VBox/bridge.pm
@@ -28,7 +28,7 @@ sub execute {
   my @blocks = split /\n\n/m, $result;
   for my $block (@blocks) {
 
-    my $if = {};
+    my $if    = {};
     my @lines = split /\n/, $block;
     for my $line (@lines) {
       if ( $line =~ /^Name:\s+(.+?)$/ ) {

--- a/t/0.31.t
+++ b/t/0.31.t
@@ -32,7 +32,7 @@ is( $servers[5], "serv06", "get_group with evaluation" );
 
 task( "authtest1", group => "foo", sub { } );
 task( "authtest2", group => "bar", sub { } );
-task( "authtest3", "srv001", sub { } );
+task( "authtest3", "srv001",           sub { } );
 task( "authtest4", group => "latebar", sub { } );
 group( "latebar", "server[01..03]" );
 

--- a/t/author-perltidy.t
+++ b/t/author-perltidy.t
@@ -1,0 +1,16 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::PerlTidy;
+
+plan skip_all => 'these tests are for testing by the author'
+  unless $ENV{AUTHOR_TESTING};
+
+run_tests(
+  exclude => [
+    'Makefile.PL', '.build/',
+    'blib/',       'misc/',
+    qr{t/(author|release)-.*\.t},
+  ],
+);

--- a/t/before_all_tasks.t
+++ b/t/before_all_tasks.t
@@ -23,8 +23,8 @@ cmp_deeply
 for my $tn (@task_names) {
   my $before = $task_list->get_task($tn)->get_data->{before};
   ok($before);
-  is( ( scalar @$before ), 1, $tn );
-  is( $before->[0]->(), 'yo', $tn ) if (@$before);
+  is( ( scalar @$before ), 1,    $tn );
+  is( $before->[0]->(),    'yo', $tn ) if (@$before);
 }
 
 done_testing();

--- a/t/can_run.t
+++ b/t/can_run.t
@@ -7,7 +7,7 @@ use Rex::Commands::Run;
 
 {
   my $command_to_check = $^O =~ /^MSWin/ ? 'where' : 'which';
-  my $result = can_run($command_to_check);
+  my $result           = can_run($command_to_check);
   ok( $result, 'Found checker command' );
 }
 

--- a/t/config-ssh.t
+++ b/t/config-ssh.t
@@ -69,7 +69,7 @@ is( $c->{'other'}->{'port'}, '3306' );
 is( $c->{'hosts'}->{'port'}, '3306' );
 
 my @lines = eval { local (@ARGV) = ("t/ssh_config.1"); <>; };
-my %data = Rex::Config::_parse_ssh_config(@lines);
+my %data  = Rex::Config::_parse_ssh_config(@lines);
 
 ok( exists $data{"*"}, "Host * exists" );
 ok(

--- a/t/dmi.t
+++ b/t/dmi.t
@@ -3,7 +3,7 @@ use Test::More tests => 30;
 use Rex::Inventory::DMIDecode;
 
 my @lines = eval { local (@ARGV) = ("t/dmi.linux.out"); <>; };
-my $dmi = Rex::Inventory::DMIDecode->new( lines => \@lines );
+my $dmi   = Rex::Inventory::DMIDecode->new( lines => \@lines );
 
 isa_ok( $dmi, "Rex::Inventory::DMIDecode", "dmi object" );
 
@@ -64,7 +64,7 @@ $bios    = undef;
 $sysinfo = undef;
 
 @lines = eval { local (@ARGV) = ("t/dmi.obsd.out"); <>; };
-$dmi = Rex::Inventory::DMIDecode->new( lines => \@lines );
+$dmi   = Rex::Inventory::DMIDecode->new( lines => \@lines );
 
 isa_ok( $dmi, "Rex::Inventory::DMIDecode", "dmi object (obsd)" );
 
@@ -125,7 +125,7 @@ $bios    = undef;
 $sysinfo = undef;
 
 @lines = eval { local (@ARGV) = ("t/dmi.fbsd.out"); <>; };
-$dmi = Rex::Inventory::DMIDecode->new( lines => \@lines );
+$dmi   = Rex::Inventory::DMIDecode->new( lines => \@lines );
 
 isa_ok( $dmi, "Rex::Inventory::DMIDecode", "dmi object (fbsd)" );
 

--- a/t/fs_files.t
+++ b/t/fs_files.t
@@ -42,7 +42,7 @@ ok -e $filename, 'file was created';
   my $read_fh = Rex::Interface::File->create('Local');
   $read_fh->open( '<', $filename );
   my $read_object = Rex::FS::File->new( fh => $read_fh );
-  my @read_lines = $read_object->read_all;
+  my @read_lines  = $read_object->read_all;
   is_deeply \@read_lines, [qw/this is a test/], 'read lines from fh';
 }
 
@@ -70,7 +70,7 @@ ok -e $filename, 'file was created';
   my $read_fh = Rex::Interface::File->create('Local');
   $read_fh->open( '<', $filename );
   my $read_object = Rex::FS::File->new( fh => $read_fh );
-  my @read_lines = $read_object->read_all;
+  my @read_lines  = $read_object->read_all;
   is_deeply \@read_lines, [qw/this is a test/], 'read lines from fh';
 }
 
@@ -98,6 +98,6 @@ ok -e $filename, 'file was created';
   $file_object->close;
 
   my $read_object = Rex::FS::File->new( filename => $filename, mode => 'r' );
-  my @read_lines = $read_object->read_all;
+  my @read_lines  = $read_object->read_all;
   is_deeply \@read_lines, [qw/this is a test/], 'read lines from fh';
 }

--- a/t/helper_path.t
+++ b/t/helper_path.t
@@ -15,23 +15,23 @@ my $expected = $file;
 is( $path, $expected, "got file path if called from Rexfile" );
 
 my $cwd = getcwd;
-$file = Rex::Helper::File::Spec->join( $cwd, "ChangeLog" );
-$path = Rex::Helper::Path::get_file_path( $file, "main", $rexfile );
+$file     = Rex::Helper::File::Spec->join( $cwd, "ChangeLog" );
+$path     = Rex::Helper::Path::get_file_path( $file, "main", $rexfile );
 $expected = $file;
 
 is( $path, $file, "got file path if called from Rexfile - absolute path" );
 
-$rexfile = Rex::Helper::File::Spec->join( "this", "is", "Rexfile" );
-$file = Rex::Helper::File::Spec->join( "files", "foo.txt" );
-$path = Rex::Helper::Path::get_file_path( $file, "main", $rexfile );
+$rexfile = Rex::Helper::File::Spec->join( "this",  "is", "Rexfile" );
+$file    = Rex::Helper::File::Spec->join( "files", "foo.txt" );
+$path     = Rex::Helper::Path::get_file_path( $file, "main", $rexfile );
 $expected = Rex::Helper::File::Spec->join( "this", "is", "files", "foo.txt" );
 
 is( $path, $expected, "got file path if called Rexfile from other directory" );
 
 $rexfile = Rex::Helper::File::Spec->join( Rex::Helper::File::Spec->rootdir(),
   "this", "is", "Rexfile" );
-$file = Rex::Helper::File::Spec->join( "files", "foo.txt" );
-$path = Rex::Helper::Path::get_file_path( $file, "main", $rexfile );
+$file     = Rex::Helper::File::Spec->join( "files", "foo.txt" );
+$path     = Rex::Helper::Path::get_file_path( $file, "main", $rexfile );
 $expected = Rex::Helper::File::Spec->join( Rex::Helper::File::Spec->rootdir(),
   "this", "is", "files", "foo.txt" );
 

--- a/t/host.t
+++ b/t/host.t
@@ -6,7 +6,7 @@ use Test::More tests => 10;
 use Rex::Commands::Host;
 
 my @content = eval { local (@ARGV) = ("t/hosts.ex"); <>; };
-my @ret = Rex::Commands::Host::_parse_hosts(@content);
+my @ret     = Rex::Commands::Host::_parse_hosts(@content);
 
 is( $ret[0]->{host}, "localhost", "got localhost" );
 is( $ret[0]->{ip},   "127.0.0.1", "got 127.0.0.1" );
@@ -16,7 +16,7 @@ is( $ret[0]->{ip},   "192.168.2.23",     "got 192.168.2.23 by alias" );
 is( $ret[0]->{host}, "mango.rexify.org", "got mango.rexify.org by alias" );
 
 @content = eval { local (@ARGV) = ("t/hosts.ex2"); <>; };
-@ret = Rex::Commands::Host::_parse_hosts(@content);
+@ret     = Rex::Commands::Host::_parse_hosts(@content);
 
 is( $ret[0]->{host}, "localhost",  "got localhost" );
 is( $ret[0]->{ip},   "127.0.0.1",  "got 127.0.0.1" );

--- a/t/issue_539.t
+++ b/t/issue_539.t
@@ -2,7 +2,7 @@ use Test::More tests => 16;
 use Rex::Hardware::Network::Linux;
 use Rex::Helper::Hash;
 
-my @in = eval { local (@ARGV) = ("t/ip.out_issue_539"); <>; };
+my @in   = eval { local (@ARGV) = ("t/ip.out_issue_539"); <>; };
 my $info = Rex::Hardware::Network::Linux::_parse_ip(@in);
 
 is( $info->{eth0}->{broadcast}, "192.168.178.255", "eth0 primary / broadcast" );

--- a/t/needs.t
+++ b/t/needs.t
@@ -24,6 +24,7 @@ use Rex::Commands;
 }
 
 {
+
   package Nested::Module;
 
   use strict;
@@ -38,6 +39,7 @@ use Rex::Commands;
 }
 
 {
+
   package Rex::Module;
 
   use strict;

--- a/t/net_interface_centos7.t
+++ b/t/net_interface_centos7.t
@@ -1,7 +1,7 @@
 use Test::More tests => 6;
 use Rex::Hardware::Network::Linux;
 
-my @in = eval { local (@ARGV) = ("t/ip.out_centos7"); <>; };
+my @in   = eval { local (@ARGV) = ("t/ip.out_centos7"); <>; };
 my $info = Rex::Hardware::Network::Linux::_parse_ip(@in);
 
 is( $info->{lo}->{netmask}, '255.0.0.0', 'loopback netmask' );
@@ -12,7 +12,7 @@ is( $info->{eth0}->{netmask},   '255.255.255.0',     'eth0 netmask' );
 is( $info->{eth0}->{broadcast}, '10.211.55.255',     'eth0 broadcast' );
 is( $info->{eth0}->{mac},       '00:1c:42:fe:5a:b5', 'eth0 mac' );
 
-@in = eval { local (@ARGV) = ("t/ip.out_centos7_alias"); <>; };
+@in   = eval { local (@ARGV) = ("t/ip.out_centos7_alias"); <>; };
 $info = Rex::Hardware::Network::Linux::_parse_ip(@in);
 
 1;

--- a/t/network_linux.t
+++ b/t/network_linux.t
@@ -2,7 +2,7 @@ use Test::More tests => 44;
 use Rex::Hardware::Network::Linux;
 use Rex::Helper::Hash;
 
-my @in = eval { local (@ARGV) = ("t/ifconfig.out1"); <>; };
+my @in   = eval { local (@ARGV) = ("t/ifconfig.out1"); <>; };
 my $info = Rex::Hardware::Network::Linux::_parse_ifconfig(@in);
 
 is( $info->{eth0}->{broadcast}, "10.18.1.255",       "ex1 / broadcast" );
@@ -17,7 +17,7 @@ is( $f->{eth0_ip},        "10.18.1.107",       "ex1 / flatten / ip" );
 is( $f->{eth0_netmask},   "255.255.255.0",     "ex1 / flatten / netmask" );
 is( $f->{eth0_broadcast}, "10.18.1.255",       "ex1 / flatten / broadcast" );
 
-@in = eval { local (@ARGV) = ("t/ifconfig.out2"); <>; };
+@in   = eval { local (@ARGV) = ("t/ifconfig.out2"); <>; };
 $info = Rex::Hardware::Network::Linux::_parse_ifconfig(@in);
 
 ok( !$info->{"vif1.0"}->{broadcast}, "ex2 / broadcast" );
@@ -32,7 +32,7 @@ ok( !$f->{"vif1_0_ip"},        "ex2 / flatten / ip" );
 ok( !$f->{"vif1_0_netmask"},   "ex2 / flatten / netmask" );
 ok( !$f->{"vif1_0_broadcast"}, "ex2 / flatten / broadcast" );
 
-@in = eval { local (@ARGV) = ("t/ip.out1"); <>; };
+@in   = eval { local (@ARGV) = ("t/ip.out1"); <>; };
 $info = Rex::Hardware::Network::Linux::_parse_ip(@in);
 
 is( $info->{wlp2s0}->{ip},        "10.20.30.40",       "ip / ip" );
@@ -55,7 +55,7 @@ is( $info->{eth1}->{netmask},   "",                  "ip / netmask" );
 is( $info->{eth1}->{broadcast}, "",                  "ip / broadcast" );
 is( $info->{eth1}->{mac},       "00:1c:42:73:ad:3c", "ip / mac" );
 
-@in = eval { local (@ARGV) = ("t/ifconfig.out6"); <>; };
+@in   = eval { local (@ARGV) = ("t/ifconfig.out6"); <>; };
 $info = Rex::Hardware::Network::Linux::_parse_ifconfig(@in);
 
 is( $info->{eth0}->{broadcast}, "192.168.112.255", "(fc19) eth0 / broadcast" );
@@ -69,14 +69,14 @@ is( $info->{"eth0:1"}->{ip},      "1.2.3.4",     "(fc19) eth0:1 / ip" );
 is( $info->{"eth0:1"}->{netmask}, "255.255.0.0", "(fc19) eth0:1 / netmask" );
 is( $info->{"eth0:1"}->{mac}, "52:54:00:37:a8:e1", "(fc19) eth0:1 / mac" );
 
-@in = eval { local (@ARGV) = ("t/ifconfig.out7"); <>; };
+@in   = eval { local (@ARGV) = ("t/ifconfig.out7"); <>; };
 $info = Rex::Hardware::Network::Linux::_parse_ifconfig(@in);
 is( $info->{ppp0}->{ip},        "123.117.251.17",  "ppp0 / ip" );
 is( $info->{ppp0}->{netmask},   "255.255.255.255", "ppp0 / netmask" );
 is( $info->{ppp0}->{broadcast}, "",                "ppp0 / broadcast" );
 is( $info->{ppp0}->{mac},       "",                "ppp0 / mac" );
 
-@in = eval { local (@ARGV) = ("t/ip.out3"); <>; };
+@in   = eval { local (@ARGV) = ("t/ip.out3"); <>; };
 $info = Rex::Hardware::Network::Linux::_parse_ip(@in);
 is( $info->{ppp0}->{ip},        "123.117.251.17",  "ppp0 / ip" );
 is( $info->{ppp0}->{netmask},   "255.255.255.255", "ppp0 / netmask" );

--- a/t/param_lookup.t
+++ b/t/param_lookup.t
@@ -10,7 +10,7 @@ $::QUIET = 1;
 task(
   "test1",
   sub {
-    my $x = param_lookup( "name", "foo" );
+    my $x  = param_lookup( "name", "foo" );
     my $tp = template( \'<%= $name %>' );
 
     is( $x,  "foo", "got default value" );
@@ -21,7 +21,7 @@ task(
 task(
   "test2",
   sub {
-    my $x = param_lookup( "name", "foo" );
+    my $x  = param_lookup( "name", "foo" );
     my $tp = template( \'<%= $name %>' );
 
     is( $x,  "rex", "got parameter value" );
@@ -34,7 +34,7 @@ task(
   sub {
     test1();
 
-    my $x = param_lookup( "name", "foo" );
+    my $x  = param_lookup( "name", "foo" );
     my $tp = template( \'<%= $name %>' );
 
     is( $x,  "xer", "got parameter value" );

--- a/t/param_lookup_resource.t
+++ b/t/param_lookup_resource.t
@@ -8,7 +8,7 @@ $::QUIET = 1;
 
 resource "foo", sub {
   my $test_name = resource_name;
-  my $mode = param_lookup "mode", "0755";
+  my $mode      = param_lookup "mode", "0755";
 
   is( $test_name, "testname", "resource name is testname" );
   is( $mode,      "0666",     "got mode 0666" );

--- a/t/summary.t
+++ b/t/summary.t
@@ -72,7 +72,7 @@ SKIP: {
         task3 => { server => '<local>', task => 'task3', exit_code => 1 },
       );
     };
-    }
+  }
 }
 
 sub create_tasks {


### PR DESCRIPTION
As a maintainer I would like to ensure consistent formatting of code in order
to be able to offload related work (formatting, validating, feedback) to
machines, iltimately making maintanance easier.

Test::PerlTidy doesn't check files under bin because they don't have an
extension, so perlcritic is used as a workaround, as early as possible (i.e.
don't even try to build the testing environment if we already know there's a
violation).

For Test::PerlTidy to work, it needs the `.perltidyrc` in the build.
Unfortunately `.../.perltidyrc` doesn't work to discover the "nearest" config
file, but anyway, it feels like a good idea to make sure the same config is
used in various environments (instead of incremental lookup accidentally
discovering some other config). So for that, GatherDir, PruneCruft, and
MANIFEST.SKIP had to be modified.

Autogenerated files and directories are excluded from tidyness checks.

Then, as a last step, the latest perltidy version was used to format all code. This fixed existing formatting violations, as well as applied some formatting rules that was made default recently.

Edit: this is also salvaging some more code from #1005, and builds up on previous work by @ehuelsmann on #1222.