### PR TITLE
allow sudo to preserve permissions with rsync

### DIFF
--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -162,6 +162,7 @@ sub sync {
 
   if (Rex::is_sudo) {
     push @rsync_cmd, "--rsync-path='sudo rsync'";
+    unshift @rsync_cmd, 'sudo';
   }
 
   $cmd = join( " ", @rsync_cmd );


### PR DESCRIPTION
This simple patch attempts to correct a problem with rsync that I was having. rysnc was not retaining file ownership even with the --archive option.

I'm not sure if this patch is the best approach but it does work.