### PR TITLE
Perlcritic tests

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -2,5 +2,4 @@ theme = core
 severity = 5
 [-BuiltinFunctions::ProhibitStringyEval]
 allow_includes = 1
-[CodeLayout::RequireTidyCode]
-severity = 5
+[-CodeLayout::RequireTidyCode]

--- a/dist.ini
+++ b/dist.ini
@@ -16,6 +16,7 @@ include_dotfiles = 1
 
 [PruneCruft]
 except = \.perltidyrc
+except = \.perlcriticrc
 
 [AutoPrereqs]
 skip = __Rexfile__
@@ -66,4 +67,4 @@ Test::PerlTidy = 0
 [Test::MinimumVersion]
 max_target_perl = 5.10.1
 
-; [Test::Perl::Critic]
+[Test::Perl::Critic]

--- a/lib/Rex/Cloud/OpenStack.pm
+++ b/lib/Rex/Cloud/OpenStack.pm
@@ -54,7 +54,7 @@ sub _request {
   Rex::Logger::debug("  $_ => $params{$_}") for keys %params;
 
   {
-    no strict 'refs';
+    no strict 'refs'; ## no critic ProhibitNoStrict
     $response = $self->{_agent}->request( $method->( $url, %params ) );
   }
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -317,7 +317,7 @@ sub task {
     push( @_, "" );
   }
 
-  no strict 'refs';
+  no strict 'refs'; ## no critic ProhibitNoStrict
   no warnings;
   push( @{"${class}::tasks"}, { name => $task_name_save, code => $_[-2] } );
   use strict;
@@ -329,7 +329,7 @@ sub task {
   if (!$class->can($task_name_save)
     && $task_name_save =~ m/^[a-zA-Z_][a-zA-Z0-9_]+$/ )
   {
-    no strict 'refs';
+    no strict 'refs'; ## no critic ProhibitNoStrict
     Rex::Logger::debug("Registering task: $task_name");
     my $code = $_[-2];
     *{"${class}::$task_name_save"} = sub {
@@ -1087,7 +1087,7 @@ sub needs {
   }
 
   if ( $caller_pkg && ( $caller_pkg eq "Rex::CLI" || $caller_pkg eq "main" ) ) {
-    no strict 'refs';
+    no strict 'refs'; ## no critic ProhibitNoStrict
     *{"main::needs"} = \&needs;
     use strict;
   }

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1059,7 +1059,7 @@ sub needs {
   if ($self) {
     my $suffix = $self;
     $suffix =~ s/::/:/g;
-    @args = map { $_ = "$suffix:$_" } @args;
+    @args = map { "$suffix:$_" } @args;
   }
 
   for my $task (@tasks_to_run) {

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1202,7 +1202,7 @@ With the LOCAL function you can do local commands within a task that is defined 
 
 =cut
 
-sub LOCAL (&) {
+sub LOCAL (&) { ## no critic ProhibitSubroutinePrototypes
   my $cur_conn      = Rex::get_current_connection();
   my $local_connect = Rex::Interface::Connection->create("Local");
 
@@ -1938,7 +1938,7 @@ sub FALSE {
   return 0;
 }
 
-sub make(&) {
+sub make(&) { ## no critic ProhibitSubroutinePrototypes
   return $_[0];
 }
 

--- a/lib/Rex/Commands/Box.pm
+++ b/lib/Rex/Commands/Box.pm
@@ -147,7 +147,7 @@ With this function you can create a new Rex/Box. The first parameter of this fun
 
 =cut
 
-sub box(&) {
+sub box(&) { ## no critic ProhibitSubroutinePrototypes
   my $code = shift;
 
   #### too much black magic...

--- a/lib/Rex/Commands/DB.pm
+++ b/lib/Rex/Commands/DB.pm
@@ -211,7 +211,7 @@ sub import {
 
   my ( $ns_register_to, $file, $line ) = caller;
 
-  no strict 'refs';
+  no strict 'refs'; ## no critic ProhibitNoStrict
   for my $func_name (@EXPORT) {
     *{"${ns_register_to}::$func_name"} = \&$func_name;
   }

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -255,7 +255,7 @@ sub run {
 
     if ( $args && ref($args) eq "ARRAY" ) {
       my $quoter = Net::OpenSSH::ShellQuoter->quoter( $exec->shell->name );
-      $cmd = "$cmd " . join( " ", map { $_ = $quoter->quote($_) } @{$args} );
+      $cmd = "$cmd " . join( " ", map { $quoter->quote($_) } @{$args} );
     }
 
     if ( exists $option->{timeout} && $option->{timeout} > 0 ) {

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -1073,7 +1073,7 @@ sub import {
   read_config_file();
 }
 
-no strict 'refs';
+no strict 'refs'; ## no critic ProhibitNoStrict
 __PACKAGE__->register_config_handler(
   base => sub {
     my ($param) = @_;

--- a/lib/Rex/Exporter.pm
+++ b/lib/Rex/Exporter.pm
@@ -15,7 +15,7 @@ use Data::Dumper;
 
 our @EXPORT;
 
-no strict 'refs';
+no strict 'refs'; ## no critic ProhibitNoStrict
 
 sub import {
   my ( $mod_to_register, %option ) = @_;

--- a/lib/Rex/Group/Entry/Server.pm
+++ b/lib/Rex/Group/Entry/Server.pm
@@ -31,7 +31,7 @@ use attributes;
 sub function {
   my ( $class, $name, $code ) = @_;
 
-  no strict "refs";
+  no strict "refs"; ## no critic ProhibitNoStrict
   *{ $class . "::" . $name } = $code;
   use strict;
 }

--- a/lib/Rex/Helper/Run.pm
+++ b/lib/Rex/Helper/Run.pm
@@ -146,7 +146,7 @@ sub i_exec {
   my $exec   = Rex::Interface::Exec->create;
   my $quoter = Net::OpenSSH::ShellQuoter->quoter( $exec->shell->name );
 
-  my $_cmd_str = "$cmd " . join( " ", map { $_ = $quoter->quote($_) } @args );
+  my $_cmd_str = "$cmd " . join( " ", map { $quoter->quote($_) } @args );
 
   i_run $_cmd_str;
 }
@@ -157,7 +157,7 @@ sub i_exec_nohup {
   my $exec   = Rex::Interface::Exec->create;
   my $quoter = Net::OpenSSH::ShellQuoter->quoter( $exec->shell->name );
 
-  my $_cmd_str = "$cmd " . join( " ", map { $_ = $quoter->quote($_) } @args );
+  my $_cmd_str = "$cmd " . join( " ", map { $quoter->quote($_) } @args );
   i_run $_cmd_str, nohup => 1;
 }
 

--- a/lib/Rex/Helper/SSH2.pm
+++ b/lib/Rex/Helper/SSH2.pm
@@ -14,6 +14,7 @@ use warnings;
 require Exporter;
 use Data::Dumper;
 require Rex::Commands;
+use Time::HiRes qw(sleep);
 
 use base qw(Exporter);
 
@@ -95,7 +96,7 @@ END_READ:
   my $wait_max = $rex_int_conf->{ssh2_channel_closewait_max} || 500;
   while ( !$chan->eof ) {
     Rex::Logger::debug("Waiting for eof on ssh channel.");
-    select undef, undef, undef, 0.002; # wait a little for retry
+    sleep 0.002; # wait a little for retry
     $wait_c++;
     if ( $wait_c >= $wait_max ) {
 

--- a/lib/Rex/Interface/Exec/Base.pm
+++ b/lib/Rex/Interface/Exec/Base.pm
@@ -77,7 +77,7 @@ sub can_run {
     return $output[0];
   }
 
-  return undef;
+  return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub direct_exec {

--- a/lib/Rex/Interface/Fs/HTTP.pm
+++ b/lib/Rex/Interface/Fs/HTTP.pm
@@ -78,7 +78,7 @@ sub stat {
     return %{ $resp->{stat} };
   }
 
-  return undef;
+  return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub is_readable {

--- a/lib/Rex/Interface/Fs/Local.pm
+++ b/lib/Rex/Interface/Fs/Local.pm
@@ -83,14 +83,14 @@ sub rmdir {
 
 sub is_dir {
   my ( $self, $path ) = @_;
-  ( -d $path ) ? return 1 : return undef;
+  ( -d $path ) ? return 1 : return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub is_file {
   my ( $self, $file ) = @_;
   ( -f $file || -l $file || -b $file || -c $file || -p $file || -S $file )
     ? return 1
-    : return undef;
+    : return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub unlink {
@@ -132,7 +132,7 @@ sub stat {
     return %ret;
   }
 
-  return undef;
+  return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub is_readable {

--- a/lib/Rex/Interface/Fs/OpenSSH.pm
+++ b/lib/Rex/Interface/Fs/OpenSSH.pm
@@ -72,7 +72,7 @@ sub is_dir {
 
   defined $attr
     ? return Rex::Helper::File::Stat->S_ISDIR( $attr->perm )
-    : return undef;
+    : return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub is_file {
@@ -92,7 +92,7 @@ sub is_file {
       || Rex::Helper::File::Stat->S_ISCHR( $attr->perm )
       || Rex::Helper::File::Stat->S_ISFIFO( $attr->perm )
       || Rex::Helper::File::Stat->S_ISSOCK( $attr->perm ) )
-    : return undef;
+    : return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub unlink {
@@ -119,7 +119,7 @@ sub stat {
   my $sftp = Rex::get_sftp();
   my $ret  = $sftp->stat($file);
 
-  if ( !$ret ) { return undef; }
+  if ( !$ret ) { return undef; } ## no critic ProhibitExplicitReturnUndef
 
   my %ret = (
     mode  => sprintf( "%04o", Rex::Helper::File::Stat->S_IMODE( $ret->perm ) ),

--- a/lib/Rex/Interface/Fs/SSH.pm
+++ b/lib/Rex/Interface/Fs/SSH.pm
@@ -68,7 +68,7 @@ sub is_dir {
 
   defined $stat && defined $stat->{mode}
     ? return Rex::Helper::File::Stat->S_ISDIR( $stat->{mode} )
-    : return undef;
+    : return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub is_file {
@@ -87,7 +87,7 @@ sub is_file {
       || Rex::Helper::File::Stat->S_ISCHR( $stat->{mode} )
       || Rex::Helper::File::Stat->S_ISFIFO( $stat->{mode} )
       || Rex::Helper::File::Stat->S_ISSOCK( $stat->{mode} ) )
-    : return undef;
+    : return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub unlink {
@@ -135,7 +135,7 @@ sub stat {
   my $sftp = Rex::get_sftp();
   my %ret  = $sftp->stat($file);
 
-  if ( !%ret ) { return undef; }
+  if ( !%ret ) { return undef; } ## no critic ProhibitExplicitReturnUndef
 
   $ret{'mode'} =
     sprintf( "%04o", Rex::Helper::File::Stat->S_IMODE( $ret{'mode'} ) );

--- a/lib/Rex/Interface/Fs/Sudo.pm
+++ b/lib/Rex/Interface/Fs/Sudo.pm
@@ -104,7 +104,7 @@ sub is_dir {
   $self->_exec("test -d $path");
   my $ret = $?;
 
-  $ret == 0 ? return 1 : return undef;
+  $ret == 0 ? return 1 : return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub is_file {
@@ -118,7 +118,7 @@ sub is_file {
   $self->_exec("test -d $file");
   my $is_dir = $?;
 
-  ( $is_file == 0 && $is_dir != 0 ) ? return 1 : return undef;
+  ( $is_file == 0 && $is_dir != 0 ) ? return 1 : return undef; ## no critic ProhibitExplicitReturnUndef
 }
 
 sub unlink {
@@ -172,7 +172,7 @@ sub stat {
   );
 
   if ( !$out ) {
-    return undef;
+    return undef; ## no critic ProhibitExplicitReturnUndef
   }
 
   my $tmp = decode_json($out);

--- a/lib/Rex/Inventory/DMIDecode/Section.pm
+++ b/lib/Rex/Inventory/DMIDecode/Section.pm
@@ -41,7 +41,7 @@ sub has {
     $item = [$_tmp];
   }
 
-  no strict 'refs';
+  no strict 'refs'; ## no critic ProhibitNoStrict
 
   for my $itm ( @{$item} ) {
     my $o_itm = $itm;
@@ -78,7 +78,7 @@ sub get_all {
   use Data::Dumper;
   my $r = ref($self);
 
-  no strict 'refs';
+  no strict 'refs'; ## no critic ProhibitNoStrict
   my @items = @{"${r}::items"};
   use strict;
 

--- a/lib/Rex/Inventory/Hal/Object.pm
+++ b/lib/Rex/Inventory/Hal/Object.pm
@@ -29,7 +29,7 @@ sub has {
     my $accessor  = $k->{accessor};
     my $overwrite = $k->{overwrite};
 
-    no strict 'refs';
+    no strict 'refs'; ## no critic ProhibitNoStrict
     if ( !$overwrite ) {
       *{"${class}::get_$accessor"} = sub {
         my ($self) = @_;
@@ -88,7 +88,7 @@ sub get_all {
 
   my $r = ref($self);
 
-  no strict 'refs';
+  no strict 'refs'; ## no critic ProhibitNoStrict
   my @items = @{"${r}::items"};
   use strict;
 

--- a/lib/Rex/Inventory/SMBios/Section.pm
+++ b/lib/Rex/Inventory/SMBios/Section.pm
@@ -41,7 +41,7 @@ sub has {
     $item = [$_tmp];
   }
 
-  no strict 'refs';
+  no strict 'refs'; ## no critic ProhibitNoStrict
 
   for my $_itm ( @{$item} ) {
     my ( $itm, $from );
@@ -87,7 +87,7 @@ sub get_all {
   use Data::Dumper;
   my $r = ref($self);
 
-  no strict 'refs';
+  no strict 'refs'; ## no critic ProhibitNoStrict
   my @items = @{"${r}::items"};
   use strict;
 

--- a/lib/Rex/Resource/Common.pm
+++ b/lib/Rex/Resource/Common.pm
@@ -95,7 +95,7 @@ sub resource {
   if (!$class->can($name)
     && $name_save =~ m/^[a-zA-Z_][a-zA-Z0-9_]+$/ )
   {
-    no strict 'refs';
+    no strict 'refs'; ## no critic ProhibitNoStrict
     Rex::Logger::debug("Registering resource: ${class}::$name_save");
 
     my $code = $_[-2];
@@ -107,7 +107,7 @@ sub resource {
     && $name_save =~ m/^[a-zA-Z_][a-zA-Z0-9_]+$/ )
   {
     # if not in main namespace, register the task as a sub
-    no strict 'refs';
+    no strict 'refs'; ## no critic ProhibitNoStrict
     Rex::Logger::debug(
       "Registering resource (not main namespace): ${class}::$name_save");
     my $code = $_[-2];
@@ -117,7 +117,7 @@ sub resource {
   }
 
   if ( exists $options->{export} && $options->{export} ) {
-    no strict 'refs';
+    no strict 'refs'; ## no critic ProhibitNoStrict
 
     # register in caller namespace
     push @{ $caller_pkg . "::ISA" }, "Rex::Exporter"

--- a/lib/Rex/Template.pm
+++ b/lib/Rex/Template.pm
@@ -38,7 +38,7 @@ our $BE_LOCAL = 1;
 sub function {
   my ( $class, $name, $code ) = @_;
 
-  no strict 'refs';
+  no strict 'refs'; ## no critic ProhibitNoStrict
   *{ $class . "::" . $name } = $code;
   use strict;
 }
@@ -117,8 +117,8 @@ sub parse {
   );
 
   eval {
-    no strict 'refs';
-    no strict 'vars';
+    no strict 'refs'; ## no critic ProhibitNoStrict
+    no strict 'vars'; ## no critic ProhibitNoStrict
 
     for my $var ( keys %{$vars} ) {
       Rex::Logger::debug("Registering: $var");

--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -216,7 +216,7 @@ sub run_task {
   );
 }
 
-sub ok($;$) {
+sub ok() {
   my ( $self, $test, $msg ) = @_;
   my $tb = Rex::Test::Base->builder;
   $tb->ok( $test, $msg );

--- a/lib/Rex/Test/Base.pm
+++ b/lib/Rex/Test/Base.pm
@@ -149,7 +149,7 @@ sub base_vm {
   $self->{vm} = $vm;
 }
 
-sub test(&) {
+sub test(&) { ## no critic ProhibitSubroutinePrototypes
   my $code = shift;
   my $test = __PACKAGE__->new;
   $code->($test);

--- a/lib/Rex/Transaction.pm
+++ b/lib/Rex/Transaction.pm
@@ -72,7 +72,7 @@ Start a transaction for $codeRef. If $codeRef dies it will rollback the transact
 
 =cut
 
-sub transaction(&) {
+sub transaction(&) { ## no critic ProhibitSubroutinePrototypes
   my ($code) = @_;
   my $ret = 1;
 
@@ -119,7 +119,7 @@ See I<transaction>.
 
 =cut
 
-sub on_rollback(&) {
+sub on_rollback(&) { ## no critic ProhibitSubroutinePrototypes
   my ($code) = @_;
 
   push(


### PR DESCRIPTION
This is still heavily work in progress, but overall I believe there are not so complicated fixes for all the violations at the current severity level, so I try to include them in this PR. If things get complicated or we decide the changes are too risky, we can still just mark the known violations as known ones for documentation purposes.

I preferred writing `## no critic ...` style comments to make sure we don't silently introduce further violations of a given policy (which is possible if we would just disable the policy completely in `.perlcriticrc`).

Depending on the decisions when the full picture is already known, I'll probably rewrite the commit messages before merging to make the history easier to understand.