### PR TITLE
Add in pkg globbing support and add it for FreeBSD.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ Revision history for Rex
 
  [ENHANCEMENTS]
  - Add on_change option for mkdir
+ - Support package globs on FreeBSD
 
  [MAJOR]
 
@@ -24,6 +25,7 @@ Revision history for Rex
  [NEW FEATURES]
  - Add new configuration option to control attaching default authentication
  info to tasks
+ - Initial support for package globs
 
  [REVISION]
 

--- a/lib/Rex/Pkg/FreeBSD.pm
+++ b/lib/Rex/Pkg/FreeBSD.pm
@@ -15,6 +15,7 @@ use Rex::Helper::Run;
 use Rex::Commands::File;
 use Rex::Pkg::Base;
 use base qw(Rex::Pkg::Base);
+use Net::OpenSSH::ShellQuoter;
 
 sub new {
   my $that  = shift;
@@ -31,8 +32,10 @@ sub new {
 
   $self->{commands} = {
     install           => 'pkg install -q -y %s',
+    install_glob      => 'pkg install -q -y -g %s',
     install_version   => 'pkg install -q -y %s',
     remove            => 'pkg remove -q -y %s',
+    remove_glob       => 'pkg remove -q -y -g %s',
     query             => 'pkg info',
     update_package_db => 'pkg update -q -f',
 
@@ -56,10 +59,14 @@ sub bulk_install {
 sub remove {
   my ( $self, $pkg ) = @_;
 
-  my ($pkg_found) = grep { $_->{"name"} eq "$pkg" } $self->get_installed();
-  my $pkg_version = $pkg_found->{"version"};
+  my $pkg_version = '';
 
-  return $self->SUPER::remove("$pkg-$pkg_version");
+  if ( $pkg !~ /\*/ ) {
+    my ($pkg_found) = grep { $_->{"name"} eq "$pkg" } $self->get_installed();
+    $pkg_version = '-' . $pkg_found->{"version"};
+  }
+
+  return $self->SUPER::remove("$pkg$pkg_version");
 }
 
 sub is_installed {
@@ -69,9 +76,23 @@ sub is_installed {
   Rex::Logger::debug(
     "Checking if $pkg" . ( $version ? "-$version" : "" ) . " is installed" );
 
+  # only need -g if pkg is a glob
+  my $extra_args = '';
+  if ( $pkg =~ /\*/ ) {
+
+    # quote the pkg glob so it will work
+    my $exec   = Rex::Interface::Exec->create;
+    my $quoter = Net::OpenSSH::ShellQuoter->quoter( $exec->shell->name );
+    $pkg        = $quoter->quote($pkg);
+    $extra_args = $extra_args . ' -g ';
+  }
+
   # pkg info -e allow get quick answer about is pkg installed or not.
   my $command =
-    $self->{commands}->{query} . " -e $pkg" . ( $version ? "-$version" : "" );
+      $self->{commands}->{query}
+    . $extra_args
+    . " -e $pkg"
+    . ( $version ? "-$version" : "" );
   i_run $command, fail_ok => 1;
 
   if ( $? != 0 ) {


### PR DESCRIPTION
While apt will do this automatically, pkg does not. Requires appending -g.

This adds in support for checking if * is passed and then if it is it checks that OS's module to see if there is a specific glob add/remove command and uses that.

This does appear to require the OS support module also include the methods remove and is_installed exist with glob support as well, at least in the case of FreeBSD.

The use case for this is basically installing like all of php72-* or the like when installing a new web environment instead of having to list each one you want to install.
