### PR TITLE
Resolve symlinks for file management commands

### DIFF
--- a/lib/Rex/Helper/Path.pm
+++ b/lib/Rex/Helper/Path.pm
@@ -24,8 +24,9 @@ use Rex::Commands;
 require Rex::Config;
 
 use Rex::Interface::Exec;
+use Rex::Interface::Fs;
 
-@EXPORT = qw(get_file_path get_tmp_file resolv_path parse_path);
+@EXPORT = qw(get_file_path get_tmp_file resolv_path parse_path resolve_symlink);
 
 set "path_map", {};
 
@@ -215,6 +216,27 @@ sub parse_path {
   }
 
   return $path;
+}
+
+sub resolve_symlink {
+  my $path = shift;
+  my $fs   = Rex::Interface::Fs::create();
+  my $resolution;
+
+  if ( $fs->is_symlink($path) ) {
+    while ( my $link = $fs->readlink($path) ) {
+      if ( $link !~ m/^\// ) {
+        $path = dirname($path) . "/" . $link;
+      }
+      else {
+        $path = $link;
+      }
+      $link = $fs->readlink($link);
+    }
+    $resolution = $path;
+  }
+
+  return $resolution;
 }
 
 1;

--- a/t/symlinks.t
+++ b/t/symlinks.t
@@ -1,0 +1,109 @@
+use strict;
+use warnings;
+
+use Test::More;
+use File::Spec;
+use File::Temp qw(tempdir);
+
+use Rex -base;
+use Rex::Helper::Path;
+
+$::QUIET = 1;
+
+my $tmp_dir        = tempdir( CLEANUP => 1 );
+my $file           = File::Spec->catfile( $tmp_dir, 'file' );
+my $symlink        = File::Spec->catfile( $tmp_dir, 'symlink' );
+my $nested_symlink = File::Spec->catfile( $tmp_dir, 'nested_symlink' );
+
+sub setup {
+  file $file, ensure => 'present';
+
+  symlink $file,    $symlink;
+  symlink $symlink, $nested_symlink;
+
+  is( is_file($file),              TRUE, 'temp file is a file' );
+  is( is_symlink($symlink),        TRUE, 'temp symlink is a symlink' );
+  is( is_symlink($nested_symlink), TRUE, 'temp nested symlink is a symlink' );
+}
+
+sub check_still_symlink {
+  is( is_symlink($symlink),      TRUE,  'temp symlink is still a symlink' );
+  is( resolve_symlink($symlink), $file, 'symlink is still resolved to file' );
+}
+
+subtest 'resolve symlinks' => sub {
+  setup();
+
+  is( resolve_symlink($symlink), $file, 'symlink is resolved to file' );
+  is( resolve_symlink($nested_symlink),
+    $file, 'nested symlink is resolved to file' );
+  is( resolve_symlink('not a symlink'),
+    undef, 'non-existing symlink is unresolved' );
+};
+
+subtest 'file command with symlinks' => sub {
+  setup();
+
+  file $symlink, content => '1';
+
+  is( cat($file), "1\n", 'file content written' );
+  check_still_symlink();
+
+  file $symlink, ensure => 'absent';
+
+  is( is_file($file), TRUE, 'file is still present' );
+  ok( !-e $symlink, 'symlink is gone' );
+};
+
+subtest 'delete_lines_matching with symlinks' => sub {
+  setup();
+
+  delete_lines_matching $symlink, '1';
+
+  is( cat($file), "", 'line deleted' );
+  check_still_symlink();
+};
+
+subtest 'append_or_amend_line with symlinks' => sub {
+  setup();
+
+  append_or_amend_line $symlink,
+    line   => '2',
+    regexp => qr{1};
+
+  is( cat($file), "2\n", 'line updated' );
+  check_still_symlink();
+};
+
+subtest 'sed with symlinks' => sub {
+  setup();
+
+  sed qr{1}, '2', $symlink;
+
+  is( cat($file), "2\n", 'line updated' );
+  check_still_symlink();
+};
+
+subtest 'file_write with symlinks' => sub {
+  setup();
+
+  my $fh = file_write $symlink;
+  $fh->write('');
+  $fh->close;
+
+  is( cat($file), '', 'file is empty' );
+  check_still_symlink();
+};
+
+subtest 'file_append with symlinks' => sub {
+  setup();
+
+  my $fh = file_append $symlink;
+  $fh->write("1\n");
+  $fh->close;
+
+  is( cat($file), "1\n", 'file has been appended' );
+  check_still_symlink();
+};
+
+done_testing();


### PR DESCRIPTION
This PR adds tests for the cases when the file management commands are used with symlinks, then adds a `resolve_symlink` helper function, which can be used to ensure file operations are done on the linked file instead of inadvertently converting the symlink itself into a file.

Before #1228 the behaviour of the file management commands were different in this regard, so it was even hardar to spot or fix the problem. Since all of them use the `file` command itself under the hood, the fix become relatively straightforward (=fix the `file` command).

One special case may deserve extra note: if the `file` command is called with `ensure => absent` on a symlink, then we have to skip resolving the symlink into the linked file (so the symlink gets deteled, not the file).