### PR TITLE
Add option to control encoding of files written by Rex

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Revision history for Rex
  [DOCUMENTATION]
 
  [ENHANCEMENTS]
+ - Add option to control encoding of files written by Rex
 
  [MAJOR]
 

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -32,36 +32,36 @@ use Data::Dumper;
 use Rex::Require;
 
 our (
-  $user,                     $password,
-  $port,                     $timeout,
-  $max_connect_fails,        $password_auth,
-  $key_auth,                 $krb5_auth,
-  $public_key,               $private_key,
-  $parallelism,              $log_filename,
-  $log_facility,             $sudo_password,
-  $ca_file,                  $ca_cert,
-  $ca_key,                   $path,
-  $no_path_cleanup,          $set_param,
-  $environment,              $connection_type,
-  $distributor,              $template_function,
-  $SET_HANDLER,              $HOME_CONFIG,
-  $HOME_CONFIG_YAML,         %SSH_CONFIG_FOR,
-  $sudo_without_locales,     $sudo_without_sh,
-  $no_tty,                   $source_global_profile,
-  $source_profile,           %executor_for,
-  $allow_empty_groups,       $use_server_auth,
-  $tmp_dir,                  %openssh_opt,
-  $use_cache,                $cache_type,
-  $use_sleep_hack,           $report_type,
-  $do_reporting,             $say_format,
-  $exec_autodie,             $verbose_run,
-  $disable_taskname_warning, $proxy_command,
-  $task_call_by_method,      $fallback_auth,
-  $register_cmdb_template,   $check_service_exists,
-  $set_no_append,            $use_net_openssh_if_present,
-  $use_template_ng,          $use_rex_kvm_agent,
-  $autodie,                  $task_chaining_cmdline_args,
-  $waitpid_blocking_sleep_time,
+  $user,                        $password,
+  $port,                        $timeout,
+  $max_connect_fails,           $password_auth,
+  $key_auth,                    $krb5_auth,
+  $public_key,                  $private_key,
+  $parallelism,                 $log_filename,
+  $log_facility,                $sudo_password,
+  $ca_file,                     $ca_cert,
+  $ca_key,                      $path,
+  $no_path_cleanup,             $set_param,
+  $environment,                 $connection_type,
+  $distributor,                 $template_function,
+  $SET_HANDLER,                 $HOME_CONFIG,
+  $HOME_CONFIG_YAML,            %SSH_CONFIG_FOR,
+  $sudo_without_locales,        $sudo_without_sh,
+  $no_tty,                      $source_global_profile,
+  $source_profile,              %executor_for,
+  $allow_empty_groups,          $use_server_auth,
+  $tmp_dir,                     %openssh_opt,
+  $use_cache,                   $cache_type,
+  $use_sleep_hack,              $report_type,
+  $do_reporting,                $say_format,
+  $exec_autodie,                $verbose_run,
+  $disable_taskname_warning,    $proxy_command,
+  $task_call_by_method,         $fallback_auth,
+  $register_cmdb_template,      $check_service_exists,
+  $set_no_append,               $use_net_openssh_if_present,
+  $use_template_ng,             $use_rex_kvm_agent,
+  $autodie,                     $task_chaining_cmdline_args,
+  $waitpid_blocking_sleep_time, $file_write_encoding,
 );
 
 # some defaults
@@ -1076,6 +1076,14 @@ sub get_waitpid_blocking_sleep_time {
   return $waitpid_blocking_sleep_time // 0.1;
 }
 
+sub set_file_write_encoding {
+  my ( $self, $file_write_encoding ) = @_;
+}
+
+sub get_file_write_encoding {
+  return $file_write_encoding;
+}
+
 sub import {
   read_ssh_config_file();
   read_config_file();
@@ -1111,7 +1119,7 @@ __PACKAGE__->register_config_handler(
 my @set_handler =
   qw/user password private_key public_key -keyauth -passwordauth -passauth
   parallelism sudo_password connection ca cert key distributor
-  template_function port waitpid_blocking_sleep_time/;
+  template_function port waitpid_blocking_sleep_time file_write_encoding/;
 for my $hndl (@set_handler) {
   __PACKAGE__->register_set_handler(
     $hndl => sub {

--- a/lib/Rex/Interface/File/Base.pm
+++ b/lib/Rex/Interface/File/Base.pm
@@ -18,6 +18,8 @@ sub new {
 
   bless( $self, $proto );
 
+  $self->{file_write_encoding} = Rex::Config->get_file_write_encoding;
+
   return $self;
 }
 
@@ -26,5 +28,10 @@ sub read  { die("Must be implemented by Interface Class."); }
 sub write { die("Must be implemented by Interface Class."); }
 sub close { die("Must be implemented by Interface Class."); }
 sub seek  { die("Must be implemented by Interface Class."); }
+
+sub get_file_write_encoding {
+  my $self = shift;
+  return $self->{file_write_encoding};
+}
 
 1;

--- a/lib/Rex/Interface/File/HTTP.pm
+++ b/lib/Rex/Interface/File/HTTP.pm
@@ -12,6 +12,7 @@ use warnings;
 # VERSION
 
 use Data::Dumper;
+use Encode;
 
 BEGIN {
   use Rex::Require;
@@ -75,6 +76,9 @@ sub read {
 
 sub write {
   my ( $self, $buf ) = @_;
+
+  $buf = Encode::encode( $self->get_file_write_encoding, $buf )
+    if defined $self->get_file_write_encoding;
 
   my $resp = connection->post(
     "/file/write_fh",

--- a/lib/Rex/Interface/File/Local.pm
+++ b/lib/Rex/Interface/File/Local.pm
@@ -11,6 +11,7 @@ use warnings;
 
 # VERSION
 
+use Encode;
 use Rex::Interface::File::Base;
 use base qw(Rex::Interface::File::Base);
 
@@ -44,6 +45,9 @@ sub read {
 
 sub write {
   my ( $self, $buf ) = @_;
+
+  $buf = Encode::encode( $self->get_file_write_encoding, $buf )
+    if defined $self->get_file_write_encoding;
 
   my $fh = $self->{fh};
   print $fh $buf;

--- a/lib/Rex/Interface/File/OpenSSH.pm
+++ b/lib/Rex/Interface/File/OpenSSH.pm
@@ -11,6 +11,7 @@ use warnings;
 
 # VERSION
 
+use Encode;
 use Fcntl;
 use Rex::Interface::Fs;
 use Rex::Interface::File::Base;
@@ -65,6 +66,10 @@ sub read {
 
 sub write {
   my ( $self, $buf ) = @_;
+
+  $buf = Encode::encode( $self->get_file_write_encoding, $buf )
+    if defined $self->get_file_write_encoding;
+
   my $sftp = Rex::get_sftp();
   $sftp->write( $self->{fh}, $buf );
 }

--- a/lib/Rex/Interface/File/SSH.pm
+++ b/lib/Rex/Interface/File/SSH.pm
@@ -11,6 +11,7 @@ use warnings;
 
 # VERSION
 
+use Encode;
 use Fcntl;
 use Rex::Interface::Fs;
 use Rex::Interface::File::Base;
@@ -58,6 +59,10 @@ sub read {
 
 sub write {
   my ( $self, $buf ) = @_;
+
+  $buf = Encode::encode( $self->get_file_write_encoding, $buf )
+    if defined $self->get_file_write_encoding;
+
   $self->{fh}->write($buf);
 }
 

--- a/lib/Rex/Interface/File/Sudo.pm
+++ b/lib/Rex/Interface/File/Sudo.pm
@@ -11,6 +11,7 @@ use warnings;
 
 # VERSION
 
+use Encode;
 use Fcntl;
 use File::Basename;
 require Rex::Commands;
@@ -85,6 +86,10 @@ sub read {
 
 sub write {
   my ( $self, $buf ) = @_;
+
+  $buf = Encode::encode( $self->get_file_write_encoding, $buf )
+    if defined $self->get_file_write_encoding;
+
   $self->{fh}->write($buf);
 }
 


### PR DESCRIPTION
Rex writes files to the managed system via `Rex::Interface::File` modules. This mechanism is used both for `file $file, content => '';` and `Rex::FS::File` as well.

Regarding the encoding of the written file, Rex behaves identically to Perl currently ("it's just Perl"). However depending on the encoding of the input, this may lead to unexpected side effects, e.g. when Rex carries out its tasks by using temporary files on the managed systems (see for example #1274).

This PR adds an option to control the encoding of files written by Rex as a first step to give more control to the users in those cases while still preserving the current behaviour for backwards compatibility.

With the option in place, it will be possible to establish a default value for this setting later, and/or to control the behaviour via a feature flag.

Example code:
```
use Rex;

set file_write_encoding => 'UTF-8';
```