### PR TITLE
Configurable sleep time for fork managers

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -61,7 +61,7 @@ our (
   $set_no_append,            $use_net_openssh_if_present,
   $use_template_ng,          $use_rex_kvm_agent,
   $autodie,                  $task_chaining_cmdline_args,
-
+  $waitpid_blocking_sleep_time,
 );
 
 # some defaults
@@ -1068,6 +1068,14 @@ sub get_use_server_auth {
   return 0;
 }
 
+sub set_waitpid_blocking_sleep_time {
+  my ( $self, $waitpid_blocking_sleep_time ) = @_;
+}
+
+sub get_waitpid_blocking_sleep_time {
+  return $waitpid_blocking_sleep_time // 0.1;
+}
+
 sub import {
   read_ssh_config_file();
   read_config_file();
@@ -1103,7 +1111,7 @@ __PACKAGE__->register_config_handler(
 my @set_handler =
   qw/user password private_key public_key -keyauth -passwordauth -passauth
   parallelism sudo_password connection ca cert key distributor
-  template_function port/;
+  template_function port waitpid_blocking_sleep_time/;
 for my $hndl (@set_handler) {
   __PACKAGE__->register_set_handler(
     $hndl => sub {

--- a/lib/Rex/Fork/Manager.pm
+++ b/lib/Rex/Fork/Manager.pm
@@ -86,7 +86,7 @@ sub wait_for {
 
         return 1 unless $all;
       }
-      sleep 0.1;
+      sleep Rex::Config->get_waitpid_blocking_sleep_time;
     }
   } until $self->{'running'} == 0;
 }

--- a/lib/Rex/TaskList/Parallel_ForkManager.pm
+++ b/lib/Rex/TaskList/Parallel_ForkManager.pm
@@ -35,7 +35,8 @@ sub run {
   }
 
   my $fm = Parallel::ForkManager->new( $self->get_thread_count($task) );
-  $fm->set_waitpid_blocking_sleep(0.1);
+  $fm->set_waitpid_blocking_sleep(
+    Rex::Config->get_waitpid_blocking_sleep_time );
   my $all_servers = $task->server;
 
   $fm->run_on_finish(

--- a/lib/Rex/TaskList/Parallel_ForkManager.pm
+++ b/lib/Rex/TaskList/Parallel_ForkManager.pm
@@ -35,6 +35,7 @@ sub run {
   }
 
   my $fm = Parallel::ForkManager->new( $self->get_thread_count($task) );
+  $fm->set_waitpid_blocking_sleep(0.1);
   my $all_servers = $task->server;
 
   $fm->run_on_finish(


### PR DESCRIPTION
I'm opening this PR as draft to share the idea early and to get testing feedback early too.

Based on profiling results, `t/summary.t` is slow mostly on the tests utilizing `Parallel::ForkManager`, and in turn that is caused by relying on the default value for `waitpid_blocking_sleep` which is 1 second. Setting it to a lower value speeds the test up considerably, and real-worls task executions should see a performance boost too.

A comparable property of the built-in `Rex::Fork::Manager` is the sleep time in `wait_for`, which is hard-coded to be 0.1 second.

My initial idea was to make those timings the same for consistency. 0.1 and 0.001 second seems to work fine for both, but it's also possible to set it to 0 for `Parallel::ForkManager` which is even more efficient but may have caveats (see [BLOCKING CALLS](https://metacpan.org/pod/Parallel::ForkManager#BLOCKING-CALLS) for more details).

So currently I think it's best to make it into a configurable option which has a default value either globally or per forking backend, but it's also overridable by the users on demand.