### PR TITLE
Document embedded templates

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
 
  [DOCUMENTATION]
+ - Document embedded templates
 
  [ENHANCEMENTS]
 

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -128,8 +128,8 @@ Use C<@end> to separate multiple templates inside C<__DATA__>.
 =head3 File templates
 
  my $content = template("/files/templates/vhosts.tpl",
-              name => "test.lan",
-              webmaster => 'webmaster@test.lan');
+               name      => "test.lan",
+               webmaster => 'webmaster@test.lan');
 
 The file name specified is subject to "path_map" processing as documented
 under the file() function to resolve to a physical file name.
@@ -144,16 +144,13 @@ exists. E.g. if rex is started as:
 then in task1 defined as:
 
  task "task1", sub {
-
     say template("files/etc/ntpd.conf");
-
  };
 
 will print the content of 'files/etc/ntpd.conf.prod' if it exists.
 
 Note: the appended environment mechanism is always applied, after
 the 'path_map' mechanism, if that is configured.
-
 
 =cut
 

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -98,6 +98,35 @@ use vars qw(%file_handles);
 
 Parse a template and return the content.
 
+=head3 Embedded templates
+
+Use C<__DATA__> to embed templates at the end of the file. Prefix embedded template names with C<@>. If embedding multiple templates, mark their end with C<@end>.
+
+=head4 Single template
+
+ my $content = template( '@hello', name => 'world' ); # Hello, world!
+ __DATA__
+ @hello
+ Hello, <%= $name -%>!
+
+=head4 Multiple templates
+
+Use C<@end> to separate multiple templates inside C<__DATA__>.
+
+ my $content     = template( '@hello', name => 'world' ); # Hello, world!
+ my $alternative = template( '@hi',    name => 'world' ); # Hi, world!
+
+ __DATA__
+ @hello
+ Hello, <%= $name -%>!
+ @end
+
+ @hi
+ Hi, <%= $name -%>!
+ @end
+
+=head3 File templates
+
  my $content = template("/files/templates/vhosts.tpl",
               name => "test.lan",
               webmaster => 'webmaster@test.lan');


### PR DESCRIPTION
This PR adds initial documentation for embedded templates.

[Reference](https://www.rexify.org/docs/rex_book/the_rex_dsl/using_templates.html)

@gonzalo-radio: is this already helpful for your use case?