### PR TITLE
Remove default host of test tasks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Revision history for Rex
  - Fix warning about redundant arguments when using sync with key
  authentication
  - Fix setting distributor when versioned feature flags are active
+ - Remove default host of test tasks
 
  [DOCUMENTATION]
  - Clarify sudo usage for multiple commands

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -15,7 +15,7 @@ $::QUIET = 1;
 
 timeout 1;
 
-task foo => "asdfsadfasdf" => sub { return "yo" };
+task foo => sub { return "yo" };
 
 before_task_start ALL => sub { $before_task_start_all += 1 };
 before_task_start foo => sub { $before_task_start     += 1 };

--- a/t/hooks_in_rexfile.t
+++ b/t/hooks_in_rexfile.t
@@ -18,7 +18,7 @@ $::QUIET = 1;
 
 timeout 1;
 
-task foo => "asdfsadfasdf" => sub { return "yo" };
+task foo => sub { return "yo" };
 
 before_task_start ALL => sub { $before_task_start_all += 1 };
 before_task_start foo => sub { $before_task_start     += 1 };


### PR DESCRIPTION
This PR fixes #1306 by removing default host of tests tasks.