### PR TITLE
Fix namespace separators for hooks (fix #1193)

### DIFF
--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -369,7 +369,7 @@ sub modify {
   my ( $self, $type, $task, $code, $package, $file, $line ) = @_;
 
   if ( $package ne "main" && $package ne "Rex::CLI" ) {
-    if ( $task =~ m/:/ ) {
+    if ( $task !~ m/:/ ) {
 
       #do we need to detect for base -Rex ?
       $package =~ s/^Rex:://;

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -373,9 +373,10 @@ sub modify {
 
       #do we need to detect for base -Rex ?
       $package =~ s/^Rex:://;
-      $package =~ s/::/:/g;
     }
   }
+
+  $package =~ s/::/:/g;
 
   my @all_tasks = map { $self->get_task($_); } grep {
     if ( $package ne "main" && $package ne "Rex::CLI" ) {

--- a/t/hooks_in_pkg.t
+++ b/t/hooks_in_pkg.t
@@ -1,0 +1,40 @@
+use strict;
+use warnings;
+use lib 't/lib';
+
+use Test::More;
+use Test::Deep;
+
+use Rex::Commands;
+use Rex::Commands::Run;
+
+use t::tasks::chicken;
+
+$::QUIET = 1;
+
+my $task_list = Rex::TaskList->create;
+
+my ($task_name) = $task_list->get_tasks;
+is( $task_name, "t:tasks:chicken:cross_road", "found_task" );
+my $task = $task_list->get_task($task_name);
+
+my $bts = $task->{before_task_start};
+
+is( @$bts, 2, "found 2 before_task_start hooks" );
+is( ref $bts->[0] eq "CODE" ? $bts->[0]->() : undef,
+  "look left", "first before_task_start hook executes" );
+is( ref $bts->[1] eq "CODE" ? $bts->[1]->() : undef,
+  "look right", "second before_task_start hook executes" );
+
+my $atf = $task->{after_task_finished};
+
+is( @$atf, 2, "found 2 after_task_finished hooks" );
+is(
+  ref $atf->[0] eq "CODE" ? $atf->[0]->() : undef,
+  "got to the other side",
+  "first after_task_finished hook executes"
+);
+is( ref $atf->[1] eq "CODE" ? $atf->[1]->() : undef,
+  "celebrate!", "second after_task_finished hook executes" );
+
+done_testing();

--- a/t/lib/t/tasks/chicken.pm
+++ b/t/lib/t/tasks/chicken.pm
@@ -1,0 +1,11 @@
+package t::tasks::chicken;
+use Rex -base;
+
+desc "cross the road";
+task "cross_road" => sub { return "make a break for it!" };
+
+before_task_start "cross_road"   => sub { return "look left" };
+before_task_start "cross_road"   => sub { return "look right" };
+after_task_finished "cross_road" => sub { return "got to the other side" };
+after_task_finished "cross_road" => sub { return "celebrate!" };
+1;


### PR DESCRIPTION
This PR fixes #1193 by converting the namespace separators from Perl-style `::` to Rex-style `:`. Most of the changes are coming from #1194 in a slightly rearranged way.

This also keeps the bug mentioned on #1173 fixed. That PR unfortunately was not the correct way to fix the underlying problem, even though it successfully addressed a slightly different use case.

Thanks to the tests added by the original authors of those PRs, @mroadhead and @jwbargsten, it was easy to validate alternative approaches and ensure all test cases work now.

@mbroadhead: as mentioned earlier, I could cherry-pick your original commits from #1194. I decided to slightly rearrange them in a way that I believe would be easier to read in the git history later, but I kept original credits for them with you. I hope it's OK like that.

@mbroadhead @jwbargsten: I'll mark this to be merged for the next release, please test your use cases with these changesets if you can, and let us know your results.