### PR TITLE
Cache CMDB lookups

### DIFF
--- a/lib/Rex/CMDB/YAML.pm
+++ b/lib/Rex/CMDB/YAML.pm
@@ -123,16 +123,7 @@ sub get {
     }
   }
 
-  if ( !$item ) {
-    return $all;
-  }
-  else {
-    return $all->{$item};
-  }
-
-  Rex::Logger::debug("CMDB - no item ($item) found");
-
-  return;
+  return $all;
 }
 
 1;

--- a/t/cmdb.t
+++ b/t/cmdb.t
@@ -1,104 +1,114 @@
 use strict;
 use warnings;
 
-use Test::More tests => 13;
+use Test::More tests => 2;
 
 use Rex::CMDB;
 use Rex::Commands;
 use Rex::Commands::File;
 
-set(
-  cmdb => {
-    type => "YAML",
-    path => "t/cmdb",
-  }
-);
+foreach my $caching (qw(0 1)) {
+  my $setting = $caching ? 'enabled' : 'disabled';
 
-my $ntp = get( cmdb( "ntp", "foo" ) );
-ok( $ntp->[0] eq "ntp1" && $ntp->[1] eq "ntp2",
-  "got something from default.yml" );
+  subtest "Caching ${setting}" => sub {
+    plan tests => 13;
 
-my $name = get( cmdb( "name", "foo" ) );
-is( $name, "foo", "got name from foo.yml" );
+    Rex::Config->set_use_cache($caching);
 
-my $dns = get( cmdb( "dns", "foo" ) );
-ok( $dns->[0] eq "1.1.1.1" && $dns->[1] eq "2.2.2.2",
-  "got dns from env/default.yml" );
-
-my $vhost = get( cmdb( "vhost", "foo" ) );
-ok( $vhost->{name} eq "foohost" && $vhost->{doc_root} eq "/var/www",
-  "got vhost from env/foo.yml" );
-
-$ntp = undef;
-$ntp = get( cmdb("ntp") );
-ok( $ntp->[0] eq "ntp1" && $ntp->[1] eq "ntp2",
-  "got something from default.yml" );
-
-$dns = undef;
-$dns = get( cmdb("dns") );
-ok( $dns->[0] eq "1.1.1.1" && $dns->[1] eq "2.2.2.2",
-  "got dns from env/default.yml" );
-
-my $all = get( cmdb( undef, "foo" ) );
-is( $all->{ntp}->[0], "ntp1",    "got ntp1 from cmdb - all request" );
-is( $all->{dns}->[1], "2.2.2.2", "got dns2 from cmdb - all request" );
-is( $all->{vhost}->{name}, "foohost",
-  "got vhost name from cmdb - all request" );
-is( $all->{name}, "foo", "got name from cmdb - all request" );
-
-Rex::Config->set_register_cmdb_template(1);
-my $content = 'Hello this is <%= $::name %>';
-is(
-  template( \$content, __no_sys_info__ => 1 ),
-  "Hello this is defaultname",
-  "get keys from CMDB"
-);
-
-is(
-  template( \$content, { name => "baz", __no_sys_info__ => 1 } ),
-  "Hello this is baz",
-  "overwrite keys from CMDB"
-);
-
-set(
-  cmdb => {
-    type           => "YAML",
-    path           => "t/cmdb",
-    merge_behavior => 'LEFT_PRECEDENT',
-  }
-);
-
-my $foo_all = get( cmdb( undef, "foo" ) );
-is_deeply(
-  $foo_all,
-  {
-    'ntp'    => [ 'ntp1',            'ntp2' ],
-    'newntp' => [ 'ntpdefaultfoo01', 'ntpdefaultfoo02', 'ntp1', 'ntp2' ],
-    'dns'    => [ '1.1.1.1',         '2.2.2.2' ],
-    'MyTest::foo::mode' => '0666',
-    'vhost'             => {
-      'name'     => 'foohost',
-      'doc_root' => '/var/www'
-    },
-    'name'   => 'foo',
-    'vhost2' => {
-      'name'     => 'vhost2foo',
-      'doc_root' => '/var/www'
-    },
-    'users' => {
-      'root' => {
-        'password' => 'proot',
-        'id'       => '0'
-      },
-      'user02' => {
-        'password' => 'puser02',
-        'id'       => '600'
-      },
-      'user01' => {
-        'password' => 'puser01',
-        'id'       => '500'
+    set(
+      cmdb => {
+        type => "YAML",
+        path => "t/cmdb",
       }
-    }
-  },
-  "DeepMerge CMDB"
-);
+    );
+
+    my $ntp = get( cmdb( "ntp", "foo" ) );
+    ok( $ntp->[0] eq "ntp1" && $ntp->[1] eq "ntp2",
+      "got something from default.yml" );
+
+    my $name = get( cmdb( "name", "foo" ) );
+    is( $name, "foo", "got name from foo.yml" );
+
+    my $dns = get( cmdb( "dns", "foo" ) );
+    ok( $dns->[0] eq "1.1.1.1" && $dns->[1] eq "2.2.2.2",
+      "got dns from env/default.yml" );
+
+    my $vhost = get( cmdb( "vhost", "foo" ) );
+    ok( $vhost->{name} eq "foohost" && $vhost->{doc_root} eq "/var/www",
+      "got vhost from env/foo.yml" );
+
+    $ntp = undef;
+    $ntp = get( cmdb("ntp") );
+    ok( $ntp->[0] eq "ntp1" && $ntp->[1] eq "ntp2",
+      "got something from default.yml" );
+
+    $dns = undef;
+    $dns = get( cmdb("dns") );
+    ok( $dns->[0] eq "1.1.1.1" && $dns->[1] eq "2.2.2.2",
+      "got dns from env/default.yml" );
+
+    my $all = get( cmdb( undef, "foo" ) );
+    is( $all->{ntp}->[0], "ntp1",    "got ntp1 from cmdb - all request" );
+    is( $all->{dns}->[1], "2.2.2.2", "got dns2 from cmdb - all request" );
+    is( $all->{vhost}->{name},
+      "foohost", "got vhost name from cmdb - all request" );
+    is( $all->{name}, "foo", "got name from cmdb - all request" );
+
+    Rex::Config->set_register_cmdb_template(1);
+    my $content = 'Hello this is <%= $::name %>';
+    is(
+      template( \$content, __no_sys_info__ => 1 ),
+      "Hello this is defaultname",
+      "get keys from CMDB"
+    );
+
+    is(
+      template( \$content, { name => "baz", __no_sys_info__ => 1 } ),
+      "Hello this is baz",
+      "overwrite keys from CMDB"
+    );
+
+    set(
+      cmdb => {
+        type           => "YAML",
+        path           => "t/cmdb",
+        merge_behavior => 'LEFT_PRECEDENT',
+      }
+    );
+
+    my $foo_all = get( cmdb( undef, "foo" ) );
+    is_deeply(
+      $foo_all,
+      {
+        'ntp'    => [ 'ntp1',            'ntp2' ],
+        'newntp' => [ 'ntpdefaultfoo01', 'ntpdefaultfoo02', 'ntp1', 'ntp2' ],
+        'dns'    => [ '1.1.1.1',         '2.2.2.2' ],
+        'MyTest::foo::mode' => '0666',
+        'vhost'             => {
+          'name'     => 'foohost',
+          'doc_root' => '/var/www'
+        },
+        'name'   => 'foo',
+        'vhost2' => {
+          'name'     => 'vhost2foo',
+          'doc_root' => '/var/www'
+        },
+        'users' => {
+          'root' => {
+            'password' => 'proot',
+            'id'       => '0'
+          },
+          'user02' => {
+            'password' => 'puser02',
+            'id'       => '600'
+          },
+          'user01' => {
+            'password' => 'puser01',
+            'id'       => '500'
+          }
+        }
+      },
+      "DeepMerge CMDB"
+    );
+  }
+}


### PR DESCRIPTION
This PR adds caching support for CMDB.

TL;DR: caching is done per server per CMDB object.

First, it makes sure that a CMDB object is instantiated only once per `set CMDB` call, instead of once per CMDB query. Beside the obvious performance improvement, this also makes it possible to use the object "ID" as part of the cache key later.

Second, the whole CMDB structure for a given server is being retrieved upon first CMDB query and stored in the cache before returning.

The test suite has also been modified to test both with and without caching to help ensure identical results as before.