### PR TITLE
Remove redundant argument to rsync command

### DIFF
--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -181,9 +181,8 @@ sub sync {
 
   if ( $auth_type eq "pass" ) {
     $cmd = sprintf( $cmd,
-      'ssh -o StrictHostKeyChecking=no -o PubkeyAuthentication=no -p '
-        . "$port",
-      $port );
+      "ssh -o StrictHostKeyChecking=no -o PubkeyAuthentication=no -p $port",
+    );
     push(
       @expect_options,
       [


### PR DESCRIPTION
The sprintf function used to populate the rsync command was getting passed two place-holder values when only one is needed.