### PR TITLE
Add write_utf8_files feature flag (close #1274)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Revision history for Rex
  [DOCUMENTATION]
 
  [ENHANCEMENTS]
+ - Add write_utf8_files feature flag to control encoding of files written by Rex
 
  [MAJOR]
 

--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -915,6 +915,18 @@ sub import {
         $found_feature = 1;
       }
 
+      if ( $add eq "write_utf8_files" ) {
+        Rex::Logger::debug("Enabling write_utf8_files feature");
+        Rex::Config->set_write_utf8_files(1);
+        $found_feature = 1;
+      }
+
+      if ( $add eq "no_write_utf8_files" ) {
+        Rex::Logger::debug("Disabling write_utf8_files feature");
+        Rex::Config->set_write_utf8_files(0);
+        $found_feature = 1;
+      }
+
       if ( $found_feature == 0 ) {
         Rex::Logger::info(
           "You tried to load a feature ($add) that doesn't exists in your Rex version. Please update.",

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -32,36 +32,36 @@ use Data::Dumper;
 use Rex::Require;
 
 our (
-  $user,                     $password,
-  $port,                     $timeout,
-  $max_connect_fails,        $password_auth,
-  $key_auth,                 $krb5_auth,
-  $public_key,               $private_key,
-  $parallelism,              $log_filename,
-  $log_facility,             $sudo_password,
-  $ca_file,                  $ca_cert,
-  $ca_key,                   $path,
-  $no_path_cleanup,          $set_param,
-  $environment,              $connection_type,
-  $distributor,              $template_function,
-  $SET_HANDLER,              $HOME_CONFIG,
-  $HOME_CONFIG_YAML,         %SSH_CONFIG_FOR,
-  $sudo_without_locales,     $sudo_without_sh,
-  $no_tty,                   $source_global_profile,
-  $source_profile,           %executor_for,
-  $allow_empty_groups,       $use_server_auth,
-  $tmp_dir,                  %openssh_opt,
-  $use_cache,                $cache_type,
-  $use_sleep_hack,           $report_type,
-  $do_reporting,             $say_format,
-  $exec_autodie,             $verbose_run,
-  $disable_taskname_warning, $proxy_command,
-  $task_call_by_method,      $fallback_auth,
-  $register_cmdb_template,   $check_service_exists,
-  $set_no_append,            $use_net_openssh_if_present,
-  $use_template_ng,          $use_rex_kvm_agent,
-  $autodie,                  $task_chaining_cmdline_args,
-  $waitpid_blocking_sleep_time,
+  $user,                        $password,
+  $port,                        $timeout,
+  $max_connect_fails,           $password_auth,
+  $key_auth,                    $krb5_auth,
+  $public_key,                  $private_key,
+  $parallelism,                 $log_filename,
+  $log_facility,                $sudo_password,
+  $ca_file,                     $ca_cert,
+  $ca_key,                      $path,
+  $no_path_cleanup,             $set_param,
+  $environment,                 $connection_type,
+  $distributor,                 $template_function,
+  $SET_HANDLER,                 $HOME_CONFIG,
+  $HOME_CONFIG_YAML,            %SSH_CONFIG_FOR,
+  $sudo_without_locales,        $sudo_without_sh,
+  $no_tty,                      $source_global_profile,
+  $source_profile,              %executor_for,
+  $allow_empty_groups,          $use_server_auth,
+  $tmp_dir,                     %openssh_opt,
+  $use_cache,                   $cache_type,
+  $use_sleep_hack,              $report_type,
+  $do_reporting,                $say_format,
+  $exec_autodie,                $verbose_run,
+  $disable_taskname_warning,    $proxy_command,
+  $task_call_by_method,         $fallback_auth,
+  $register_cmdb_template,      $check_service_exists,
+  $set_no_append,               $use_net_openssh_if_present,
+  $use_template_ng,             $use_rex_kvm_agent,
+  $autodie,                     $task_chaining_cmdline_args,
+  $waitpid_blocking_sleep_time, $write_utf8_files,
 );
 
 # some defaults
@@ -1074,6 +1074,15 @@ sub set_waitpid_blocking_sleep_time {
 
 sub get_waitpid_blocking_sleep_time {
   return $waitpid_blocking_sleep_time // 0.1;
+}
+
+sub set_write_utf8_files {
+  my $self = shift;
+  $write_utf8_files = shift;
+}
+
+sub get_write_utf8_files {
+  return $write_utf8_files;
 }
 
 sub import {

--- a/lib/Rex/Interface/File/HTTP.pm
+++ b/lib/Rex/Interface/File/HTTP.pm
@@ -76,6 +76,9 @@ sub read {
 sub write {
   my ( $self, $buf ) = @_;
 
+  utf8::encode($buf)
+    if Rex::Config->get_write_utf8_files && utf8::is_utf8($buf);
+
   my $resp = connection->post(
     "/file/write_fh",
     {

--- a/lib/Rex/Interface/File/Local.pm
+++ b/lib/Rex/Interface/File/Local.pm
@@ -45,6 +45,9 @@ sub read {
 sub write {
   my ( $self, $buf ) = @_;
 
+  utf8::encode($buf)
+    if Rex::Config->get_write_utf8_files && utf8::is_utf8($buf);
+
   my $fh = $self->{fh};
   print $fh $buf;
 }

--- a/lib/Rex/Interface/File/OpenSSH.pm
+++ b/lib/Rex/Interface/File/OpenSSH.pm
@@ -65,6 +65,10 @@ sub read {
 
 sub write {
   my ( $self, $buf ) = @_;
+
+  utf8::encode($buf)
+    if Rex::Config->get_write_utf8_files && utf8::is_utf8($buf);
+
   my $sftp = Rex::get_sftp();
   $sftp->write( $self->{fh}, $buf );
 }

--- a/lib/Rex/Interface/File/SSH.pm
+++ b/lib/Rex/Interface/File/SSH.pm
@@ -58,6 +58,10 @@ sub read {
 
 sub write {
   my ( $self, $buf ) = @_;
+
+  utf8::encode($buf)
+    if Rex::Config->get_write_utf8_files && utf8::is_utf8($buf);
+
   $self->{fh}->write($buf);
 }
 

--- a/lib/Rex/Interface/File/Sudo.pm
+++ b/lib/Rex/Interface/File/Sudo.pm
@@ -85,6 +85,10 @@ sub read {
 
 sub write {
   my ( $self, $buf ) = @_;
+
+  utf8::encode($buf)
+    if Rex::Config->get_write_utf8_files && utf8::is_utf8($buf);
+
   $self->{fh}->write($buf);
 }
 

--- a/t/write_utf8_files.t
+++ b/t/write_utf8_files.t
@@ -1,0 +1,69 @@
+use strict;
+use warnings;
+
+use Test::More;
+use File::Temp qw(tempfile);
+
+use Rex -base;
+use Rex::Interface::File;
+
+if ( $^O =~ m/^MSWin/ ) {
+  plan skip_all => 'No encoding tests on Windows';
+}
+else {
+  plan tests => 2;
+}
+
+subtest 'no_write_utf8_files' => sub {
+  Rex::Config->set_write_utf8_files(0);
+
+  subtest 'no utf8 pragma' => sub {
+    no utf8;
+    my $file = write_file('möp');
+    is( get_encoding($file), 'utf-8',
+      'encoding no_write_utf8_files flag, no utf8 pragma' );
+  };
+
+  subtest 'utf8 pragma' => sub {
+    use utf8;
+    my $file = write_file('möp');
+    is( get_encoding($file), 'iso-8859-1',
+      'encoding no_write_utf8_files flag, utf8 pragma' );
+  };
+};
+
+subtest 'write_utf8_files' => sub {
+  Rex::Config->set_write_utf8_files(1);
+
+  subtest 'no utf8 pragma' => sub {
+    no utf8;
+    my $file = write_file('möp');
+    is( get_encoding($file), 'utf-8',
+      'encoding write_utf8_files flag, no utf8 pragma' );
+  };
+
+  subtest 'utf8 pragma' => sub {
+    use utf8;
+    my $file = write_file('möp');
+    is( get_encoding($file), 'utf-8',
+      'encoding write_utf8_files flag, utf8 pragma' );
+  };
+};
+
+sub write_file {
+  my $content = shift;
+  my ( undef, $filename ) = tempfile( UNLINK => 1 );
+
+  my $fh = Rex::Interface::File->create();
+  $fh->open( '>', $filename );
+  $fh->write($content);
+  $fh->close;
+
+  return $filename;
+}
+
+sub get_encoding {
+  my $file     = shift;
+  my $encoding = run qq(file --brief --mime-encoding $file);
+  return $encoding;
+}


### PR DESCRIPTION
This PR is a reiteration of #1275 with a different approach.

The idea here is to check the utf8 flag of the string to be written to a file, and encode it as needed.

This "check and encode" step is controlled by the `(no_)write_utf8_files` feature flag to allow complete opt-in/opt-out choice over it.