### PR TITLE
Make group resource idempotent

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Make group resource idempotent
 
  [DOCUMENTATION]
  - Clarify auth documentation

--- a/lib/Rex/Commands/User.pm
+++ b/lib/Rex/Commands/User.pm
@@ -311,11 +311,17 @@ sub group_resource {
     Rex::get_current_connection()->{reporter}
       ->report_resource_start( type => "group", name => $group_name );
 
+    my $gid = get_gid($group_name);
+
     if ( $option{ensure} eq "present" ) {
-      Rex::Commands::User::create_group( $group_name, %option );
+      if ( !defined $gid ) {
+        Rex::Commands::User::create_group( $group_name, %option );
+      }
     }
     elsif ( $option{ensure} eq "absent" ) {
-      Rex::Commands::User::delete_group($group_name);
+      if ( defined $gid ) {
+        Rex::Commands::User::delete_group($group_name);
+      }
     }
     else {
       die "Unknown 'ensure' value. Valid values are 'present' and 'absent'.";


### PR DESCRIPTION
This PR fixes #1321 by making the group resource idempotent for both `present` and `absent` values of `ensure`.

## Checklist

- [x] tests pass on Travis CI
- [x] git history is clean
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)