### PR TITLE
Fix setting of waitpid blocking sleep time

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix setting custom waitpid_blocking_sleep_time
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -1069,7 +1069,8 @@ sub get_use_server_auth {
 }
 
 sub set_waitpid_blocking_sleep_time {
-  my ( $self, $waitpid_blocking_sleep_time ) = @_;
+  my $self = shift;
+  $waitpid_blocking_sleep_time = shift;
 }
 
 sub get_waitpid_blocking_sleep_time {

--- a/t/waitpid_blocking_sleep_time.t
+++ b/t/waitpid_blocking_sleep_time.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+
+use Test::More tests => 2;
+
+use Rex -base;
+
+is( Rex::Config->get_waitpid_blocking_sleep_time, 0.1, 'default is set' );
+
+Rex::Config->set_waitpid_blocking_sleep_time(1);
+is( Rex::Config->get_waitpid_blocking_sleep_time,
+  1, 'waitpid blocking sleep time is set' );


### PR DESCRIPTION
Apparently setting the `waitpid_blocking_sleep_time` was not possible due to a (scoping) bug.

This PR adds tests and a fix for that.