### PR TITLE
Fix known failures from CPAN Testers

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -63,6 +63,7 @@ YAML = != 1.25
 
 [Prereqs / BuildRequires]
 Test::Pod = 0
+Test::UseAllModules = 0.15
 
 [Prereqs / DevelopRequires]
 Test::PerlTidy = 0

--- a/t/env.t
+++ b/t/env.t
@@ -7,6 +7,6 @@ $::QUIET = 1;
 SKIP: {
   skip 'Do not run tests on Windows', 1 if $^O =~ m/^MSWin/;
 
-  my $s = run( "printenv REX", env => { 'REX' => 'XER' } );
+  my $s = run( q(perl -e 'print $ENV{REX}'), env => { 'REX' => 'XER' } );
   like( $s, qr/XER/, "run with env" );
 }

--- a/t/summary.t
+++ b/t/summary.t
@@ -29,12 +29,7 @@ subtest "distributor => 'Base'" => sub {
     Rex::Config->set_distributor('Base');
     test_summary(
       task0 => { server => '<local>', task => 'task0', exit_code => 1 },
-      task1 => {
-        server => '<local>',
-        task   => 'task1',
-        exit_code =>
-          ( $^O =~ m/^(MSWin|freebsd|darwin|netbsd|openbsd)/ ? 1 : 2 )
-      },
+      task1 => { server => '<local>', task => 'task1', exit_code => 1 },
       task2 => { server => '<local>', task => 'task2', exit_code => 0 },
       task3 => { server => '<local>', task => 'task3', exit_code => 1 },
     );
@@ -62,12 +57,7 @@ SKIP: {
       Rex::Config->set_distributor('Parallel_ForkManager');
       test_summary(
         task0 => { server => '<local>', task => 'task0', exit_code => 1 },
-        task1 => {
-          server => '<local>',
-          task   => 'task1',
-          exit_code =>
-            ( $^O =~ m/^(MSWin|freebsd|darwin|netbsd|openbsd)/ ? 1 : 2 )
-        },
+        task1 => { server => '<local>', task => 'task1', exit_code => 1 },
         task2 => { server => '<local>', task => 'task2', exit_code => 0 },
         task3 => { server => '<local>', task => 'task3', exit_code => 1 },
       );
@@ -83,7 +73,7 @@ sub create_tasks {
 
   desc "desc 1";
   task "task1" => sub {
-    my $cmd = $^O =~ /MSWin32/ ? "dir" : "ls";
+    my $cmd = $^O =~ /MSWin32/ ? "type" : "cat";
     run "$cmd asdfxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
   };
 


### PR DESCRIPTION
This PR fixes all known, reproducible and real failures reported for Rex-1.6.0 via CPAN Testers (thanks!).

By "real", I mean failures that is not caused by the perl-5.8.8 vs perl-5.8.9 [issue](https://github.com/RexOps/Rex/issues/578).

This includes the following:
  
- Fix summary testing failures ([example report](http://www.cpantesters.org/cpan/report/c3e6fae4-f059-11e8-afbf-aec3b07506ca))

    This is one of the most common failure. When testing the run command in a task, that is expected to fail, the exit code was either `1` or `2` depending on OS, based on various implementations of `ls`. By using `type` and `cat` instead, I expect the exit code will be always `1`. This should fix the test suite on DragonFly BSD in particular (replacing #1242), and should be valid for all non-Linux systems too, allowing a simplification of the testing code.
  
- Use perl to query environment ([example report](http://www.cpantesters.org/cpan/report/c3e6fae4-f059-11e8-afbf-aec3b07506ca), same as above)

    Some environments does not seem to have a `printenv` command, but `perl` should be available, since we're already running the test suite. That might also fix environment tests on Windows, but I'd prefer dealing with Windows cases separately, and use this PR to only focus on the already reported failures.
  
- Require recent Test::UseAllModules ([example report](http://www.cpantesters.org/cpan/report/1baadcfa-f04b-11e8-9f72-eeb84b3d96e1))

    Another quite common failure, but was only temporary. It won't hurt to require a minimum version here, while "handling dependencies" can be a separate topic. See Test-More/test-more#685 for details.

If this passes CI tests, I plan to merge and release 1.6.0_02 aka 1.7.0-rc2, to gather more feedback from CPAN Testers.