### PR TITLE
Fix autodie feature for local unlink commands

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Fix setting custom waitpid_blocking_sleep_time
+ - Fix autodie feature for local unlink commands
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Commands/Fs.pm
+++ b/lib/Rex/Commands/Fs.pm
@@ -182,9 +182,6 @@ sub unlink {
 
     if ( $fs->is_file($file) || $fs->is_symlink($file) ) {
       $fs->unlink($file);
-      if ( $fs->is_file($file) || $fs->is_symlink($file) ) {
-        die "Can't remove $file.";
-      }
 
       my $tmp_path = Rex::Config->get_tmp_dir;
       if ( $file !~ m/^\Q$tmp_path\E[\/\\][a-z]+\.tmp$/ ) { # skip tmp rex files

--- a/lib/Rex/Interface/Fs/Local.pm
+++ b/lib/Rex/Interface/Fs/Local.pm
@@ -95,7 +95,14 @@ sub is_file {
 
 sub unlink {
   my ( $self, @files ) = @_;
-  CORE::unlink(@files);
+  for my $file (@files) {
+    if ( CORE::unlink($file) == 0 ) {
+      die "Error unlinking file: $file" if ( Rex::Config->get_autodie );
+      return 0;
+    }
+  }
+
+  return 1;
 }
 
 sub mkdir {


### PR DESCRIPTION
This makes the unlink behavior consistent across file system interface
modules, and also makes autodie behavior consistent for all commands
that is changing the state of the file system.