### PR TITLE
fix redundant argument warning

### DIFF
--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -235,10 +235,9 @@ sub sync {
   else {
     if ( $auth_type eq "key" ) {
       $cmd = sprintf( $cmd,
-        'ssh -i '
+            'ssh -i '
           . $server->get_private_key
-          . " -o StrictHostKeyChecking=no -p " . "$port",
-        $port );
+          . " -o StrictHostKeyChecking=no -p $port" );
     }
     else {
       $cmd = sprintf( $cmd, 'ssh -o StrictHostKeyChecking=no -p ' . "$port" );


### PR DESCRIPTION
rsync reported a redundant argument when using ssh with a key. This patch is similar to #1237 and removes the second, unnecessary port argument.