### PR TITLE
Discontinue support for some EOL Windows versions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Discontinue support for Windows 7, Windows Server 2018 R2, and older
 
  [DOCUMENTATION]
 

--- a/dist.ini
+++ b/dist.ini
@@ -22,7 +22,7 @@ skip = __Rexfile__
 
 [MakeMaker::Awesome]
 eumm_version = 7.1101
-header = die 'OS unsupported' if ( $^O eq 'MSWin32' && scalar((Win32::GetOSVersion())[1]) < 6 );
+header_file = misc/check_supported_OS.pl
 
 [ManifestSkip]
 

--- a/misc/check_supported_OS.pl
+++ b/misc/check_supported_OS.pl
@@ -1,0 +1,1 @@
+die 'OS unsupported' if ( $^O eq 'MSWin32' && scalar((Win32::GetOSVersion())[1]) < 6 );

--- a/misc/check_supported_OS.pl
+++ b/misc/check_supported_OS.pl
@@ -1,1 +1,7 @@
-die 'OS unsupported' if ( $^O eq 'MSWin32' && scalar((Win32::GetOSVersion())[1]) < 6 );
+if ( $^O eq 'MSWin32' ) {
+  my ( undef, $major ) = Win32::GetOSVersion();
+
+  if ( $major < 6 ) {
+    die 'OS unsupported';
+  }
+}

--- a/misc/check_supported_OS.pl
+++ b/misc/check_supported_OS.pl
@@ -1,7 +1,10 @@
 if ( $^O eq 'MSWin32' ) {
-  my ( undef, $major ) = Win32::GetOSVersion();
+  my ( undef, $major, $minor ) = Win32::GetOSVersion();
 
   if ( $major < 6 ) {
+    die 'OS unsupported';
+  }
+  elsif ( $major == 6 && $minor < 2 ) {
     die 'OS unsupported';
   }
 }


### PR DESCRIPTION
This PR closes #1347 by disabling support for the following Windows versions, which are all already EOL:

- Windows Vista
- Windows 7
- Windows Server 2008
- Windows Server 2008 R2

Due to the slightly increased complexity of the check, the logic has been moved to a file that is included into `Makefile.PL` by `MakeMaker::Awesome`.

## Checklist

- [ ] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)