### PR TITLE
Improve perltidy steps in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ jobs:
         - export "PATH=/c/Strawberry/perl/site/bin:/c/Strawberry/perl/bin:/c/Strawberry/c/bin:$PATH"
         - export "PERL5LIB=/c/Strawberry/perl/site/lib:/c/Strawberry/perl/site/lib:/c/Strawberry/perl/vendor/lib:/c/Strawberry/perl/lib"
         - ln -snf /c/Strawberry/perl/bin/perl /bin/perl
-        - cpanm Perl::Critic
-        - perlcritic --quiet --single-policy=RequireTidyCode bin
         - cpanm --reinstall Module::Pluggable::Object
         - cpanm Dist::Zilla
         - dzil authordeps --missing | cpanm
@@ -65,8 +63,6 @@ jobs:
             - openssl
       before_install:
         - export "PATH=/usr/local/Cellar/perl/5.30.0/bin:${PATH}"
-        - cpanm Perl::Critic
-        - perlcritic --quiet --single-policy=RequireTidyCode bin
         - cpanm Dist::Zilla
         - dzil authordeps --missing | cpanm
         - dzil listdeps --author --missing | cpanm

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
           - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/lib
           - ${PERLBREW_ROOT}/perls/${PERLBREW_PERL}/bin
       before_install:
-        - cpanm Perl::Critic
+        - cpanm Perl::Critic Perl::Tidy
         - perlcritic --quiet --single-policy=RequireTidyCode bin
         - dzil authordeps --missing | cpanm
         - dzil listdeps --author --missing | cpanm


### PR DESCRIPTION
This PR improves tidyness related steps in Travis builds by
 - simplifying the Windows and Max OS X cases: no need to run tidy checks on all platforms
 - try to update Perl::Tidy on each run: so it's updated even if a previous version is already installed in the Travis build caches