### PR TITLE
Hooks documentation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ Revision history for Rex
  - Fix typos
  - Document limitations of nesting shared variables
  - Add initial documentation for Rex::Hook
+ - Clarify hooks documentation
 
  [ENHANCEMENTS]
  - Check availability of sysctl command

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ Revision history for Rex
  - Clarify Rex::Transaction documentation
  - Fix typos
  - Document limitations of nesting shared variables
+ - Add initial documentation for Rex::Hook
 
  [ENHANCEMENTS]
  - Check availability of sysctl command

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1433,7 +1433,7 @@ sub before_task_start {
 
 Run code after the task is finished (and after the ssh connection is terminated). This gets executed only once for a task.
 
-The task name is a regular expression to find all tasks with a matching name. The special task name C<'ALL'> can be used to run code before all tasks.
+The task name is a regular expression to find all tasks with a matching name. The special task name C<'ALL'> can be used to run code after all tasks.
 
 If called repeatedly, each sub will be appended to a list of 'after_task_finished' functions.
 

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -363,25 +363,31 @@ you use Perl packages.
 All the possible variables ('{environment}', '{hostname}', ...) are documented
 in the CMDB YAML documentation.
 
-This function supports the following hooks:
+This function supports the following L<hooks|Rex::Hook>:
 
-=over 8
+=over 4
 
 =item before
 
-This gets executed before everything is done. The return value of this hook overwrite the original parameters of the function-call.
+This gets executed before anything is done. All original parameters are passed to it.
+
+The return value of this hook overwrites the original parameters of the function-call.
 
 =item before_change
 
-This gets executed right before the new file is written. Only with I<content> parameter. For the I<source> parameter the hook of the upload function is used.
+This gets executed right before the new file is written. All original parameters are passed to it.
+
+Only called when the C<content> parameter is used. For the C<source> parameter, the L<upload|Rex::Commands::Upload#upload> hooks are used.
 
 =item after_change
 
-This gets executed right after the file was written. Only with I<content> parameter. For the I<source> parameter the hook of the upload function is used.
+This gets executed right after the file is written. All original parameters, and any returned results are passed to it.
+
+Only called when the C<content> parameter is used. For the C<source> parameter, the L<upload|Rex::Commands::Upload#upload> hooks are used.
 
 =item after
 
-This gets executed right before the file() function returns.
+This gets executed right before the C<file()> function returns. All original parameters, and any returned results are passed to it.
 
 =back
 

--- a/lib/Rex/Commands/Pkg.pm
+++ b/lib/Rex/Commands/Pkg.pm
@@ -240,25 +240,31 @@ This is deprecated since 0.9. Please use L<File> I<file> instead.
 
 =back
 
-This function supports the following hooks:
+This function supports the following L<hooks|Rex::Hook>:
 
-=over 8
+=over 4
 
 =item before
 
-This gets executed before everything is done. The return value of this hook overwrite the original parameters of the function-call.
+This gets executed before anything is done. All original parameters are passed to it.
+
+The return value of this hook overwrites the original parameters of the function-call.
 
 =item before_change
 
-This gets executed right before the new package is installed. This hook is only available for package installations. If you need file hooks, you have to use the file() function.
+This gets executed right before the new package is installed. All original parameters are passed to it.
+
+This hook is only available for package installations. If you need file hooks, you have to use the L<file()|Rex::Commands::File#file> function.
 
 =item after_change
 
-This gets executed right after the new package was installed. This hook is only available for package installations. If you need file hooks, you have to use the file() function.
+This gets executed right after the new package was installed. All original parameters, and the fact of change (C<{ changed => TRUE|FALSE }>) are passed to it.
+
+This hook is only available for package installations. If you need file hooks, you have to use the L<file()|Rex::Commands::File#file> function.
 
 =item after
-
-This gets executed right before the install() function returns.
+ 
+This gets executed right before the C<install()> function returns. All original parameters, and any returned results are passed to it.
 
 =back
 

--- a/lib/Rex/Commands/Service.pm
+++ b/lib/Rex/Commands/Service.pm
@@ -124,22 +124,21 @@ If you need to define a custom command for start, stop, restart, reload or statu
      reload  => "killall httpd && /usr/local/bin/httpd -f /etc/my/httpd.conf";
  };
 
-This function supports the following hooks:
+This function supports the following L<hooks|Rex::Hook>:
 
-=over 8
+=over 4
 
+=item before_${action}
 
-=item before_I<action>
+For example: C<before_start>, C<before_stop>, C<before_restart>
 
-For example: before_start, before_stop, before_restart
+This gets executed right before the given service action. All original parameters are passed to it.
 
-This gets executed right before the service action.
+=item after_${action}
 
-=item after_I<action>
+For example: C<after_start>, C<after_stop>, C<after_restart>
 
-For example: after_start, after_stop, after_restart
-
-This gets executed right after the service action.
+This gets executed right after the given service action. All original parameters, and any returned results are passed to it.
 
 =back
 

--- a/lib/Rex/Commands/Upload.pm
+++ b/lib/Rex/Commands/Upload.pm
@@ -52,26 +52,27 @@ Perform an upload. If $remote is a directory the file will be uploaded to that d
    upload "localfile", "/path";
  };
 
+This function supports the following L<hooks|Rex::Hook>:
 
-This function supports the following hooks:
-
-=over 8
+=over 4
 
 =item before
 
-This gets executed before everything is done. The return value of this hook overwrite the original parameters of the function-call.
+This gets executed before anything is done. All original parameters are passed to it.
+
+The return value of this hook overwrites the original parameters of the function-call.
 
 =item before_change
 
-This gets executed right before the new file is written.
+This gets executed right before the new file is written. The local file name, and the remote file name are passed as parameters.
 
 =item after_change
 
-This gets executed right after the file was written.
+This gets executed right after the file was written. On top of the local file name, and the remote file name, any returned results are passed as parameters.
 
 =item after
 
-This gets executed right before the upload() function returns.
+This gets executed right before the C<upload()> function returns. All original parameters, and any results returned are passed to it.
 
 =back
 

--- a/lib/Rex/Commands/User.pm
+++ b/lib/Rex/Commands/User.pm
@@ -126,6 +126,20 @@ sub account {
 
 Create or update a user.
 
+This function supports the following L<hooks|Rex::Hook>:
+
+=over 4
+
+=item before
+
+This gets executed before the user is created. All original parameters are passed to it.
+
+=item after
+
+This gets executed after the user is created. All original parameters, and the user's C<UID> are passed to it.
+
+=back
+
 =cut
 
 sub create_user {

--- a/lib/Rex/Hook.pm
+++ b/lib/Rex/Hook.pm
@@ -11,6 +11,22 @@ use warnings;
 
 # VERSION
 
+=head1 NAME
+
+Rex::Hook - manage Rex hooks
+
+=head1 DESCRIPTION
+
+This module manages hooks of various Rex functions.
+
+=head1 SYNOPSIS
+
+ use Rex::Hook;
+ 
+ register_function_hooks { $state => { $function => $coderef, }, };
+
+=cut
+
 require Exporter;
 use base qw(Exporter);
 use vars qw(@EXPORT);
@@ -18,6 +34,20 @@ use vars qw(@EXPORT);
 @EXPORT = qw(register_function_hooks);
 
 my $__hooks = {};
+
+=head1 EXPORTED FUNCTIONS
+
+=head2 register_function_hooks { $state => { $function => $coderef } };
+
+Registers a C<$coderef> to be called when C<$function> reaches C<$state> during its execution.
+
+For example:
+
+ register_function_hooks { before_change => { file => \&backup } };
+
+C<$coderef> may get parameters passed to it depending on the hook in question. See the given hook's documentation about details.
+
+=cut
 
 sub register_function_hooks {
   my ($hooks) = @_;


### PR DESCRIPTION
This PR fixes #1337 by adding an initial documentation to `Rex::Hook`, and clarifying descriptions of the various hooks. Oh, it fixes a semi-related typo as well.

## Checklist

- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)