### PR TITLE
Fix tests on Dragonfly BSD

### DIFF
--- a/t/summary.t
+++ b/t/summary.t
@@ -30,10 +30,11 @@ subtest "distributor => 'Base'" => sub {
     test_summary(
       task0 => { server => '<local>', task => 'task0', exit_code => 1 },
       task1 => {
-        server => '<local>',
-        task   => 'task1',
-        exit_code =>
-          ( $^O =~ m/^(MSWin|freebsd|darwin|netbsd|openbsd)/ ? 1 : 2 )
+        server    => '<local>',
+        task      => 'task1',
+        exit_code => (
+          $^O =~ m/^(MSWin|freebsd|darwin|netbsd|openbsd|dragonfly)/ ? 1 : 2
+        )
       },
       task2 => { server => '<local>', task => 'task2', exit_code => 0 },
       task3 => { server => '<local>', task => 'task3', exit_code => 1 },
@@ -63,10 +64,11 @@ SKIP: {
       test_summary(
         task0 => { server => '<local>', task => 'task0', exit_code => 1 },
         task1 => {
-          server => '<local>',
-          task   => 'task1',
-          exit_code =>
-            ( $^O =~ m/^(MSWin|freebsd|darwin|netbsd|openbsd)/ ? 1 : 2 )
+          server    => '<local>',
+          task      => 'task1',
+          exit_code => (
+            $^O =~ m/^(MSWin|freebsd|darwin|netbsd|openbsd|dragonfly)/ ? 1 : 2
+          )
         },
         task2 => { server => '<local>', task => 'task2', exit_code => 0 },
         task3 => { server => '<local>', task => 'task3', exit_code => 1 },


### PR DESCRIPTION
Based on [CPAN Testers results for Rex-1.6.0 on Dragonfly BSD](http://www.cpantesters.org/distro/R/Rex.html?grade=1&perlmat=2&patches=2&oncpan=2&distmat=2&perlver=ALL&osname=dragonfly&version=1.6.0), the exit codes need to be adjusted.