### PR TITLE
Support on_change option for file command with `ensure => 'directory'`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ Revision history for Rex
  - Clarify sudo usage for multiple commands
  - Clarify task hooks documentation
  - Clarify usage and purpose of configuration methods
+ - Clarify mkdir usage
 
  [ENHANCEMENTS]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ Revision history for Rex
  - Clarify mkdir usage
 
  [ENHANCEMENTS]
+ - Add on_change option for mkdir
 
  [MAJOR]
 

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -623,7 +623,7 @@ sub file {
         $dir_option{mode} = $option->{mode};
       }
 
-      Rex::Commands::Fs::mkdir( $file, %dir_option );
+      Rex::Commands::Fs::mkdir( $file, %dir_option, on_change => $on_change );
     }
   }
 

--- a/lib/Rex/Commands/Fs.pm
+++ b/lib/Rex/Commands/Fs.pm
@@ -245,6 +245,18 @@ sub rmdir {
 
 This function will create a new directory.
 
+The following options are supported:
+
+=over 4
+
+=item * owner
+
+=item * group
+
+=item * mode
+
+=back
+
 With Rex-0.45 and newer, please use the L<file|Rex::Commands::File#file> resource instead.
 
  task "prepare", sub {
@@ -254,6 +266,8 @@ With Rex-0.45 and newer, please use the L<file|Rex::Commands::File#file> resourc
      group  => "root",
      mode   => 1777;
  };
+
+Direct usage:
  
  task "mkdir", "server01", sub {
    mkdir "/tmp";

--- a/lib/Rex/Commands/Fs.pm
+++ b/lib/Rex/Commands/Fs.pm
@@ -255,6 +255,8 @@ The following options are supported:
 
 =item * mode
 
+=item * on_change
+
 =back
 
 With Rex-0.45 and newer, please use the L<file|Rex::Commands::File#file> resource instead.
@@ -286,6 +288,8 @@ sub mkdir {
   $dir = resolv_path($dir);
 
   my $options = {@_};
+
+  $options->{on_change} //= sub { };
 
   Rex::get_current_connection()->{reporter}
     ->report_resource_start( type => "mkdir", name => $dir );
@@ -386,6 +390,9 @@ sub mkdir {
 
   if ( $changed == 0 ) {
     Rex::get_current_connection()->{reporter}->report( changed => 0, );
+  }
+  else {
+    $options->{on_change}->($dir);
   }
 
   Rex::get_current_connection()->{reporter}

--- a/t/file.t
+++ b/t/file.t
@@ -4,7 +4,7 @@ use warnings;
 use Cwd 'getcwd';
 my $cwd = getcwd;
 
-use Test::More tests => 55;
+use Test::More tests => 57;
 
 use Rex::Commands::File;
 use Rex::Commands::Fs;
@@ -314,6 +314,17 @@ unlink "$tmp_dir/multiline-$$.txt";
 
 file "$tmp_dir/test.d-$$", ensure => "directory";
 
+ok( -d "$tmp_dir/test.d-$$", "created directory with file()" );
+rmdir "$tmp_dir/test.d-$$";
+
+$changed = 0;
+file "$tmp_dir/test.d-$$",
+  ensure    => "directory",
+  on_change => sub {
+  $changed = 1;
+  };
+
+ok( $changed,                "on_change hook with directory" );
 ok( -d "$tmp_dir/test.d-$$", "created directory with file()" );
 rmdir "$tmp_dir/test.d-$$";
 


### PR DESCRIPTION
This PR adds an on_change option for the underlying `mkdir` command when the file command is executed with `ensure => 'directory'`. Also add documentation for preexisting `mkdir` options.