### PR TITLE
Detect upstart

### DIFF
--- a/lib/Rex/Service.pm
+++ b/lib/Rex/Service.pm
@@ -33,6 +33,9 @@ sub get {
   i_run "systemctl --no-pager > /dev/null", fail_ok => 1;
   my $can_run_systemctl = $? == 0 ? 1 : 0;
 
+  i_run "initctl version | grep upstart", fail_ok => 1;
+  my $running_upstart = $? == 0 ? 1 : 0;
+
   my $class;
 
   $class = "Rex::Service::" . $operatingsystem;
@@ -63,6 +66,11 @@ sub get {
 
     # this also counts for Ubuntu and LinuxMint
     $class = "Rex::Service::Debian::systemd";
+  }
+  elsif ( is_debian($operatingsystem) && $running_upstart ) {
+
+    # this is mainly Ubuntu with upstart
+    $class = "Rex::Service::Ubuntu";
   }
   elsif ( is_debian($operatingsystem) ) {
     $class = "Rex::Service::Debian";


### PR DESCRIPTION
This PR is a proposed fix for #1190. It tries to detect if it needs to use upstart to manage services on the currently running system, and if yes, loads the related service module. Currently the logic only applies to Debian-like systems, but it should be straightforward to adapt the logic to other systems too.

I belive the detection logic to choose which service module to use can be simplified, but to keep backwards compatibility I've decided against doing it right now.