### PR TITLE
Mark Test::Pod a development dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -74,12 +74,12 @@ perl = 5.010001
 YAML = != 1.25
 
 [Prereqs / BuildRequires]
-Test::Pod = 0
 Test::UseAllModules = 0.15
 
 [Prereqs / DevelopRequires]
 Test::Kwalitee = 0
 Test::PerlTidy = 0
+Test::Pod = 0
 
 [Test::MinimumVersion]
 max_target_perl = 5.10.1


### PR DESCRIPTION
See gentoo/gentoo#14313 for [reference](https://github.com/gentoo/gentoo/pull/14313#issuecomment-581294635).

TL;DR: it's required by author (extra) tests, and for building.