### PR TITLE
Document configuration functions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Revision history for Rex
  [DOCUMENTATION]
  - Categorize file system commands based on ability to change contents
  - Clarify documentation of file system commands
+ - Document configuration methods
 
  [ENHANCEMENTS]
  - Add write_utf8_files feature flag to control encoding of files written by Rex

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -269,14 +269,6 @@ sub get_use_cache {
   return $use_cache;
 }
 
-sub get_sudo_without_locales {
-  return $sudo_without_locales;
-}
-
-sub get_sudo_without_sh {
-  return $sudo_without_sh;
-}
-
 sub set_openssh_opt {
   my ( $class, %opt ) = @_;
 
@@ -300,9 +292,17 @@ sub set_sudo_without_locales {
   $sudo_without_locales = shift;
 }
 
+sub get_sudo_without_locales {
+  return $sudo_without_locales;
+}
+
 sub set_sudo_without_sh {
   my $class = shift;
   $sudo_without_sh = shift;
+}
+
+sub get_sudo_without_sh {
+  return $sudo_without_sh;
 }
 
 sub set_executor_for {
@@ -391,9 +391,43 @@ sub set_user {
   $user = shift;
 }
 
+sub has_user {
+  my $class = shift;
+  return $user;
+}
+
+sub get_user {
+  my $class = shift;
+
+  if ( exists $ENV{REX_USER} ) {
+    return $ENV{REX_USER};
+  }
+
+  if ($user) {
+    return $user;
+  }
+
+  if ( $^O =~ m/^MSWin/ ) {
+    return getlogin;
+  }
+  else {
+    return scalar getpwuid($<);
+  }
+}
+
 sub set_password {
   my $class = shift;
   $password = shift;
+}
+
+sub get_password {
+  my $class = shift;
+
+  if ( exists $ENV{REX_PASSWORD} ) {
+    return $ENV{REX_PASSWORD};
+  }
+
+  return $password;
 }
 
 sub set_port {
@@ -401,9 +435,43 @@ sub set_port {
   $port = shift;
 }
 
+sub get_port {
+  my $class = shift;
+  my $param = {@_};
+
+  if ( exists $param->{server}
+    && exists $SSH_CONFIG_FOR{ $param->{server} }
+    && exists $SSH_CONFIG_FOR{ $param->{server} }->{port} )
+  {
+    return $SSH_CONFIG_FOR{ $param->{server} }->{port};
+  }
+
+  return $port;
+}
+
 sub set_sudo_password {
   my $class = shift;
   $sudo_password = shift;
+}
+
+sub get_sudo_password {
+  my $class = shift;
+
+  if ( exists $ENV{REX_SUDO_PASSWORD} ) {
+    return $ENV{REX_SUDO_PASSWORD};
+  }
+
+  if ($sudo_password) {
+    return $sudo_password;
+  }
+  elsif ( !defined $sudo_password ) {
+    return "";
+  }
+  else {
+    return $password;
+  }
+
+  return "";
 }
 
 sub set_source_global_profile {
@@ -434,54 +502,6 @@ sub get_max_connect_fails {
   return $max_connect_fails || 3;
 }
 
-sub has_user {
-  my $class = shift;
-  return $user;
-}
-
-sub get_user {
-  my $class = shift;
-
-  if ( exists $ENV{REX_USER} ) {
-    return $ENV{REX_USER};
-  }
-
-  if ($user) {
-    return $user;
-  }
-
-  if ( $^O =~ m/^MSWin/ ) {
-    return getlogin;
-  }
-  else {
-    return scalar getpwuid($<);
-  }
-}
-
-sub get_password {
-  my $class = shift;
-
-  if ( exists $ENV{REX_PASSWORD} ) {
-    return $ENV{REX_PASSWORD};
-  }
-
-  return $password;
-}
-
-sub get_port {
-  my $class = shift;
-  my $param = {@_};
-
-  if ( exists $param->{server}
-    && exists $SSH_CONFIG_FOR{ $param->{server} }
-    && exists $SSH_CONFIG_FOR{ $param->{server} }->{port} )
-  {
-    return $SSH_CONFIG_FOR{ $param->{server} }->{port};
-  }
-
-  return $port;
-}
-
 sub set_proxy_command {
   my $class = shift;
   $proxy_command = shift;
@@ -499,26 +519,6 @@ sub get_proxy_command {
   }
 
   return $proxy_command;
-}
-
-sub get_sudo_password {
-  my $class = shift;
-
-  if ( exists $ENV{REX_SUDO_PASSWORD} ) {
-    return $ENV{REX_SUDO_PASSWORD};
-  }
-
-  if ($sudo_password) {
-    return $sudo_password;
-  }
-  elsif ( !defined $sudo_password ) {
-    return "";
-  }
-  else {
-    return $password;
-  }
-
-  return "";
 }
 
 sub set_timeout {
@@ -547,20 +547,6 @@ sub set_password_auth {
   $password_auth = shift || 1;
 }
 
-sub set_key_auth {
-  my $class = shift;
-  $password_auth = 0;
-  $krb5_auth     = 0;
-  $key_auth      = shift || 1;
-}
-
-sub set_krb5_auth {
-  my $class = shift;
-  $password_auth = 0;
-  $key_auth      = 0;
-  $krb5_auth     = shift || 1;
-}
-
 sub get_password_auth {
   if ( exists $ENV{REX_AUTH_TYPE} && $ENV{REX_AUTH_TYPE} eq "pass" ) {
     return 1;
@@ -568,11 +554,25 @@ sub get_password_auth {
   return $password_auth;
 }
 
+sub set_key_auth {
+  my $class = shift;
+  $password_auth = 0;
+  $krb5_auth     = 0;
+  $key_auth      = shift || 1;
+}
+
 sub get_key_auth {
   if ( exists $ENV{REX_AUTH_TYPE} && $ENV{REX_AUTH_TYPE} eq "key" ) {
     return 1;
   }
   return $key_auth;
+}
+
+sub set_krb5_auth {
+  my $class = shift;
+  $password_auth = 0;
+  $key_auth      = 0;
+  $krb5_auth     = shift || 1;
 }
 
 sub get_krb5_auth {
@@ -859,6 +859,60 @@ sub get_no_tty {
   return $no_tty;
 }
 
+sub set_allow_empty_groups {
+  my ( $class, $set ) = @_;
+  if ($set) {
+    $allow_empty_groups = 1;
+  }
+  else {
+    $allow_empty_groups = 0;
+  }
+}
+
+sub get_allow_empty_groups {
+  if ($allow_empty_groups) {
+    return 1;
+  }
+
+  return 0;
+}
+
+sub set_use_server_auth {
+  my ( $class, $set ) = @_;
+  if ($set) {
+    $use_server_auth = 1;
+  }
+  else {
+    $use_server_auth = 0;
+  }
+}
+
+sub get_use_server_auth {
+  if ($use_server_auth) {
+    return 1;
+  }
+
+  return 0;
+}
+
+sub set_waitpid_blocking_sleep_time {
+  my $self = shift;
+  $waitpid_blocking_sleep_time = shift;
+}
+
+sub get_waitpid_blocking_sleep_time {
+  return $waitpid_blocking_sleep_time // 0.1;
+}
+
+sub set_write_utf8_files {
+  my $self = shift;
+  $write_utf8_files = shift;
+}
+
+sub get_write_utf8_files {
+  return $write_utf8_files;
+}
+
 =head2 register_set_handler($handler_name, $code)
 
 Register a handler that gets called by I<set>.
@@ -1030,60 +1084,6 @@ sub _parse_ssh_config {
   }
 
   return %ret;
-}
-
-sub set_allow_empty_groups {
-  my ( $class, $set ) = @_;
-  if ($set) {
-    $allow_empty_groups = 1;
-  }
-  else {
-    $allow_empty_groups = 0;
-  }
-}
-
-sub get_allow_empty_groups {
-  if ($allow_empty_groups) {
-    return 1;
-  }
-
-  return 0;
-}
-
-sub set_use_server_auth {
-  my ( $class, $set ) = @_;
-  if ($set) {
-    $use_server_auth = 1;
-  }
-  else {
-    $use_server_auth = 0;
-  }
-}
-
-sub get_use_server_auth {
-  if ($use_server_auth) {
-    return 1;
-  }
-
-  return 0;
-}
-
-sub set_waitpid_blocking_sleep_time {
-  my $self = shift;
-  $waitpid_blocking_sleep_time = shift;
-}
-
-sub get_waitpid_blocking_sleep_time {
-  return $waitpid_blocking_sleep_time // 0.1;
-}
-
-sub set_write_utf8_files {
-  my $self = shift;
-  $write_utf8_files = shift;
-}
-
-sub get_write_utf8_files {
-  return $write_utf8_files;
 }
 
 sub import {

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -6,13 +6,11 @@
 
 =head1 NAME
 
-Rex::Config - Handles the configuration.
+Rex::Config - Handles Rex configuration
 
 =head1 DESCRIPTION
 
-This module holds all configuration parameters for Rex.
-
-With this module you can specify own configuration parameters for your modules.
+This module holds all configuration parameters for Rex, and also allows you to specify your own configuration parameters for your modules.
 
 =head1 EXPORTED METHODS
 
@@ -72,6 +70,18 @@ our (
   bash   => "bash",
 );
 
+=head2 set_autodie
+
+=head2 get_autodie
+
+Sets and gets the value of the C<$autodie> configuration variable.
+
+This controls whether Rex should C<die()> if there's an error while executing L<file system commands that are supposed to change the contents|Rex::Commands::Fs#Changing-content>.
+
+Default is C<undef>.
+
+=cut
+
 sub set_autodie {
   my $class = shift;
   $autodie = shift;
@@ -80,6 +90,18 @@ sub set_autodie {
 sub get_autodie {
   return $autodie;
 }
+
+=head2 set_use_net_openssh_if_present
+
+=head2 get_use_net_openssh_if_present
+
+Sets and gets the value of the C<$use_net_openssh_if_present> configuration variable.
+
+This controls whether Rex should use L<Net::OpenSSH> for connections if that is available. 
+
+Default is C<undef>.
+
+=cut
 
 sub set_use_net_openssh_if_present {
   my $class = shift;
@@ -90,6 +112,18 @@ sub get_use_net_openssh_if_present {
   return $use_net_openssh_if_present;
 }
 
+=head2 set_use_rex_kvm_agent
+
+=head2 get_use_rex_kvm_agent
+
+Sets and gets the value of the C<$use_rex_kvm_agent> configuration variable.
+
+This controls whether Rex should setup and use a serial device for the experimental L<Rex KVM agent|https://github.com/RexOps/rex-kvm-agent> for managed VMs.
+
+Default is C<undef>.
+
+=cut
+
 sub set_use_rex_kvm_agent {
   my $class = shift;
   $use_rex_kvm_agent = shift;
@@ -98,6 +132,18 @@ sub set_use_rex_kvm_agent {
 sub get_use_rex_kvm_agent {
   return $use_rex_kvm_agent;
 }
+
+=head2 set_use_template_ng
+
+=head2 get_use_template_ng
+
+Sets and gets the value of the C<$use_template_ng> configuration variable.
+
+This controls whether Rex should use L<Rex::Template::NG> to render templates.
+
+Default is C<undef>.
+
+=cut
 
 sub set_use_template_ng {
   my $class = shift;
@@ -108,6 +154,18 @@ sub get_use_template_ng {
   return $use_template_ng;
 }
 
+=head2 set_set_no_append
+
+=head2 get_set_no_append
+
+Sets and gets the value of the C<$set_no_append> configuration variable.
+
+This controls whether Rex should overwrite or append values of configuration options when using the L<set|Rex::Commands#set> command.
+
+Default is C<undef>.
+
+=cut
+
 sub set_set_no_append {
   my $class = shift;
   $set_no_append = shift;
@@ -116,6 +174,18 @@ sub set_set_no_append {
 sub get_set_no_append {
   return $set_no_append;
 }
+
+=head2 set_check_service_exists
+
+=head2 get_check_service_exists
+
+Sets and gets the value of the C<$check_service_exists> configuration variable.
+
+This controls whether Rex should C<die()> early if it is asked to manage a service that doesn't exist.
+
+Default is C<undef>.
+
+=cut
 
 sub set_check_service_exists {
   my $class = shift;
@@ -126,6 +196,18 @@ sub get_check_service_exists {
   return $check_service_exists;
 }
 
+=head2 set_register_cmdb_template
+
+=head2 get_register_cmdb_template
+
+Sets and gets the value of the C<$register_cmdb_template> configuration variable.
+
+This controls whether Rex should make L<CMDB|Rex::CMDB> data available to be used in templates as variables.
+
+Default is C<undef>.
+
+=cut
+
 sub set_register_cmdb_template {
   my $class = shift;
   $register_cmdb_template = shift;
@@ -134,6 +216,18 @@ sub set_register_cmdb_template {
 sub get_register_cmdb_template {
   return $register_cmdb_template;
 }
+
+=head2 set_fallback_auth
+
+=head2 get_fallback_auth
+
+Sets and gets the value of the C<$fallback_auth> configuration variable.
+
+This can be used to define an array of hash references, each of them containing L<authentication details|Rex::Commands#auth> to be tried during connection attempts when the directly specified ones fail.
+
+Default is C<undef>.
+
+=cut
 
 sub set_fallback_auth {
   my $class = shift;
@@ -144,6 +238,18 @@ sub get_fallback_auth {
   return $fallback_auth;
 }
 
+=head2 set_task_call_by_method
+
+=head2 get_task_call_by_method
+
+Sets and gets the value of the C<$task_call_by_method> configuration variable.
+
+This controls whether calling tasks as a method is allowed or not.
+
+Default is C<undef>.
+
+=cut
+
 sub set_task_call_by_method {
   my $class = shift;
   $task_call_by_method = shift;
@@ -152,6 +258,18 @@ sub set_task_call_by_method {
 sub get_task_call_by_method {
   return $task_call_by_method;
 }
+
+=head2 set_disable_taskname_warning
+
+=head2 get_disable_taskname_warning
+
+Sets and gets the value of the C<$disable_taskname_warning> configuration variable.
+
+This controls whether Rex should show or suppress the warning message about task names that can not be used as Perl identifiers.
+
+Default is C<undef>.
+
+=cut
 
 sub set_disable_taskname_warning {
   my $class = shift;
@@ -162,6 +280,18 @@ sub get_disable_taskname_warning {
   return $disable_taskname_warning;
 }
 
+=head2 set_task_chaining_cmdline_args
+
+=head2 get_task_chaining_cmdline_args
+
+Sets and gets the value of the C<$task_chaining_cmdline_args> configuration variable.
+
+This controls whether Rex should parse task arguments on the command line per task, or should pass all arguments to all tasks.
+
+Default is C<undef>.
+
+=cut
+
 sub set_task_chaining_cmdline_args {
   my $class = shift;
   $task_chaining_cmdline_args = shift;
@@ -170,6 +300,18 @@ sub set_task_chaining_cmdline_args {
 sub get_task_chaining_cmdline_args {
   return $task_chaining_cmdline_args;
 }
+
+=head2 set_verbose_run
+
+=head2 get_verbose_run
+
+Sets and gets the value of the C<$verbose_run> configuration variable.
+
+This controls whether Rex should show verbose output about executed L<run|Rex::Commands::Run#run> commands. This means an error message if the command is not found, a warning message if the exit code indicates an error, and an informational message upon success.
+
+Default is C<undef>.
+
+=cut
 
 sub set_verbose_run {
   my $class = shift;
@@ -180,6 +322,18 @@ sub get_verbose_run {
   return $verbose_run;
 }
 
+=head2 set_exec_autodie
+
+=head2 get_exec_autodie
+
+Sets and gets the value of the C<$exec_autodie> configuration variable.
+
+This controls whether Rex should C<die()> or not when the exit code of executed L<run|Rex::Commands::Run#run> command indicate an error.
+
+Default is C<undef>.
+
+=cut
+
 sub set_exec_autodie {
   my $class = shift;
   $exec_autodie = shift;
@@ -188,6 +342,18 @@ sub set_exec_autodie {
 sub get_exec_autodie {
   return $exec_autodie;
 }
+
+=head2 set_no_path_cleanup
+
+=head2 get_no_path_cleanup
+
+Sets and gets the value of the C<$no_path_cleanup> configuration variable.
+
+This controls whether Rex should clean up the C<$PATH> before executing a L<run|Rex::Commands::Run#run> command.
+
+Default is C<undef>.
+
+=cut
 
 sub set_no_path_cleanup {
   my $class = shift;
@@ -198,6 +364,18 @@ sub get_no_path_cleanup {
   return $no_path_cleanup;
 }
 
+=head2 set_source_profile
+
+=head2 get_source_profile
+
+Sets and gets the value of the C<$source_profile> configuration variable.
+
+This controls whether Rex should source shell-specific profile files before executing commands.
+
+Default is C<undef>.
+
+=cut
+
 sub set_source_profile {
   my $class = shift;
   $source_profile = shift;
@@ -206,6 +384,18 @@ sub set_source_profile {
 sub get_source_profile {
   return $source_profile;
 }
+
+=head2 set_say_format
+
+=head2 get_say_format
+
+Sets and gets the value of the C<$say_format> configuration variable.
+
+This controls the output format of the built-in C<say> command (see also L<sayformat|Rex::Commands#sayformat>).
+
+Default is C<undef>.
+
+=cut
 
 sub set_say_format {
   my $class = shift;
@@ -216,6 +406,18 @@ sub get_say_format {
   return $say_format;
 }
 
+=head2 set_do_reporting
+
+=head2 get_do_reporting
+
+Sets and gets the value of the C<$do_reporting> configuration variable.
+
+This controls whether Rex should do reporting on executed resources where it is supported. This only affects the data structures returned internally.
+
+Default is C<undef>.
+
+=cut
+
 sub set_do_reporting {
   my $class = shift;
   $do_reporting = shift;
@@ -224,6 +426,18 @@ sub set_do_reporting {
 sub get_do_reporting {
   return $do_reporting;
 }
+
+=head2 set_report_type
+
+=head2 get_report_type
+
+Sets and gets the value of the C<$report_type> configuration variable, which can also be controlled via the C<REX_REPORT_TYPE> environment variable.
+
+This selects the reporting type (format) Rex should use, e.g. C<'YAML'>.
+
+Default is C<undef>.
+
+=cut
 
 sub set_report_type {
   my $class = shift;
@@ -238,6 +452,20 @@ sub get_report_type {
   return $report_type;
 }
 
+=head2 set_sleep_hack
+
+=head2 get_sleep_hack
+
+Sets and gets the value of the C<$sleep_hack> configuration variable.
+
+This controls whether Rex should use or not an extra 10 ns long sleep after executed commands.
+
+This might help working around an issue when Rex runs inside a KVM virtualized host and L<Net::SSH2>/L<libssh2|https://www.libssh2.org> is used to connect to another VM on the same hardware.
+
+Default is C<undef>.
+
+=cut
+
 sub set_sleep_hack {
   my $class = shift;
   $use_sleep_hack = shift;
@@ -246,6 +474,18 @@ sub set_sleep_hack {
 sub get_sleep_hack {
   return $use_sleep_hack;
 }
+
+=head2 set_cache_type
+
+=head2 get_cache_type
+
+Sets and gets the value of the C<$cache_type> configuration variable, which can also be controlled via the C<REX_CACHE_TYPE> environment variable.
+
+This selects the cache type Rex should use, e.g. C<'YAML'>.
+
+Default is C<'Base'>.
+
+=cut
 
 sub set_cache_type {
   my $class = shift;
@@ -260,6 +500,18 @@ sub get_cache_type {
   return $cache_type || "Base";
 }
 
+=head2 set_use_cache
+
+=head2 get_use_cache
+
+Sets and gets the value of the C<$use_cache> configuration variable.
+
+This controls whether Rex should use caching or not for runtime information like CMDB contents, hardware and operating system information, or the shell type that is being used to execute commands on the managed endpoint.
+
+Default is C<undef>.
+
+=cut
+
 sub set_use_cache {
   my $class = shift;
   $use_cache = shift;
@@ -268,6 +520,18 @@ sub set_use_cache {
 sub get_use_cache {
   return $use_cache;
 }
+
+=head2 set_openssh_opt
+
+=head2 get_openssh_opt
+
+Sets and gets the value of the C<$openssh_opt> configuration variable.
+
+This sets the hash containing OpenSSH options Rex should use when using L<Net::OpenSSH> for SSH connections.
+
+Default is C<undef>.
+
+=cut
 
 sub set_openssh_opt {
   my ( $class, %opt ) = @_;
@@ -287,6 +551,20 @@ sub get_openssh_opt {
   return %openssh_opt;
 }
 
+=head2 set_sudo_without_locales
+
+=head2 get_sudo_without_locales
+
+Sets and gets the value of the C<$sudo_without_locales> configuration variable.
+
+This controls whether Rex should execute L<sudo|Rex::Commands::Run#sudo> commands without setting any locales via the C<LC_ALL> environment variable.
+
+B<Warning:> if the locale is something else than C<C> or C<en_US>, then things will break!
+
+Default is C<undef>.
+
+=cut
+
 sub set_sudo_without_locales {
   my $class = shift;
   $sudo_without_locales = shift;
@@ -296,6 +574,18 @@ sub get_sudo_without_locales {
   return $sudo_without_locales;
 }
 
+=head2 set_sudo_without_sh
+
+=head2 get_sudo_without_sh
+
+Sets and gets the value of the C<$sudo_without_sh> configuration variable.
+
+This controls whether Rex should run L<sudo|Rex::Commands::Run#sudo> commands without C<sh>. This might break things.
+
+Default is C<undef>.
+
+=cut
+
 sub set_sudo_without_sh {
   my $class = shift;
   $sudo_without_sh = shift;
@@ -304,6 +594,25 @@ sub set_sudo_without_sh {
 sub get_sudo_without_sh {
   return $sudo_without_sh;
 }
+
+=head2 set_executor_for
+
+=head2 get_executor_for
+
+Sets and gets the keys and values of the C<%executor_for> configuration variable.
+
+This sets the executor for a given file type when using the C<upload_and_run()> function of L<Rex::Helper::Run> module.
+
+Default is:
+
+ (
+   perl   => 'perl',
+   python => 'python',
+   ruby   => 'ruby',
+   bash   => 'bash',
+ )
+
+=cut
 
 sub set_executor_for {
   my $class = shift;
@@ -319,6 +628,26 @@ sub get_executor_for {
 
   return $executor_for{$e};
 }
+
+=head2 set_tmp_dir
+
+=head2 get_tmp_dir
+
+Sets and gets the value of the C<$tmp_dir> configuration variable.
+
+This controls which directory Rex should use for temporary files.
+
+Default is determined by the following logic:
+
+=over 4
+
+=item * try to use what C<< File::Spec->tmpdir >> would return on the managed endpoint
+
+=item * fall back to C<'/tmp'>
+
+=back
+
+=cut
 
 sub set_tmp_dir {
   my ( $class, $dir ) = @_;
@@ -370,6 +699,29 @@ sub get_tmp_dir {
   return $tmp_dir;
 }
 
+=head2 set_path
+
+=head2 get_path
+
+Sets and gets the value of the C<$path> configuration variable.
+
+This controls which C<PATH> Rex should use when executing L<run|Rex::Commands::Run#run> commands. The value should be set as an array reference, and will be dereferenced as such before returned by C<get_path>.
+
+Default is
+
+ qw(
+   /bin
+   /sbin
+   /usr/bin
+   /usr/sbin
+   /usr/local/bin
+   /usr/local/sbin
+   /usr/pkg/bin
+   /usr/pkg/sbin
+ )
+
+=cut
+
 sub set_path {
   my $class = shift;
   $path = shift;
@@ -385,6 +737,28 @@ sub get_path {
   }
   return @{$path};
 }
+
+=head2 set_user
+
+=head2 get_user
+
+Sets and gets the value of the C<$user> configuration variable, which also can be set via the C<REX_USER> environment variable.
+
+This controls which L<user|Rex::Commands#user> Rex should use for authentication.
+
+Default is determined by the following logic:
+
+=over 4
+
+=item * value of C<REX_USER> environment variable
+
+=item * user set by L<user|Rex::Commands#user> command
+
+=item * user running Rex
+
+=back
+
+=cut
 
 sub set_user {
   my $class = shift;
@@ -415,6 +789,18 @@ sub get_user {
   }
 }
 
+=head2 set_password
+
+=head2 get_password
+
+Sets and gets the value of the C<$password> configuration variable, which also can be set via the C<REX_PASSWORD> environment variable.
+
+This controls what L<password|Rex::Commands#password> Rex should use for authentication or as passphrase when using private keys.
+
+Default is C<undef>.
+
+=cut
+
 sub set_password {
   my $class = shift;
   $password = shift;
@@ -429,6 +815,20 @@ sub get_password {
 
   return $password;
 }
+
+=head2 set_port
+
+=head2 get_port
+
+Sets and gets the value of the C<$port> configuration variable.
+
+This controls which L<port|Rex::Commands#port> Rex should connect to.
+
+C<get_port> accepts an optional C<< server => $server >> argument to return the C<port> setting for the given C<$server> as optionally set in group files.
+
+Default is C<undef>.
+
+=cut
 
 sub set_port {
   my $class = shift;
@@ -448,6 +848,30 @@ sub get_port {
 
   return $port;
 }
+
+=head2 set_sudo_password
+
+=head2 get_sudo_password
+
+Sets and gets the value of the C<$sudo_password> configuration variable, which can also be controlled via the C<REX_SUDO_PASSWORD> environment variable.
+
+This controls what L<sudo password|Rex::Commands#sudo_password> Rex should use.
+
+Default is determined by the following logic:
+
+=over 4
+
+=item * value of C<REX_SUDO_PASSWORD> environment variable
+
+=item * sudo password set by the L<sudo_password|Rex::Command#sudo_password> command
+
+=item * password set by the L<password|Rex::Command#password> command
+
+=item * empty string (C<''>)
+
+=back
+
+=cut
 
 sub set_sudo_password {
   my $class = shift;
@@ -474,6 +898,18 @@ sub get_sudo_password {
   return "";
 }
 
+=head2 set_source_global_profile
+
+=head2 get_source_global_profile
+
+Sets and gets the value of the C<$source_global_profile> configuration variable.
+
+This controls whether Rex should source C</etc/profile> before executing commands.
+
+Default is C<undef>.
+
+=cut
+
 sub set_source_global_profile {
   my $class = shift;
   $source_global_profile = shift;
@@ -482,6 +918,20 @@ sub set_source_global_profile {
 sub get_source_global_profile {
   return $source_global_profile;
 }
+
+=head2 set_max_connect_fails
+
+=head2 get_max_connect_fails
+
+Sets and gets the value of the C<$max_connect_fails> configuration variable.
+
+This controls how many times Rex should retry to connect before giving up.
+
+C<get_max_connect_fails> accepts an optional C<< server => $server >> argument to C<connectionattempts> setting for the given C<$server> as optionally set in group files.
+
+Default is C<undef>.
+
+=cut
 
 sub set_max_connect_fails {
   my $class = shift;
@@ -502,6 +952,20 @@ sub get_max_connect_fails {
   return $max_connect_fails || 3;
 }
 
+=head2 set_proxy_command
+
+=head2 get_proxy_command
+
+Sets and gets the value of the C<$proxy_command> configuration variable.
+
+This controls the SSH ProxyCommand Rex should set for connections when L<Net::OpenSSH> is used.
+
+C<get_proxy_command> accepts an optional C<< server => $server >> argument to return the C<proxycommand> setting for the given C<$server> as optionally set in group files.
+
+Default is C<undef>.
+
+=cut
+
 sub set_proxy_command {
   my $class = shift;
   $proxy_command = shift;
@@ -520,6 +984,20 @@ sub get_proxy_command {
 
   return $proxy_command;
 }
+
+=head2 set_timeout
+
+=head2 get_timeout
+
+Sets and gets the value of the C<$timeout> configuration variable.
+
+This controls how many seconds Rex should wait for connections to succeed when using SSH or L<Rex::Commands::Rsync>.
+
+C<get_timeout> accepts an optional C<< server => $server >> argument to return the C<connecttimeout> setting for the given C<$server> as optionally set in group files.
+
+Default is C<undef>.
+
+=cut
 
 sub set_timeout {
   my $class = shift;
@@ -540,6 +1018,18 @@ sub get_timeout {
   return $timeout || 2;
 }
 
+=head2 set_password_auth
+
+=head2 get_password_auth
+
+Sets and gets the value of the C<$password_auth> configuration variable, which can also be set by setting the C<REX_AUTH_TYPE> environment variable to C<pass>.
+
+This controls whether Rex should use the L<password authentication|Rex::Commands#pass_auth> method.
+
+Default is C<undef>.
+
+=cut
+
 sub set_password_auth {
   my $class = shift;
   $key_auth      = 0;
@@ -553,6 +1043,18 @@ sub get_password_auth {
   }
   return $password_auth;
 }
+
+=head2 set_key_auth
+
+=head2 get_key_auth
+
+Sets and gets the value of the C<$key_auth> configuration variable, which can also be set by setting the C<REX_AUTH_TYPE> environment variable to C<key>.
+
+This controls whether Rex should use the L<key authentication|Rex::Commands#key_auth> method.
+
+Default is C<undef>.
+
+=cut
 
 sub set_key_auth {
   my $class = shift;
@@ -568,6 +1070,18 @@ sub get_key_auth {
   return $key_auth;
 }
 
+=head2 set_krb5_auth
+
+=head2 get_krb5_auth
+
+Sets and gets the value of the C<$krb5_auth> configuration variable, which can also be set by setting the C<REX_AUTH_TYPE> environment variable to C<krb5>.
+
+This controls whether Rex should use the L<Kerberos 5|Rex::Commands#krb5_auth> authentication method.
+
+Default is C<undef>.
+
+=cut
+
 sub set_krb5_auth {
   my $class = shift;
   $password_auth = 0;
@@ -581,6 +1095,18 @@ sub get_krb5_auth {
   }
   return $krb5_auth;
 }
+
+=head2 set_public_key
+
+=head2 get_public_key
+
+Sets and gets the value of the C<$public_key> configuration variable.
+
+This controls which L<public key|Rex::Commands#public_key> Rex should use when using L<Net::SSH2> for connections.
+
+Default is C<undef>.
+
+=cut
 
 sub set_public_key {
   my $class = shift;
@@ -600,6 +1126,18 @@ sub get_public_key {
   return;
 }
 
+=head2 set_private_key
+
+=head2 get_private_key
+
+Sets and gets the value of the C<$private_key> configuration variable.
+
+This controls which L<private key|Rex::Commands#private_key> Rex should use with L<Rex::Commands::Rsync> or when using L<Net::SSH2> for connections.
+
+Default is C<undef>.
+
+=cut
+
 sub set_private_key {
   my $class = shift;
   $private_key = shift;
@@ -618,6 +1156,18 @@ sub get_private_key {
   return;
 }
 
+=head2 set_parallelism
+
+=head2 get_parallelism
+
+Sets and gets the value of the C<$parallelism> configuration variable.
+
+This controls how many hosts Rex should connect to in L<parallel|Rex::Commands#parallelism>.
+
+Default is C<1>.
+
+=cut
+
 sub set_parallelism {
   my $class = shift;
   $parallelism = $_[0];
@@ -627,6 +1177,18 @@ sub get_parallelism {
   my $class = shift;
   return $parallelism || 1;
 }
+
+=head2 set_log_filename
+
+=head2 get_log_filename
+
+Sets and gets the value of the C<$log_filename> configuration variable.
+
+This controls which file Rex should use for L<logging|Rex::Commands#logging>.
+
+Default is C<undef>.
+
+=cut
 
 sub set_log_filename {
   my $class = shift;
@@ -638,6 +1200,18 @@ sub get_log_filename {
   return $log_filename;
 }
 
+=head2 set_log_facility
+
+=head2 get_log_facility
+
+Sets and gets the value of the C<$log_facility> configuration variable.
+
+This controls which log facility Rex should use when L<logging|Rex::Commands#logging> to syslog.
+
+Default is C<'local0'>.
+
+=cut
+
 sub set_log_facility {
   my $class = shift;
   $log_facility = shift;
@@ -647,6 +1221,18 @@ sub get_log_facility {
   my $class = shift;
   return $log_facility || "local0";
 }
+
+=head2 set_environment
+
+=head2 get_environment
+
+Sets and gets the value of the C<$environment> configuration variable.
+
+This controls which L<environment|Rex::Commands#environment> Rex should use.
+
+Default is C<''>.
+
+=cut
 
 sub set_environment {
   my ( $class, $env ) = @_;
@@ -778,6 +1364,18 @@ sub get_ca_key {
   return $ca_key || "";
 }
 
+=head2 set_distributor
+
+=head2 get_distributor
+
+Sets and gets the value of the C<$distributor> configuration variable.
+
+This controls which method Rex should use for distributing tasks for parallel execution.
+
+Default is C<'Base'>.
+
+=cut
+
 sub set_distributor {
   my $class = shift;
   $distributor = shift;
@@ -787,6 +1385,26 @@ sub get_distributor {
   my $class = shift;
   return $distributor || "Base";
 }
+
+=head2 set_template_function
+
+=head2 get_template_function
+
+Sets and gets the value of the C<$template_function> configuration variable.
+
+This controls the function to be used for rendering L<templates|Rex::Commands::File#template>. The value should be a subroutine reference that will be called with passing two scalar references as positional arguments: first is template content, second is template variables.
+
+Default is determined by the following logic:
+
+=over 4
+
+=item * if L<Rex::Template::NG> is loadable and L<use_template_ng|Rex::Config#get_use_template_ng> is true, use that
+
+=item * fall back to L<Rex::Template> otherwise
+
+=back
+
+=cut
 
 sub set_template_function {
   my $class = shift;
@@ -850,6 +1468,18 @@ sub get_template_function {
   };
 }
 
+=head2 set_no_tty
+
+=head2 get_no_tty
+
+Sets and gets the value of the C<$no_tty> configuration variable.
+
+This controls whether Rex should request a terminal when using L<Net::SSH2> or allocate a pseudo-tty for the remote process when using L<Net::OpenSSH>.
+
+Default is C<undef>.
+
+=cut
+
 sub set_no_tty {
   shift;
   $no_tty = shift;
@@ -858,6 +1488,18 @@ sub set_no_tty {
 sub get_no_tty {
   return $no_tty;
 }
+
+=head2 set_allow_empty_groups
+
+=head2 get_allow_empty_groups
+
+Sets and gets the value of the C<$allow_empty_groups> configuration variable.
+
+This controls whether Rex should allow empty L<groups of hosts|Rex::Commands#group> or not.
+
+Default is C<0>.
+
+=cut
 
 sub set_allow_empty_groups {
   my ( $class, $set ) = @_;
@@ -877,6 +1519,18 @@ sub get_allow_empty_groups {
   return 0;
 }
 
+=head2 set_use_server_auth
+
+=head2 get_use_server_auth
+
+Sets and gets the value of the C<$use_server_auth> configuration variable.
+
+This controls whether Rex should use server-specific authentication information from group files.
+
+Default is C<0>.
+
+=cut
+
 sub set_use_server_auth {
   my ( $class, $set ) = @_;
   if ($set) {
@@ -895,6 +1549,18 @@ sub get_use_server_auth {
   return 0;
 }
 
+=head2 set_waitpid_blocking_sleep_time
+
+=head2 get_waitpid_blocking_sleep_time
+
+Sets and gets the value of the C<$waitpid_blocking_sleep_time> configuration variable.
+
+This controls how many seconds Rex should sleep between checking forks.
+
+Default is C<0.1>.
+
+=cut
+
 sub set_waitpid_blocking_sleep_time {
   my $self = shift;
   $waitpid_blocking_sleep_time = shift;
@@ -903,6 +1569,18 @@ sub set_waitpid_blocking_sleep_time {
 sub get_waitpid_blocking_sleep_time {
   return $waitpid_blocking_sleep_time // 0.1;
 }
+
+=head2 set_write_utf8_files
+
+=head2 get_write_utf8_files
+
+Sets and gets the value of the C<$write_utf8_files> configuration variable.
+
+This controls whether Rex should force C<UTF-8> encoding when writing files.
+
+Default is C<undef>.
+
+=cut
 
 sub set_write_utf8_files {
   my $self = shift;
@@ -984,7 +1662,7 @@ sub get_all {
 
 =head2 register_config_handler($topic, $code)
 
-With this function it is possible to register own sections in the users config file ($HOME/.rex/config.yml).
+With this function it is possible to register own sections in the users config file (C<$HOME/.rex/config.yml>).
 
 Example:
 


### PR DESCRIPTION
This PR aims to document all configuration options supported by Rex as codified in `Rex::Config`.

I'm publishing this ongoing work early as a draft PR to allow others to proofread my descriptions and possibly to get help from others in this effort.

Most of the POD has been autogenerated in a way that should be easier to fill out as a human on one hand, and makes the POD coverage tests of `Devel::Cover` happy on the other.

In the short time I already worked on this, I already found this to be a good exercise to check for validity of those options and to spot potential bugs and improvement possibilities.