### PR TITLE
Fix rsync operations for source directories containing a relative pat…

### DIFF
--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -122,7 +122,7 @@ sub sync {
   if ( !exists $opt->{download} && $source !~ m/^\// ) {
 
     # relative path, calculate from module root
-    $source = Rex::Helper::Path::get_file_path( $source, caller() );
+    $source = Rex::Helper::Path::get_file_path($source);
   }
 
   Rex::Logger::debug("Syncing $source -> $dest with rsync.");


### PR DESCRIPTION
This seems to do the trick for #1106.

I also ran a quick local test with a source destination that did not have a wildcard and it still worked.
