### PR TITLE
Support dotted semantic versioning for trial releases

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -23,6 +23,7 @@ Revision history for Rex
  [ENHANCEMENTS]
  - Check availability of sysctl command
  - Checksum file only when content is managed
+ - Support dotted semantic versioning for trial releases
 
  [MAJOR]
 

--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -647,7 +647,7 @@ sub import {
       if ( $add =~ m/^(\d+\.\d+)$/ ) {
         my $vers = $1;
         my ( $major, $minor, $patch, $dev_release ) =
-          $Rex::VERSION =~ m/^(\d+)\.(\d+)\.(\d+)_?(\d+)?$/;
+          $Rex::VERSION =~ m/^(\d+)\.(\d+)\.(\d+)[_.]?(\d+)?$/;
 
         my ( $c_major, $c_minor ) = split( /\./, $vers );
 


### PR DESCRIPTION
This PR fixes #1343 by allowing not just an underscore, but also a dot to separate the dev release number at the end of the version string.

## Checklist

- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)