### PR TITLE
Use Symbol instead of `no strict refs`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Revision history for Rex
 
  [REVISION]
  - Use author tests to check tidiness of bin files
+ - Use Symbol to manipulate Perl symbols
 
 1.11.0 2020-06-05 Ferenc Erki <erkiferenc@gmail.com>
  [BUG FIXES]

--- a/lib/Rex/Commands/DB.pm
+++ b/lib/Rex/Commands/DB.pm
@@ -68,6 +68,7 @@ BEGIN {
 
 use Rex::Logger;
 use Data::Dumper;
+use Symbol;
 
 use vars qw(@EXPORT $dbh);
 
@@ -211,11 +212,10 @@ sub import {
 
   my ( $ns_register_to, $file, $line ) = caller;
 
-  no strict 'refs'; ## no critic ProhibitNoStrict
   for my $func_name (@EXPORT) {
-    *{"${ns_register_to}::$func_name"} = \&$func_name;
+    my $ref_to_function = qualify_to_ref( $func_name, $ns_register_to );
+    *{$ref_to_function} = \&$func_name;
   }
-  use strict;
 
 }
 

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -42,6 +42,7 @@ use Rex::Logger;
 use YAML;
 use Data::Dumper;
 use Rex::Require;
+use Symbol;
 
 our (
   $user,                        $password,
@@ -1809,7 +1810,6 @@ sub import {
   read_config_file();
 }
 
-no strict 'refs'; ## no critic ProhibitNoStrict
 __PACKAGE__->register_config_handler(
   base => sub {
     my ($param) = @_;
@@ -1831,7 +1831,10 @@ __PACKAGE__->register_config_handler(
         next;
       }
 
-      $$key = $param->{$key};
+      my $ref_to_key        = qualify_to_ref( $key, __PACKAGE__ );
+      my $ref_to_key_scalar = *{$ref_to_key}{SCALAR};
+
+      ${$ref_to_key_scalar} = $param->{key};
     }
   }
 );
@@ -1857,12 +1860,13 @@ for my $hndl (@set_handler) {
       if ( $hndl eq "cert" )       { $hndl = "ca_cert"; }
       if ( $hndl eq "key" )        { $hndl = "ca_key"; }
 
-      $$hndl = $val;
+      my $ref_to_hndl        = qualify_to_ref( $hndl, __PACKAGE__ );
+      my $ref_to_hndl_scalar = *{$ref_to_hndl}{SCALAR};
+
+      ${$ref_to_hndl_scalar} = $val;
     }
   );
 }
-
-use strict;
 
 sub _home_dir {
   if ( $^O =~ m/^MSWin/ ) {

--- a/lib/Rex/Group/Entry/Server.pm
+++ b/lib/Rex/Group/Entry/Server.pm
@@ -17,6 +17,7 @@ use Rex::Config;
 use Rex::Interface::Exec;
 use Data::Dumper;
 use Sort::Naturally;
+use Symbol;
 
 use List::MoreUtils qw(uniq);
 
@@ -31,9 +32,8 @@ use attributes;
 sub function {
   my ( $class, $name, $code ) = @_;
 
-  no strict "refs"; ## no critic ProhibitNoStrict
-  *{ $class . "::" . $name } = $code;
-  use strict;
+  my $ref_to_function = qualify_to_ref( $name, $class );
+  *{$ref_to_function} = $code;
 }
 
 sub new {

--- a/lib/Rex/Inventory/DMIDecode/Section.pm
+++ b/lib/Rex/Inventory/DMIDecode/Section.pm
@@ -12,6 +12,7 @@ use warnings;
 # VERSION
 
 require Exporter;
+use Symbol;
 use base qw(Exporter);
 use vars qw($SECTION @EXPORT);
 
@@ -41,20 +42,18 @@ sub has {
     $item = [$_tmp];
   }
 
-  no strict 'refs'; ## no critic ProhibitNoStrict
-
   for my $itm ( @{$item} ) {
     my $o_itm = $itm;
     $itm =~ s/[^a-zA-Z0-9_]+/_/g;
-    *{"${class}::get_\L$itm"} = sub {
+    my $ref_to_item_getter = qualify_to_ref( "get_\L$itm", $class );
+    *{$ref_to_item_getter} = sub {
       my $self = shift;
       return $self->get( $o_itm, $is_array );
     };
 
-    push( @{"${class}::items"}, "\L$itm" );
+    my $ref_to_items = qualify_to_ref( 'items', $class );
+    push( @{ *{$ref_to_items} }, "\L$itm" );
   }
-
-  use strict;
 }
 
 sub dmi {
@@ -78,9 +77,8 @@ sub get_all {
   use Data::Dumper;
   my $r = ref($self);
 
-  no strict 'refs'; ## no critic ProhibitNoStrict
-  my @items = @{"${r}::items"};
-  use strict;
+  my $ref_to_items = qualify_to_ref( 'items', $r );
+  my @items        = @{$ref_to_items};
 
   my $ret = {};
   for my $itm (@items) {

--- a/lib/Rex/Template.pm
+++ b/lib/Rex/Template.pm
@@ -25,6 +25,7 @@ package Rex::Template;
 
 use strict;
 use warnings;
+use Symbol;
 
 # VERSION
 
@@ -38,9 +39,8 @@ our $BE_LOCAL = 1;
 sub function {
   my ( $class, $name, $code ) = @_;
 
-  no strict 'refs'; ## no critic ProhibitNoStrict
-  *{ $class . "::" . $name } = $code;
-  use strict;
+  my $ref_to_name = qualify_to_ref( 'name', $class );
+  *{$ref_to_name} = $code;
 }
 
 sub new {
@@ -117,16 +117,18 @@ sub parse {
   );
 
   eval {
-    no strict 'refs'; ## no critic ProhibitNoStrict
     no strict 'vars'; ## no critic ProhibitNoStrict
 
     for my $var ( keys %{$vars} ) {
       Rex::Logger::debug("Registering: $var");
+
+      my $ref_to_var = qualify_to_ref($var);
+
       unless ( ref( $vars->{$var} ) ) {
-        $$var = \$vars->{$var};
+        $ref_to_var = \$vars->{$var};
       }
       else {
-        $$var = $vars->{$var};
+        $ref_to_var = $vars->{$var};
       }
     }
 


### PR DESCRIPTION
Turns out in many, if not all cases, using the core `Symbol` module makes it possible to avoid using `no strict refs`.

This PR is a work in progress to clean all cases up. During the WIP phase I convert cases one-by-one on each commit to make it easier to test and review. Before merging I plan to squash them all into one, or at least group them together somehow, and write proper useful commit messages.