### PR TITLE
Fix distributor setting when versioned feature flag is active

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,8 @@ Revision history for Rex
  [MINOR]
 
  [NEW FEATURES]
+ - Add new configuration option to control attaching default authentication
+ info to tasks
 
  [REVISION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Fix warning about redundant arguments when using sync with key
  authentication
+ - Fix setting distributor when versioned feature flags are active
 
  [DOCUMENTATION]
  - Clarify sudo usage for multiple commands

--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -757,7 +757,7 @@ sub import {
       # remove default task auth
       if ( $add =~ m/^\d+\.\d+$/ && $add >= 0.31 ) {
         Rex::Logger::debug("activating featureset >= 0.31");
-        Rex::TaskList->create()->set_default_auth(0);
+        Rex::Config->set_default_auth(0);
         $found_feature = 1;
       }
 

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -60,6 +60,7 @@ our (
   $use_template_ng,             $use_rex_kvm_agent,
   $autodie,                     $task_chaining_cmdline_args,
   $waitpid_blocking_sleep_time, $write_utf8_files,
+  $default_auth,
 );
 
 # some defaults
@@ -1589,6 +1590,27 @@ sub set_write_utf8_files {
 
 sub get_write_utf8_files {
   return $write_utf8_files;
+}
+
+=head2 set_default_auth
+
+=head2 get_default_auth
+
+Sets and gets the value of the C<$default_auth> configuration variable.
+
+This controls whether Rex should attach default authentication info to tasks.
+
+Default is C<1>.
+
+=cut
+
+sub set_default_auth {
+  my $self = shift;
+  $default_auth = shift;
+}
+
+sub get_default_auth {
+  return $default_auth // 1;
 }
 
 =head2 register_set_handler($handler_name, $code)

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -35,7 +35,7 @@ sub new {
   bless( $self, $proto );
 
   $self->{IN_TRANSACTION} = 0;
-  $self->{DEFAULT_AUTH}   = 1;
+  $self->{DEFAULT_AUTH}   = Rex::Config->get_default_auth();
   $self->{tasks}          = {};
 
   return $self;

--- a/t/group.t
+++ b/t/group.t
@@ -4,6 +4,7 @@ use warnings;
 use Test::More tests => 95;
 
 use Rex -feature => '0.31';
+use Rex::Group;
 
 delete $ENV{REX_USER};
 


### PR DESCRIPTION
This PR converts the default_auth setting into a first-class configuration option, so the `0.31` feature flag can be converted to use it, instead of instantiating a TaskList object early.

This makes the versioned feature flags to behave consistently too (in other words, they are just loading modules and/or setting configuration options after this change).