### PR TITLE
Test on Windows with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,50 @@
-language: perl
-perl:
-  - "5.30"
-env:
-  - AUTHOR_TESTING=1 RELEASE_TESTING=1 PERL_CPANM_OPT="--quiet --notest"
-cache:
-  directories:
-    - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/lib
-    - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/bin
-before_install:
-  - cpanm Perl::Critic
-  - perlcritic --quiet --single-policy=RequireTidyCode bin
-  - dzil authordeps --missing | cpanm
-  - dzil listdeps --author --missing | cpanm
-  - cpanm DBI IPC::Shareable Parallel::ForkManager Digest::HMAC_SHA1
-  - cpanm String::Escape XML::LibXML Net::SFTP::Foreign IO::Pty Test::mysqld
-install:
-  - dzil build --in build --notgz
-script:
-  - cd build && prove --timer --lib --recurse --jobs $(nproc) --shuffle t/ xt/
+jobs:
+  include:
+    - stage: test
+      language: perl
+      perl:
+        - "5.30"
+      env:
+        - AUTHOR_TESTING=1 RELEASE_TESTING=1 PERL_CPANM_OPT="--quiet --notest"
+      cache:
+        directories:
+          - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/lib
+          - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/bin
+      before_install:
+        - cpanm Perl::Critic
+        - perlcritic --quiet --single-policy=RequireTidyCode bin
+        - dzil authordeps --missing | cpanm
+        - dzil listdeps --author --missing | cpanm
+        - cpanm DBI IPC::Shareable Parallel::ForkManager Digest::HMAC_SHA1
+        - cpanm String::Escape XML::LibXML Net::SFTP::Foreign IO::Pty Test::mysqld
+      install:
+        - dzil build --in build --notgz
+      script:
+        - cd build && prove --timer --lib --recurse --jobs $(nproc) --shuffle t/ xt/
+    - stage: test
+      os: windows
+      language: shell
+      env:
+        - PERL_CPANM_OPT="--quiet --notest"
+      cache:
+        directories:
+          - /c/Strawberry
+      before_install:
+        - cinst -y strawberryperl
+        - export "PATH=/c/Strawberry/perl/site/bin:/c/Strawberry/perl/bin:/c/Strawberry/c/bin:$PATH"
+        - export "PERL5LIB=/c/Strawberry/perl/site/lib:/c/Strawberry/perl/site/lib:/c/Strawberry/perl/vendor/lib:/c/Strawberry/perl/lib"
+        - ln -snf /c/Strawberry/perl/bin/perl /bin/perl
+        - cpanm Perl::Critic
+        - perlcritic --quiet --single-policy=RequireTidyCode bin
+        - cpanm --reinstall Module::Pluggable::Object
+        - cpanm Dist::Zilla
+        - dzil authordeps --missing | cpanm
+        - dzil listdeps --author --missing | cpanm
+        - cpanm DBI Parallel::ForkManager Digest::HMAC_SHA1
+        - cpanm String::Escape XML::LibXML
+        - cpanm --reinstall App::Prove
+      install:
+        - dzil build --in build --notgz
+      script:
+        - cd build
+        - prove --timer --lib --recurse --jobs $(nproc) --shuffle t/

--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -103,8 +103,6 @@ our ( @EXPORT, @CONNECTION_STACK, $GLOBAL_SUDO, $MODULE_PATHS,
 $WITH_EXIT_STATUS = 1; # since 0.50 activated by default
 @FEATURE_FLAGS    = ();
 
-my $cur_dir;
-
 BEGIN {
 
   sub generate_inc {
@@ -237,7 +235,7 @@ sub search_module_path {
       close $fh_t if $fh_t;
       my ($path) = ( $file =~ m/^(.*)\/.+?$/ );
       if ( $path !~ m/\// ) {
-        $path = $cur_dir . "/$path";
+        $path = getcwd() . "/$path";
       }
 
       # module found, register path

--- a/t/symlinks.t
+++ b/t/symlinks.t
@@ -8,6 +8,10 @@ use File::Temp qw(tempdir);
 use Rex -base;
 use Rex::Helper::Path;
 
+if ( $^O =~ m/^MSWin/ ) {
+  plan skip_all => 'No symlink support on Windows';
+}
+
 $::QUIET = 1;
 
 my $tmp_dir        = tempdir( CLEANUP => 1 );


### PR DESCRIPTION
This PR adds a second job to our Travis CI config to run the tests on Windows too.

EDIT: that's the _current best_ I could figure out on my own. Workarounds/changes:
  - it installs Strawberry Perl, so it has to add extra environment variables
  - it has to replace the perl binary built-in to Git Bash with a symlink to Strawberry Perl's binary
  - it has to reinstall Module::Pluggable::Object and App::Prove, otherwise they are not found and/or doesn't work
  - less optional modules are installed:
    - Test::mysqld: there's no MySQL available in Windows builds, so can't test easily (the linux job still tests it though)
    - IPC::Shareable and IO::Pty: can't install on Windows, not needed on Windows
    - Net::SFTP::Foreign: not needed on Windows
  - no extra tests are run (the linux job still tests them though)

It's already passing and helped to fix Windows issues, so I'd say it would be useful to merge.