### PR TITLE
Fix using external_master constructor parameter with Net::OpenSSH

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Revision history for Rex
  - Make group resource idempotent
  - Fix sysctl detection for Gentoo
  - Fix setting false values as sysctl parameters
+ - Fix passing external_master as Net::OpenSSH constructor parameter
 
  [DOCUMENTATION]
  - Clarify auth documentation

--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -94,11 +94,16 @@ sub connect {
 
   my @connection_props = ( "" . $server ); # stringify server object, so that a dumper don't print out passwords.
   push @connection_props, ( user => $user, port => $port );
-  push @connection_props, master_opts => \@ssh_opts_line
-    if @ssh_opts_line
-    && !( $net_openssh_constructor_options{external_master} );
-  push @connection_props, default_ssh_opts => \@ssh_opts_line if @ssh_opts_line;
-  push @connection_props, proxy_command    => $proxy_command  if $proxy_command;
+
+  if (@ssh_opts_line) {
+    if ( !$net_openssh_constructor_options{external_master} ) {
+      push @connection_props, master_opts => \@ssh_opts_line;
+    }
+
+    push @connection_props, default_ssh_opts => \@ssh_opts_line;
+  }
+
+  push @connection_props, proxy_command => $proxy_command if $proxy_command;
 
   my @auth_types_to_try;
   if ( $auth_type && $auth_type eq "pass" ) {

--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -94,8 +94,9 @@ sub connect {
 
   my @connection_props = ( "" . $server ); # stringify server object, so that a dumper don't print out passwords.
   push @connection_props, ( user => $user, port => $port );
-  push @connection_props, master_opts      => \@ssh_opts_line if @ssh_opts_line
-    && !($net_openssh_constructor_options{external_master});
+  push @connection_props, master_opts => \@ssh_opts_line
+    if @ssh_opts_line
+    && !( $net_openssh_constructor_options{external_master} );
   push @connection_props, default_ssh_opts => \@ssh_opts_line if @ssh_opts_line;
   push @connection_props, proxy_command    => $proxy_command  if $proxy_command;
 

--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -94,7 +94,8 @@ sub connect {
 
   my @connection_props = ( "" . $server ); # stringify server object, so that a dumper don't print out passwords.
   push @connection_props, ( user => $user, port => $port );
-  push @connection_props, master_opts      => \@ssh_opts_line if @ssh_opts_line;
+  push @connection_props, master_opts      => \@ssh_opts_line if @ssh_opts_line
+    && !($net_openssh_constructor_options{external_master});
   push @connection_props, default_ssh_opts => \@ssh_opts_line if @ssh_opts_line;
   push @connection_props, proxy_command    => $proxy_command  if $proxy_command;
 


### PR DESCRIPTION
This PR fixes #1310 (and closes #1312) by making sure `master_opts` and `external_master` can't be set at the same time, preventing Net::OpenSSH contructor to throw an exception.

Idea cherry-picked from #1312 (thanks @sdondley!), with some follow-up fixes (tidy, refactor, changelog).

## Checklist

- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)