### PR TITLE
ensure before/after hooks work in Rexfile with "packaged" task modules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Revision history for Rex
  authentication
  - Fix setting distributor when versioned feature flags are active
  - Remove default host of test tasks
+ - Fix task hooks specified in Rexfile for tasks defined in modules
 
  [DOCUMENTATION]
  - Clarify sudo usage for multiple commands

--- a/lib/Rex/TaskList/Base.pm
+++ b/lib/Rex/TaskList/Base.pm
@@ -383,7 +383,7 @@ sub modify {
       $_ =~ m/^\Q$package\E:/;
     }
     else {
-      $_ !~ m/:/;
+      $_;
     }
   } $self->get_all_tasks($task);
 

--- a/t/hooks_in_rexfile_tasks_in_pkg.t
+++ b/t/hooks_in_rexfile_tasks_in_pkg.t
@@ -1,0 +1,44 @@
+package Rex::CLI;
+
+BEGIN {
+  use Test::More tests => 8;
+  use lib 't/lib';
+  use t::tasks::alien;
+  use File::Temp;
+  use Rex::Commands;
+  use Rex::RunList;
+  use Rex::Shared::Var;
+  share
+    qw( $before_task_start_all $before_task_start $before_all $before $after $after_all $after_task_finished $after_task_finished_all);
+}
+
+$::QUIET = 1;
+
+timeout 1;
+
+before_task_start ALL => sub { $before_task_start_all += 1; };
+before_task_start 't:tasks:alien:negotiate' => sub { $before_task_start += 1 };
+before ALL                                  => sub { $before_all        += 1 };
+before 't:tasks:alien:negotiate'            => sub { $before            += 1 };
+
+after 't:tasks:alien:negotiate' => sub { $after     += 1 };
+after ALL                       => sub { $after_all += 1 };
+after_task_finished 't:tasks:alien:negotiate' =>
+  sub { $after_task_finished += 1 };
+after_task_finished ALL => sub { $after_task_finished_all += 1 };
+
+@ARGV = qw(t:tasks:alien:negotiate);
+my $run_list = Rex::RunList->instance;
+$run_list->parse_opts(@ARGV);
+
+$run_list->run_tasks;
+
+is $before_task_start_all, 1, 'before_task_start ALL hook';
+is $before_task_start,     1, 'before_task_start hook';
+is $before_all,            1, 'before ALL hook';
+is $before,                1, 'before hook';
+
+is $after,                   1, 'after hook';
+is $after_all,               1, 'after ALL hook';
+is $after_task_finished,     1, 'after_task_finished hook';
+is $after_task_finished_all, 1, 'after_task_finished ALL hook';


### PR DESCRIPTION
When the following Rexfile:
```
use Rex -feature => ['1.4'];
use Blah;

before_task_start 'ALL' => sub {
  print "WTF\n";
};
```

is used in conjunction with a task module like this:
```
package Blah; 
use Rex -base;
task blah => sub {
  say 'poopood';
};
1;
```

And is called from command line with `rex Blah.blah`, an error is thrown: `INFO - Can't add before_task_start (?^:.*), as it is not yet defined`

This patch attempts to fix this issue.

