### PR TITLE
Perltidy

### DIFF
--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -284,7 +284,7 @@ CHECK_OVERWRITE: {
 
     Rex::global_sudo(0);
     Rex::Logger::debug("Removing lockfile") if ( !exists $opts{'F'} );
-    CORE::unlink("$::rexfile.lock") if ( !exists $opts{'F'} );
+    CORE::unlink("$::rexfile.lock")         if ( !exists $opts{'F'} );
     CORE::exit 0;
   }
 
@@ -783,7 +783,7 @@ sub load_rexfile {
     my @lines = split( $/, $e );
 
     Rex::Logger::info( "Compile time errors:", 'error' );
-    Rex::Logger::info( "\t$_", 'error' ) for @lines;
+    Rex::Logger::info( "\t$_",                 'error' ) for @lines;
 
     exit 1;
   }
@@ -796,7 +796,7 @@ sub exit_rex {
 
   Rex::global_sudo(0);
   Rex::Logger::debug("Removing lockfile") if !exists $opts{'F'};
-  unlink("$::rexfile.lock") if !exists $opts{'F'};
+  unlink("$::rexfile.lock")               if !exists $opts{'F'};
 
   select STDOUT;
 

--- a/lib/Rex/CMDB/YAML.pm
+++ b/lib/Rex/CMDB/YAML.pm
@@ -113,7 +113,7 @@ sub get {
     if ( -f $file ) {
 
       my $content = eval { local ( @ARGV, $/ ) = ($file); <>; };
-      my $t = Rex::Config->get_template_function();
+      my $t       = Rex::Config->get_template_function();
       $content .= "\n"; # for safety
       $content = $t->( $content, \%template_vars );
 

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -416,7 +416,7 @@ sub file {
   Rex::get_current_connection()->{reporter}
     ->report_resource_start( type => "file", name => $file );
 
-  my $need_md5 = ( $option->{"on_change"} && !$is_directory ? 1 : 0 );
+  my $need_md5  = ( $option->{"on_change"} && !$is_directory ? 1 : 0 );
   my $on_change = $option->{"on_change"} || sub { };
 
   my $__ret = { changed => 0 };

--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -337,7 +337,7 @@ sub install {
     }
     else {
 
-      my $source = Rex::Helper::Path::get_file_path( $source, caller() );
+      my $source  = Rex::Helper::Path::get_file_path( $source, caller() );
       my $content = eval { local ( @ARGV, $/ ) = ($source); <>; };
 
       my $local_md5 = "";

--- a/lib/Rex/Group/Lookup/XML.pm
+++ b/lib/Rex/Group/Lookup/XML.pm
@@ -115,7 +115,7 @@ sub groups_xml {
   foreach my $server_node ( $xmldoc->findnodes('/configuration/group/server') )
   {
     my ($group) =
-      map  { $_->getValue() }
+      map { $_->getValue() }
       grep { $_->nodeName eq 'name' } $server_node->parentNode->attributes();
     my %atts =
       map { $_->nodeName => $_->getValue() } $server_node->attributes();

--- a/lib/Rex/Hardware/Network/Linux.pm
+++ b/lib/Rex/Hardware/Network/Linux.pm
@@ -51,7 +51,7 @@ sub get_bridge_devices {
 sub get_network_devices {
 
   my $command = can_run('ip') ? 'ip addr show' : 'ifconfig -a';
-  my @output = i_run( "$command", fail_ok => 1 );
+  my @output  = i_run( "$command", fail_ok => 1 );
 
   my $devices =
     ( $command eq 'ip addr show' )
@@ -67,7 +67,7 @@ sub get_network_configuration {
   my $device_info = {};
 
   my $command = can_run('ip') ? 'ip addr show' : 'ifconfig -a';
-  my @output = i_run( "$command", fail_ok => 1 );
+  my @output  = i_run( "$command", fail_ok => 1 );
 
   my $br_data = get_bridge_devices();
 

--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -60,7 +60,7 @@ sub connect {
 
   my $proxy_command = Rex::Config->get_proxy_command( server => $server );
 
-  $port ||= Rex::Config->get_port( server => $server ) || 22;
+  $port    ||= Rex::Config->get_port( server => $server )    || 22;
   $timeout ||= Rex::Config->get_timeout( server => $server ) || 3;
 
   $server =

--- a/lib/Rex/Interface/Connection/SSH.pm
+++ b/lib/Rex/Interface/Connection/SSH.pm
@@ -63,7 +63,7 @@ sub connect {
   my $fail_connect = 0;
 
 CON_SSH:
-  $port ||= Rex::Config->get_port( server => $server ) || 22;
+  $port    ||= Rex::Config->get_port( server => $server )    || 22;
   $timeout ||= Rex::Config->get_timeout( server => $server ) || 3;
   $self->{ssh}->timeout( $timeout * 1000 );
 

--- a/lib/Rex/Resource.pm
+++ b/lib/Rex/Resource.pm
@@ -15,7 +15,7 @@ use Rex::Constants;
 
 our @CURRENT_RES;
 
-sub is_inside_resource { ref $CURRENT_RES[-1] ? 1 : 0 }
+sub is_inside_resource   { ref $CURRENT_RES[-1] ? 1 : 0 }
 sub get_current_resource { $CURRENT_RES[-1] }
 
 sub new {

--- a/lib/Rex/Shared/Var/Common.pm
+++ b/lib/Rex/Shared/Var/Common.pm
@@ -29,7 +29,7 @@ our $LOCK_FILE =
 
 sub __lock {
   sysopen( my $dblock, $LOCK_FILE, O_RDONLY | O_CREAT ) or die($!);
-  flock( $dblock, LOCK_EX ) or die($!);
+  flock( $dblock, LOCK_EX )                             or die($!);
 
   my $ret = $_[0]->();
 

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -238,7 +238,7 @@ sub create_task {
 sub get_tasks {
   my $self = shift;
   return grep { $self->{tasks}->{$_}->hidden() == 0 }
-    sort      { $a cmp $b } keys %{ $self->{tasks} };
+    sort { $a cmp $b } keys %{ $self->{tasks} };
 }
 
 sub get_all_tasks {

--- a/lib/Rex/Test/Base/has_cron_env.pm
+++ b/lib/Rex/Test/Base/has_cron_env.pm
@@ -31,7 +31,7 @@ sub new {
 sub run_test {
   my ( $self, $user, $key, $value, $count ) = @_;
 
-  my @envs = cron env => $user => "list";
+  my @envs         = cron env => $user => "list";
   my @matched_envs = grep { $_->{name} eq $key && $_->{value} eq $value } @envs;
 
   if ($count) {
@@ -47,7 +47,7 @@ sub run_test {
 sub run_not_test {
   my ( $self, $user, $key, $value, $count ) = @_;
 
-  my @envs = cron env => $user => "list";
+  my @envs         = cron env => $user => "list";
   my @matched_envs = grep { $_->{name} eq $key && $_->{value} eq $value } @envs;
 
   if ($count) {

--- a/lib/Rex/Virtualization/Lxc/list.pm
+++ b/lib/Rex/Virtualization/Lxc/list.pm
@@ -35,7 +35,7 @@ sub execute {
     exists $opts->{format}
     ? $opts->{format}
     : 'name,state,autostart,groups,ipv4,ipv6,pid';
-  my $fancy = exists $opts->{fancy} ? '-f' : '';
+  my $fancy  = exists $opts->{fancy}  ? '-f'                   : '';
   my $groups = exists $opts->{groups} ? '-g' . $opts->{groups} : '';
 
   # When using not fancy output, lxc-ls defaults to outputting only name.

--- a/t/0.31.t
+++ b/t/0.31.t
@@ -32,7 +32,7 @@ is( $servers[5], "serv06", "get_group with evaluation" );
 
 task( "authtest1", group => "foo", sub { } );
 task( "authtest2", group => "bar", sub { } );
-task( "authtest3", "srv001",           sub { } );
+task( "authtest3", "srv001", sub { } );
 task( "authtest4", group => "latebar", sub { } );
 group( "latebar", "server[01..03]" );
 

--- a/t/before_all_tasks.t
+++ b/t/before_all_tasks.t
@@ -23,8 +23,8 @@ cmp_deeply
 for my $tn (@task_names) {
   my $before = $task_list->get_task($tn)->get_data->{before};
   ok($before);
-  is( ( scalar @$before ), 1, $tn );
-  is( $before->[0]->(), 'yo', $tn ) if (@$before);
+  is( ( scalar @$before ), 1,    $tn );
+  is( $before->[0]->(),    'yo', $tn ) if (@$before);
 }
 
 done_testing();

--- a/t/config-ssh.t
+++ b/t/config-ssh.t
@@ -69,7 +69,7 @@ is( $c->{'other'}->{'port'}, '3306' );
 is( $c->{'hosts'}->{'port'}, '3306' );
 
 my @lines = eval { local (@ARGV) = ("t/ssh_config.1"); <>; };
-my %data = Rex::Config::_parse_ssh_config(@lines);
+my %data  = Rex::Config::_parse_ssh_config(@lines);
 
 ok( exists $data{"*"}, "Host * exists" );
 ok(

--- a/t/cron.t
+++ b/t/cron.t
@@ -13,7 +13,7 @@ my @cron = $c->list;
 
 is( $cron[0]->{type}, "comment", "first line is a comment" );
 
-is( $cron[1]->{type}, "comment", "second line is comment" );
+is( $cron[1]->{type}, "comment",                   "second line is comment" );
 is( $cron[1]->{line}, "# Shell variable for cron", "got the line content #2" );
 
 is( $cron[2]->{type},  "env",       "3rd line is a env variable" );

--- a/t/dmi.t
+++ b/t/dmi.t
@@ -3,7 +3,7 @@ use Test::More tests => 30;
 use Rex::Inventory::DMIDecode;
 
 my @lines = eval { local (@ARGV) = ("t/dmi.linux.out"); <>; };
-my $dmi = Rex::Inventory::DMIDecode->new( lines => \@lines );
+my $dmi   = Rex::Inventory::DMIDecode->new( lines => \@lines );
 
 isa_ok( $dmi, "Rex::Inventory::DMIDecode", "dmi object" );
 
@@ -64,7 +64,7 @@ $bios    = undef;
 $sysinfo = undef;
 
 @lines = eval { local (@ARGV) = ("t/dmi.obsd.out"); <>; };
-$dmi = Rex::Inventory::DMIDecode->new( lines => \@lines );
+$dmi   = Rex::Inventory::DMIDecode->new( lines => \@lines );
 
 isa_ok( $dmi, "Rex::Inventory::DMIDecode", "dmi object (obsd)" );
 
@@ -125,7 +125,7 @@ $bios    = undef;
 $sysinfo = undef;
 
 @lines = eval { local (@ARGV) = ("t/dmi.fbsd.out"); <>; };
-$dmi = Rex::Inventory::DMIDecode->new( lines => \@lines );
+$dmi   = Rex::Inventory::DMIDecode->new( lines => \@lines );
 
 isa_ok( $dmi, "Rex::Inventory::DMIDecode", "dmi object (fbsd)" );
 

--- a/t/host.t
+++ b/t/host.t
@@ -6,7 +6,7 @@ use Test::More tests => 10;
 use Rex::Commands::Host;
 
 my @content = eval { local (@ARGV) = ("t/hosts.ex"); <>; };
-my @ret = Rex::Commands::Host::_parse_hosts(@content);
+my @ret     = Rex::Commands::Host::_parse_hosts(@content);
 
 is( $ret[0]->{host}, "localhost", "got localhost" );
 is( $ret[0]->{ip},   "127.0.0.1", "got 127.0.0.1" );
@@ -16,7 +16,7 @@ is( $ret[0]->{ip},   "192.168.2.23",     "got 192.168.2.23 by alias" );
 is( $ret[0]->{host}, "mango.rexify.org", "got mango.rexify.org by alias" );
 
 @content = eval { local (@ARGV) = ("t/hosts.ex2"); <>; };
-@ret = Rex::Commands::Host::_parse_hosts(@content);
+@ret     = Rex::Commands::Host::_parse_hosts(@content);
 
 is( $ret[0]->{host}, "localhost",  "got localhost" );
 is( $ret[0]->{ip},   "127.0.0.1",  "got 127.0.0.1" );

--- a/t/issue/1008.t
+++ b/t/issue/1008.t
@@ -37,12 +37,12 @@ is( $p, 2222,             "got port from v4 ip with slash" );
 ( $s, $p ) = ( undef, undef );
 ( $s, $p ) = Rex::Helper::IP::get_server_and_port($ipv6);
 is( $s, "fe80::a00:27ff:fe36:9377", "got v6 ip" );
-is( $p, undef, "got no port from v6 ip" );
+is( $p, undef,                      "got no port from v6 ip" );
 
 ( $s, $p ) = ( undef, undef );
 ( $s, $p ) = Rex::Helper::IP::get_server_and_port($ipv6_port);
 is( $s, "fe80::a00:27ff:fe36:9377", "got v6 ip with port" );
-is( $p, 3333, "got port from v6 ip with colon" );
+is( $p, 3333,                       "got port from v6 ip with colon" );
 
 ( $s, $p ) = Rex::Helper::IP::get_server_and_port($hostname);
 is( $s, "blah01", "got hostname" );


### PR DESCRIPTION
Perl-Tidy-20191203 has just been released fixing/improving vertical alignment cases.

This PR applies the formatting to the codebase with this latest version to be up-to-date.

ps.: I'd like to solve the "which version of Perl::Tidy to use" question separately (probably by making it a versioned dependency, and/or improving Travis CI to upgrade earlier than caches expire).