### PR TITLE
Return username for local connections

### DIFF
--- a/lib/Rex/Interface/Connection/Local.pm
+++ b/lib/Rex/Interface/Connection/Local.pm
@@ -36,6 +36,10 @@ sub get_fs_connection_object { my ($self) = @_; return $self; }
 sub is_connected             { return 1; }
 sub is_authenticated         { return 1; }
 
+sub get_auth_user {
+  return Rex::Config::get_user();
+}
+
 sub get_connection_type {
   my ($self) = @_;
 


### PR DESCRIPTION
When rex is being used locally (without any SSH connection), then it makes sense to treat the user running rex as the one who made the authentication, thus returning the username for `get_auth_user` requests on `Local` type of connections.

It fixes some cases when trying to use `sudo` locally. Namely rex can `chown` the temporary files to the local user during execution with this fix, instead of failing because the returned username is an empty string from `Rex::Interface::Connection::Base::get_auth_user`, since `__auth_user__` doesn't exist in that case..