### PR TITLE
Fix CMDB examples (fix #1151)

### DIFF
--- a/lib/Rex/CMDB.pm
+++ b/lib/Rex/CMDB.pm
@@ -26,8 +26,8 @@ This module exports a function to access a CMDB via a common interface.
  };
  
  task "prepare", "server1", sub {
-   my $virtual_host = cmdb("vhost");
-   my %all_information = cmdb;
+   my $virtual_host = get cmdb("vhost");
+   my %all_information = get cmdb;
  };
 
 =head1 EXPORTED FUNCTIONS
@@ -139,8 +139,8 @@ Rex::Config->register_set_handler(
 Function to query a CMDB. If this function is called without $item it should return a hash containing all the information for the requested server. If $item is given it should return only the value for $item.
 
  task "prepare", "server1", sub {
-   my $virtual_host = cmdb("vhost");
-   my %all_information = cmdb;
+   my $virtual_host = get cmdb("vhost");
+   my %all_information = get cmdb;
  };
 
 =cut


### PR DESCRIPTION
This PR fixes the CMDB examples for a smoother works-out-of-the-box experience.

The `cmdb` call itself only returns a `Rex::Value` instance, so it has to be prefixed with `get` to get the actual value assigned to the left-hand side of the examples.