### PR TITLE
Fix setting false values as sysctl parameters

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Make group resource idempotent
  - Fix sysctl detection for Gentoo
+ - Fix setting false values as sysctl parameters
 
  [DOCUMENTATION]
  - Clarify auth documentation

--- a/lib/Rex/Commands/Sysctl.pm
+++ b/lib/Rex/Commands/Sysctl.pm
@@ -91,7 +91,7 @@ sub sysctl {
   my ( $key, $val, %options ) = @_;
   my $sysctl = get_sysctl_command();
 
-  if ($val) {
+  if ( defined $val ) {
 
     Rex::Logger::debug("Setting sysctl key $key to $val");
     my $ret = i_run "$sysctl -n $key";


### PR DESCRIPTION
This PR fixes #1320 by checking definedness of passed value, as originally proposed by @uralm1 on the issue (thanks!).

## Checklist

- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)