### PR TITLE
Fix Travis tests on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ jobs:
             - perl
             - cpanminus
             - openssl
+          update: true
       before_install:
         - export "PATH=/usr/local/Cellar/perl/5.30.0/bin:${PATH}"
         - cpanm Dist::Zilla

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
             - openssl
           update: true
       before_install:
-        - export "PATH=/usr/local/Cellar/perl/5.30.0/bin:${PATH}"
+        - export "PATH=/usr/local/Cellar/perl/5.30.1/bin:${PATH}"
         - cpanm Dist::Zilla
         - mkdir ~/.dzil
         - export AUTHOR_EMAIL="$(git log -1 ${TRAVIS_COMMIT} --pretty='%aE')"

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ Revision history for Rex
  [NEW FEATURES]
 
  [REVISION]
+ - Fix Travis builds on OS X
 
 1.8.1 2020-02-05 Ferenc Erki <erkiferenc@gmail.com>
  [DOCUMENTATION]


### PR DESCRIPTION
Looks like we were also affected by the things described on travis-ci/packer-templates-mac#13, and the workaround is to run `brew update` on each build.

Downside is that it makes the OS X builds slower, but I expect it can be reverted once the issue linked above is fixed.