### PR TITLE
Support for Void Linux

### DIFF
--- a/lib/Rex/Commands/Gather.pm
+++ b/lib/Rex/Commands/Gather.pm
@@ -45,7 +45,7 @@ use vars qw(@EXPORT);
 
 @EXPORT = qw(operating_system_is network_interfaces memory
   get_operating_system operating_system operating_system_version operating_system_release
-  is_freebsd is_netbsd is_openbsd is_redhat is_linux is_bsd is_solaris is_suse is_debian is_mageia is_windows is_alt is_openwrt is_gentoo is_fedora is_arch
+  is_freebsd is_netbsd is_openbsd is_redhat is_linux is_bsd is_solaris is_suse is_debian is_mageia is_windows is_alt is_openwrt is_gentoo is_fedora is_arch is_void
   get_system_information dump_system_information kernelname);
 
 =head2 get_operating_system
@@ -557,6 +557,20 @@ sub is_arch {
   if ( grep { /$os/i } @arch_clones ) {
     return 1;
   }
+}
+
+=head2 is_void
+
+Returns true if the target system is a Void Linux system.
+
+=cut
+
+sub is_void {
+  my $os = get_operating_system();
+  if ( $os =~ m/VoidLinux/i ) {
+    return 1;
+  }
+
 }
 
 1;

--- a/lib/Rex/Pkg/VoidLinux.pm
+++ b/lib/Rex/Pkg/VoidLinux.pm
@@ -1,0 +1,91 @@
+#
+# (c) 2019 Leah Neukirchen <leah@vuxu.org>
+# based on Rex::Pkg::Arch
+# (c) Harm Müller <harm _DOT_ mueller _AT_ g m a i l _Dot_ com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Pkg::VoidLinux;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Rex::Helper::Run;
+use Rex::Commands::File;
+use Rex::Commands::Fs;
+
+use Rex::Pkg::Base;
+use base qw(Rex::Pkg::Base);
+
+sub new {
+  my $that  = shift;
+  my $proto = ref($that) || $that;
+  my $self  = $proto->SUPER::new(@_);
+
+  bless( $self, $proto );
+
+  if ( Rex::has_feature_version('1.5') ) {
+    $self->{commands} = {
+      install => 'xbps-install -y %s',
+      install_version => 'xbps-install -y %s', # makes no sense to specify the package version
+      update_system   => 'xbps-install -yu',
+      dist_update_system => 'xbps-install -yu',
+      remove             => 'xbps-remove -Ry %s',
+      update_package_db  => 'xbps-install -S',
+    };
+  }
+  else {
+    $self->{commands} = {
+      install => 'xbps-install -y %s',
+      install_version => 'xbps-install -y %s', # makes no sense to specify the package version
+      update_system   => 'xbps-install -Syu',
+      dist_update_system => 'xbps-install -Syu',
+      remove             => 'xbps-remove -Ry %s',
+      update_package_db  => 'xbps-install -S',
+    };
+  }
+
+  return $self;
+}
+
+sub bulk_install {
+  my ( $self, $packages_aref, $option ) = @_;
+
+  delete $option->{version}; # makes no sense to specify the same version for several packages
+
+  $self->update( "@{$packages_aref}", $option );
+
+  return 1;
+}
+
+sub get_installed {
+  my ( $self, $pkg ) = @_;
+  my ( @pkgs, $name, $version, $release, $arch );
+  my $pkg_query = 'xbps-query --search=';
+  if ( defined($pkg) ) {
+    $pkg_query .= $pkg;
+  }
+  my @installed_packages = i_run $pkg_query;
+  for my $line (@installed_packages) {
+    if ( $line =~ /^\[\*\] ([^ ]*)-([^- ]*)_(\d+)/ ) {
+      $name    = $1;
+      $version = $2;
+      $release = $3;
+      push(
+        @pkgs,
+        {
+          name    => $name,
+          version => $version,
+          release => $release,
+        }
+      );
+    }
+  }
+
+  return @pkgs;
+}
+
+1;

--- a/lib/Rex/Service/VoidLinux.pm
+++ b/lib/Rex/Service/VoidLinux.pm
@@ -1,0 +1,55 @@
+#
+# (c) 2019 Leah Neukirchen <leah@vuxu.org>
+# based on Rex::Service::Gentoo
+# (c) Jan Gehring <jan.gehring@gmail.com>
+#
+# vim: set ts=2 sw=2 tw=0:
+# vim: set expandtab:
+
+package Rex::Service::VoidLinux;
+
+use strict;
+use warnings;
+
+# VERSION
+
+use Rex::Helper::Run;
+
+use base qw(Rex::Service::Base);
+
+sub new {
+  my $that  = shift;
+  my $proto = ref($that) || $that;
+  my $self  = $proto->SUPER::new(@_);
+
+  bless( $self, $proto );
+
+  $self->{commands} = {
+    start          => 'ln -sf /etc/sv/%s /var/service',
+    restart        => 'sv restart %s',
+    stop           => 'rm /var/service/%s',
+    reload         => 'sv reload %s',
+    status         => 'sv status %s | grep -q ^run:',
+    ensure_stop    => 'rm /var/service/%s',
+    ensure_start   => 'ln -sf /etc/sv/%s /var/service',
+    service_exists => 'test -d /etc/sv/%s',
+  };
+
+  return $self;
+}
+
+sub action {
+  my ( $self, $service, $action ) = @_;
+
+  my $ret_val;
+  eval {
+    i_run "sv $action $service >/dev/null", nohup => 1;
+    $ret_val = 1;
+  } or do {
+    $ret_val = 0;
+  };
+
+  return $ret_val;
+}
+
+1;


### PR DESCRIPTION
The first beginnings of Void Linux support in Rex.

Mapping runit to Rex::Service is not completely straight-forward, as services need to be enabled before they are started, so we merge both operations currenty. (This does not support taking a service down using a `down` file in runit.)

Closes #1258.