### PR TITLE
Fix sysctl on Gentoo

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Make group resource idempotent
+ - Fix sysctl detection for Gentoo
 
  [DOCUMENTATION]
  - Clarify auth documentation

--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Revision history for Rex
  - Clarify setting per-host authentication details within a group
 
  [ENHANCEMENTS]
+ - Check availability of sysctl command
 
  [MAJOR]
 

--- a/lib/Rex/Commands/Sysctl.pm
+++ b/lib/Rex/Commands/Sysctl.pm
@@ -138,7 +138,7 @@ sub sysctl {
 }
 
 sub get_sysctl_command {
-  my $sysctl = can_run('/sbin/sysctl');
+  my $sysctl = can_run( '/sbin/sysctl', '/usr/sbin/sysctl' );
 
   if ( !defined $sysctl ) {
     my $message = q(Couldn't find sysctl executable);


### PR DESCRIPTION
This PR fixes #1323 by checking if the `sysctl` executable is available at the expected locations, and adding a check for the `/usr/sbin/sysctl` path which is used on Gentoo.

## Checklist

- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)