### PR TITLE
Release 1.6.0_01 aka 1.7.0-rc1

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,6 +15,7 @@ Brian Manning
 Cameron Daniel
 Chris Steigmeier
 Christophe Wolfhugel
+Crimson Thompson
 Cuong Manh Le
 Daniel Baeurer
 Daniel Dico
@@ -25,6 +26,7 @@ Dominik Danter
 Dominik Schulz
 eduardoj
 Eivin Giske Skaaren
+elisdg
 Elmer Quintanilla
 Eric Johnson
 Erik Huelsmann
@@ -38,6 +40,7 @@ H. Daniel Cesario
 Harm Müller
 Hiroaki Nakamura
 Hiroki Matsuo
+iblinder
 Ilya Evseev
 James D Bearden
 Jean Charles Passard
@@ -56,8 +59,11 @@ Keedi Kim
 Ken Crowell
 Kent Fredric
 Kirill Babikhin
+labbeduddel
 Laird Liu
+LeMerP
 Mario Domgoergen
+Max E. Aubrey
 Mitch Broadhead
 Nathan Abu
 Naveed Massjouni
@@ -68,6 +74,7 @@ Nikolay Fetisov
 Nils Domrose
 okaoka
 Oleg Hardt
+Oliver Cherrier
 Paco Esteban
 Patrick Lauer
 Pavel Timofeev
@@ -83,11 +90,13 @@ Rapenne Solène
 RenatoCRON
 Renee Bäcker
 Robert Abraham
+Roy Storey
 Samuele Tognini
 Sascha Askani
 Sascha Guenther
 Simon Bertrang
 Stephane Benoit
+Steve Dondley
 Sven Dowideit
 Tamas Molnar
 Tianon Gravi

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,7 +13,6 @@ bollwarm
 Boris Däppen
 Brian Manning
 Cameron Daniel
-Сергей Романов (complefor)
 Chris Steigmeier
 Christophe Wolfhugel
 Cuong Manh Le
@@ -96,3 +95,4 @@ Tokuhiro Matsuno
 Tomohiro Hosaka
 Walery Wysotsky
 Yanick Champoux
+Сергей Романов (complefor)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,67 @@
+2019-10-26 Ferenc Erki <erkiferenc@gmail.com> (1.6.0_01)
+  * Cache CMDB lookups (fix #1239) - Ferenc Erki
+  * Test CMDB both with and without caching - Ferenc Erki
+  * Instantiate CMDB object during initialization - Ferenc Erki
+  * Remove redundant argument to rsync command - Steve Dondley
+  * Detect upstart (fix #1190) - Ferenc Erki
+  * Simplify quoting (close #1206) - Ferenc Erki
+  * Better message and remove unused variable (ref #1206) - Roy Storey
+  * Quote parameters that might have spaces (fix #807) - Roy Storey
+  * Resolve symlinks for file management commands (fix #1195, close #1199) - Ferenc Erki
+  * Add resolve_symlink helper - Ferenc Erki
+  * Add symlink tests for file management commands - Ferenc Erki
+  * Update link of installation intructions - Ferenc Erki
+  * Update testing instructions - Ferenc Erki
+  * Update list of useful resources - Ferenc Erki
+  * Fix typos - Ferenc Erki
+  * Update supported Perl versions - Ferenc Erki
+  * Convert namespace separators from module to task (fix #1193) - Ferenc Erki
+  * Add tests for package hooks (ref #1194) - Mitch Broadhead
+  * create_host: drop useless get_host invocation (close #1181) - Ali Polatel
+  * Run extra tests on Travis - Ferenc Erki
+  * Ignore tidyness checks for generated extra tests - Ferenc Erki
+  * Rename perltidy test - Ferenc Erki
+  * Replace [ExtraTests] with [RunExtraTests] (fix #964) - Kent Fredric
+  * Use file command for file operations - Ferenc Erki
+  * Fix fallback method for getting username - Ferenc Erki
+  * Return username for local connections - Ferenc Erki
+  * only source ~/.profile if it really exists - Joachim Bargsten
+  * Accept critic for ProhibitExplicitReturnUndef - Ferenc Erki
+  * Accept critic for ProhibitNoStrict - Ferenc Erki
+  * Accept critic for ProhibitSubroutinePrototypes - Ferenc Erki
+  * Remove unnecessary subroutine prototype - Ferenc Erki
+  * Fix critic for ProhibitMutatingListFunctions - Ferenc Erki
+  * Fix critic for ProhibitSleepViaSelect - Erik Huelsmann
+  * Disable tidyness checks in perlcritic - Ferenc Erki
+  * improved error handling in run_task if task does not exist - Joachim Bargsten
+  * Fixes virtualization type,role for Digital Ocean Droplets (close #1192) - Mitch Broadhead
+  * Fix UID handling for OpenBSD (fix #1213) - Olivier Cherrier
+  * Added the Option 'continuous_read' to the documentation - elisdg
+  * Test for code tidyness - Ferenc Erki
+  * Fix placeholder matching for %h in ssh config. (#1214) - Max E. Aubrey
+  * Set minimum required Perl version to 5.10.1 - Ferenc Erki
+  * Use Travis CI for testing - Ferenc Erki
+  * added option to list all tasks, including hidden - Joachim Bargsten
+  * errorless git checkout if on checkout branch - Joachim Bargsten
+  * added clone_args as extra option for git checkout - Joachim Bargsten
+  * git checkout also supports environment settings for e.g. proxies - Joachim Bargsten
+  * added ssh as possible protocols for git-based rex modules - Joachim Bargsten
+  * Improve package handling on OpenBSD - Olivier Cherrier
+  * Enhance the OpenBSD User handling support - Olivier Cherrier
+  * Document the 'requiretty' setting with the sudo command - Erik Huelsmann
+  * delete_host: fix regex so it does not match on prefixes - Ali Polatel
+  * Added Oracle Linux (fix #1168, close #1174) - labbeduddel
+  * Ignore YAML-1.25 (fix #1197) - Ferenc Erki
+  * Adds SLE 15 / Leap 15.0 support - LeMerP
+  * Use virsh connect URI from config - Ferenc Erki
+  * Update README about contributing guide - Ferenc Erki
+  * Initial version of the contributing guide - Ferenc Erki
+  * Convert namespace separators from module to task (fix #1188) - Ferenc Erki
+  * Add test for using needs with nested modules (ref #1188) - Ferenc Erki
+  * Added Virtuozzo as Red Hat clone. - iblinder
+  * Print warning instead of dying when delete_user called on non existing user - Crimson Thompson
+  * Fix Pkgconf for Debian - Andy Beverley
+
 2017-12-03 Jan Gehring <jfried@rexify.org> (1.6.0)
   * Check brctl command is available (resolves #1115) - perlancar
   * fixed path bug in git scm checkout - Joachim Bargsten

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -33,3 +33,4 @@ upload
 ^images
 projects
 Rex\-\d+.*
+tags

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name = Rex
-version = 1.6.0
-release_status = stable
+version = 1.6.0_01
+release_status = testing
 author = Jan Gehring <jfried@rexify.org>
 license = Apache_2_0
 copyright_holder = Jan Gehring


### PR DESCRIPTION
This PR prepares for the 1.6.0_01 development release aka 1.7.0-rc1.

Upon successful tests, I'll merge the changes, tag the release, and upload a tarball to CPAN. This helps us to get further feedback from a wider range if systems via the wonderful CPAN Testers project before doing a stable release.