### PR TITLE
Release 1.7.0_01 aka 1.7.1-rc1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2019-12-03 Ferenc Erki <erkiferenc@gmail.com> (1.7.0_01)
+  * Clarify POD - Ferenc Erki
+  * Fix POD formatting - Ferenc Erki
+  * Fix CMDB examples (fix #1151) - Ferenc Erki
+  * Test on OS X with Travis CI - Ferenc Erki
+  * Fix getting current directory in Windows - Ferenc Erki
+  * Skip symlink tests on Windows - Ferenc Erki
+  * Test on Windows with Travis CI - Ferenc Erki
+  * Update description - Ferenc Erki
+
 2019-11-05 Ferenc Erki <erkiferenc@gmail.com> (1.7.0)
   * Fix test dependency - Ferenc Erki
   * Use perl to query environment - Ferenc Erki

--- a/dist.ini
+++ b/dist.ini
@@ -1,6 +1,6 @@
 name = Rex
-version = 1.7.0
-release_status = stable
+version = 1.7.0_01
+release_status = testing
 author = Jan Gehring <jfried@rexify.org>
 license = Apache_2_0
 copyright_holder = Jan Gehring


### PR DESCRIPTION
By extending our automated testing to more platforms, we could fix a Windows installation issue. On top of that a few documentation fixes happened, so let's just prepare relasing them as 1.7.1.