### PR TITLE
Add tools in contrib/ to strip dist.ini in-place for Gentoo

### DIFF
--- a/contrib/vendor/gentoo.sh
+++ b/contrib/vendor/gentoo.sh
@@ -1,0 +1,43 @@
+# This script patches the tree, and dist.ini to remove plugins
+# and soforth that are either useless, or harmful, when building
+# rex from git sources for Gentoo
+#
+# Many of these are useful for authorship to ensure the code meets
+# various standards, but this is not useful at a point of consumption
+# as defects in things like documentation or spelling, aren't things
+# that should be considered "blockers" for an end user, and can
+# substantially inflate the dependency tree without adding any user
+# value
+
+# usage:
+#   cd ${git_root}
+#   bash contrib/vendor/gentoo.sh
+
+info() {
+  printf "contrib/vendor/gentoo.sh: %s\n" "$@" >&1
+}
+err() {
+  printf "contrib/vendor/gentoo.sh: ERROR: %s\n" "$@" >&1
+  exit 1
+}
+
+blacklist=(
+  PodSyntaxTests
+  Test::MinimumVersion
+  Test::Perl::Critic
+  Test::Kwalitee
+  Test::CPAN::Changes
+)
+for section in "${blacklist[@]}"; do
+  perl contrib/vendor/remove-section.pl "${section}" dist.ini ||
+    err "Can't remove [$section]"
+done
+
+devdep_blacklist=(
+  Test::Kwalitee
+  Test::PerlTidy
+  Test::Pod
+)
+
+perl contrib/vendor/remove-dev-requires.pl "${devdep_blacklist[@]}" dist.ini ||
+  err "Can't strip DevelopRequires prereqs"

--- a/contrib/vendor/remove-dev-requires.pl
+++ b/contrib/vendor/remove-dev-requires.pl
@@ -1,0 +1,119 @@
+#!perl
+use strict;
+use warnings;
+
+# This script is to remove various entries from dist.ini
+# for gentoo purposes.
+#
+# Primarily, it removes entries from the DevelopRequires Prereqs
+# section, and if only blacklisted entries are found, removes the whole section
+#
+# usage: perl contrib/vendor/gentoo-dev-requires.pl Test::Kwalitee Test::PerlTidy dist.ini
+
+use File::Spec::Functions qw( splitpath catpath );
+
+exit usage() if grep /\A-(h|H|-help|\?)/, @ARGV;
+
+my $section = '[Prereqs / DevelopRequires]';
+my $file =
+  ( @ARGV > 0 ? pop @ARGV : die usage_err("Missing argument for 'FILE'") );
+my $out = do {
+  my (@path) = splitpath($file);
+  my (@out)  = @path;
+  $out[-1] = "._tmp_" . $path[-1] . "." . $$;
+  catpath(@out);
+};
+my (@blacklisted) =
+  ( @ARGV > 0 ? @ARGV : die usage_err("Missing argument for 'DEP'") );
+my (%removed);
+
+open my $src,  '<', $file or die "Can't open $file for read, $!";
+open my $dest, '>', $out  or die "Can't open $out for write, $!";
+
+my $seen = 0;
+
+main_loop: while ( my $line = <$src> ) {
+  if ( $line !~ /^\Q$section\E/ ) {
+    $dest->print($line);
+    next main_loop;
+  }
+  $seen++;
+
+  # Stash plugin heading for later
+  my $heading       = $line;
+  my $needs_section = 0;
+plugin_loop: while ( my $section_line = <$src> ) {
+    for my $blacklisted (@blacklisted) {
+      $removed{$blacklisted} = 0 unless exists $removed{$blacklisted};
+      if ( $section_line =~ /^\Q$blacklisted\E\s*=/ ) {
+        STDERR->print("Removing $section -> $section_line");
+        $removed{$blacklisted}++;
+        next plugin_loop;
+      }
+    }
+    if ( $section_line =~ /^\s*$/ ) {
+      if ($needs_section) {
+
+        # keep blank lines if we keep the section
+        $dest->print($_);
+      }
+      else {
+        next plugin_loop;
+      }
+    }
+
+    # Abort parsing on the first plugin section after this one
+    if ( $section_line =~ /^\[/ ) {
+      if ( not $needs_section ) {
+        STDERR->print("Removed section $section\n");
+      }
+
+      # forget we saw this line and reinject it into the main loop
+      $line = $section_line;
+      redo main_loop;
+    }
+
+    # Line is a non-blacklisted, section is needed
+    # So we need this section
+    if ( not $needs_section ) {
+      $dest->print($heading);
+      $needs_section = 1;
+    }
+    $dest->print($section_line);
+  }
+}
+
+close $src  or warn "Error closing input file $file, $!";
+close $dest or die "Error closing output file $out, $!";
+if ( $seen > 1 ) {
+  warn "Multiple sections stripped named $section, probably a bug";
+}
+if ( $seen < 1 ) {
+  unlink $out or warn "Can't cleanup temp file $out, $!";
+  die "No section named '$section' found in $file";
+}
+if ( my (@unremoved) = grep { $removed{$_} == 0 } keys %removed ) {
+  unlink $out or warn "Can't cleanup temp file $out, $!";
+  die "No dependencies [@unremoved] in $file section $section";
+}
+if ( my (@multimatch) = grep { $removed{$_} > 1 } keys %removed ) {
+  warn "Multiple definitions of dependencies [@multimatch], probably a bug";
+}
+rename $out, $file or die "Failed to rename $out to $file, $!";
+
+exit 0;
+
+sub usage {
+  STDERR->print("perl $0 DEP [DEP...] FILE\n");
+  STDERR->print("\n");
+  STDERR->print("\tDEP\tname of development dependency to remove\n");
+  STDERR->print("\tFILE\tname of file to remove dependencies from\n");
+  1;
+}
+
+sub usage_err {
+  my ($message) = @_;
+  STDERR->print("$message\n\n") if defined $message;
+  usage();
+  "$message";
+}

--- a/contrib/vendor/remove-section.pl
+++ b/contrib/vendor/remove-section.pl
@@ -1,0 +1,89 @@
+#!perl
+use strict;
+use warnings;
+
+# This tool implements a quick hack to strip a given section from
+# a dzil dist.ini
+#
+# Its slightly complicated vs the easy "sed -i " alternative, but
+# it allows more granular control, in particular, the ability to fail
+# when no changes are made
+#
+# And it has slightly more controlled 'in-place editing', using
+# ._tmp_dist.ini.<PID> and only doing the final replace
+# when changes are actually needed, and can be done without error
+#
+# Usage:
+#   perl contrib/vendor/remove-section Test::Kwalitee dist.ini
+#
+use File::Spec::Functions qw( splitpath catpath );
+
+exit usage() if grep /\A-(h|H|-help|\?)/, @ARGV;
+
+my $section =
+  ( $ARGV[0] ? $ARGV[0] : die usage_err("Missing argument for 'SECTION'") );
+my $file =
+  ( $ARGV[1] ? $ARGV[1] : die usage_err("Missing argument for 'FILE'") );
+
+my $out = do {
+  my (@path) = splitpath($file);
+  my (@out)  = @path;
+  $out[-1] = "._tmp_" . $path[-1] . "." . $$;
+  catpath(@out);
+};
+
+STDERR->print("Removing section '$section' from '$file'\n");
+
+open my $src,  '<', $file or die "Can't open $file for read, $!";
+open my $dest, '>', $out  or die "Can't open $out for write, $!";
+
+my $seen = 0;
+
+section_scan: while ( my $line = <$src> ) {
+  if ( $line !~ /\A\s*\[\Q$section\E\]\s*\z/ ) {
+    $dest->print($line);
+    next;
+  }
+  $seen++;
+  while ( my $section_line = <$src> ) {
+    if ( $section_line =~ /\A\s*\[/ ) {
+
+      # this basically works like an 'unread' of <$src>
+      # so when a new section start appears, the current section is considred
+      # finished and the main loop resumes.
+      #
+      # This means it can strip the same section occurring twice in a row
+      # without barbaric code
+      $line = $section_line;
+      redo section_scan;
+    }
+  }
+}
+close $src  or warn "Error closing input file $file, $!";
+close $dest or die "Error closing output file $out, $!";
+
+if ( $seen > 1 ) {
+  warn "Multiple sections stripped named $section, probably a bug";
+}
+if ( $seen < 1 ) {
+  unlink $out or warn "Can't cleanup temp file $out, $!";
+  die "No section named '$section' found in $file";
+}
+rename $out, $file or die "Failed to rename $out to $file, $!";
+
+exit 0;
+
+sub usage {
+  STDERR->print("perl $0 SECTION FILE\n");
+  STDERR->print("\n");
+  STDERR->print("\tSECTION\tname of section to remove\n");
+  STDERR->print("\tFILE\tname of file to remove section from\n");
+  1;
+}
+
+sub usage_err {
+  my ($message) = @_;
+  STDERR->print("$message\n\n") if defined $message;
+  usage();
+  "$message";
+}

--- a/dist.ini
+++ b/dist.ini
@@ -12,6 +12,9 @@ copyright_holder = Jan Gehring
 
 [GatherDir]
 include_dotfiles = 1
+exclude_filename = contrib/vendor/gentoo.sh
+exclude_filename = contrib/vendor/remove-section.pl
+exclude_filename = contrib/vendor/remove-dev-requires.pl
 
 [PruneCruft]
 except = \.perltidyrc


### PR DESCRIPTION
The implementation of this is slightly more complicated than strictly
necessary, but it adds a lot of value in output transparency and the
ability to error when things that were expected to be removed, failed
to remove, for whatever reason.

The idea is that in gentoo's live ebuilds, instead of this logic
being embedded in the ebuild, we can invoke this during `src_prepare`,
and subsequently, give the git repository far more control of keeping
this problem under wraps, as when plugins are added that pose a
problem, they can be removed again by this script in order to get the
gentoo live ebuilds working again for your users, without needing to
push more changes through gentoo.

I've tried to make the various extraction tools as vendor agnostic
as possible, and that way, if need be, other vendors can have their own
script in this dir which nukes different things.

Also, these contributed files are currently configured in `[GatherDir]`
such that they are trimmed from the published release, as they really
don't have much value there, because as it is, many projects will *not*
work when running `dzil build` on the published sources, as vast
quantities of assumptions it makes about "things not being changed yet"
fail to be true.