### PR TITLE
Fix fallback method for getting username

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -454,7 +454,7 @@ sub get_user {
     return getlogin;
   }
   else {
-    return getpwuid($<);
+    return scalar getpwuid($<);
   }
 }
 


### PR DESCRIPTION
Calling `getpwuid` in list context returns the array containing all the fields of the user entry from `/etc/passwd` on linux.

Forcing scalar context ensures that only the username is returned. It fixes some use cases when there's no explicit `user 'myusername';` available in the Rexfile, so rex has to try and guess it (and assumes that the current user needs to be used).