### PR TITLE
Fix expansion and quoting of rsync pathes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -25,6 +25,7 @@ Revision history for Rex
  - Use author tests to check tidiness of bin files
  - Use Symbol to manipulate Perl symbols
  - Add initial rsync tests
+ - Test rsync with spaces in source path
 
 1.11.0 2020-06-05 Ferenc Erki <erkiferenc@gmail.com>
  [BUG FIXES]

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Discontinue support for Windows 7, Windows Server 2008 R2, and older
  - Avoid caching of Bash completion options to support multiple Rexfiles
+ - Fix calling get_file_path from Rexfile
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Revision history for Rex
  - Discontinue support for Windows 7, Windows Server 2008 R2, and older
  - Avoid caching of Bash completion options to support multiple Rexfiles
  - Fix calling get_file_path from Rexfile
+ - Fix quoting of rsync parameters
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Revision history for Rex
  - Use Symbol to manipulate Perl symbols
  - Add initial rsync tests
  - Test rsync with spaces in source path
+ - Test rsync with wildcard in source path
 
 1.11.0 2020-06-05 Ferenc Erki <erkiferenc@gmail.com>
  [BUG FIXES]

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ Revision history for Rex
 
  [ENHANCEMENTS]
  - Extend Bash completion with known hosts
+ - Support wildcards in get_file_path
 
  [MAJOR]
 

--- a/lib/Rex/Helper/Path.pm
+++ b/lib/Rex/Helper/Path.pm
@@ -65,6 +65,10 @@ sub get_file_path {
 
   $::rexfile ||= $0;
 
+  if ( $caller_file =~ m|^/loader/[^/]+/__Rexfile__.pm$| ) {
+    $caller_file = $::rexfile;
+  }
+
   my @path_parts;
   if ( $^O =~ m/^MSWin/ && !Rex::is_ssh() ) {
     @path_parts = split( /\//, $::rexfile );

--- a/lib/Rex/Helper/Path.pm
+++ b/lib/Rex/Helper/Path.pm
@@ -12,7 +12,7 @@ use warnings;
 # VERSION
 
 use Rex::Helper::File::Spec;
-use File::Basename qw(dirname);
+use File::Basename qw(basename dirname);
 require Exporter;
 
 use base qw(Exporter);
@@ -44,9 +44,22 @@ sub get_file_path {
     $ends_with_slash = 1;
   }
 
+  my $has_wildcard = 0;
+  my $base_name    = basename($file_name);
+
+  if ( $base_name =~ qr{\*} ) {
+    $has_wildcard = 1;
+    $file_name    = dirname($file_name);
+  }
+
   my $fix_path = sub {
     my ($path) = @_;
     $path =~ s:^\./::;
+
+    if ($has_wildcard) {
+      $path = Rex::Helper::File::Spec->catfile( $path, $base_name );
+    }
+
     if ($ends_with_slash) {
       if ( $path !~ m/\/$/ ) {
         return "$path/";

--- a/t/rsync.t
+++ b/t/rsync.t
@@ -13,6 +13,7 @@ BEGIN {
 }
 
 use Cwd qw(realpath);
+use File::Basename qw(dirname);
 use File::Find;
 use File::Temp qw(tempdir);
 
@@ -52,12 +53,15 @@ sub test_rsync {
     # test sync results
     my ( @expected, @result );
 
+    my $prefix = dirname($source);
+
     # expected results
     find(
       {
-        wanted => sub {
-          s:^(t|.*/t)(?=/)::;
-          push @expected, $_;
+        preprocess => sub { sort @_ },
+        wanted     => sub {
+          s/$prefix//;
+          push @expected, $_ if length($_);
         },
         no_chdir => 1
       },
@@ -67,7 +71,8 @@ sub test_rsync {
     # actual results
     find(
       {
-        wanted => sub {
+        preprocess => sub { sort @_ },
+        wanted     => sub {
           s/$target//;
           push @result, $_ if length($_);
         },

--- a/t/rsync.t
+++ b/t/rsync.t
@@ -18,10 +18,12 @@ use File::Find;
 use File::Temp qw(tempdir);
 
 my %source_for = (
-  'rsync with absolute path'           => realpath('t/sync'),
-  'rsync with relative path'           => 't/sync',
-  'rsync with spaces in absolute path' => realpath('t/sync/dir with spaces'),
-  'rsync with spaces in relative path' => 't/sync/dir with spaces',
+  'rsync with absolute path'             => realpath('t/sync'),
+  'rsync with relative path'             => 't/sync',
+  'rsync with spaces in absolute path'   => realpath('t/sync/dir with spaces'),
+  'rsync with spaces in relative path'   => 't/sync/dir with spaces',
+  'rsync with wildcard in absolute path' => realpath('t/sync/*'),
+  'rsync with wildcard in relative path' => 't/sync/*',
 );
 
 plan tests => scalar keys %source_for;

--- a/t/rsync.t
+++ b/t/rsync.t
@@ -13,7 +13,7 @@ BEGIN {
 }
 
 use Cwd qw(realpath);
-use File::Basename qw(dirname);
+use File::Basename qw(basename dirname);
 use File::Find;
 use File::Temp qw(tempdir);
 
@@ -55,7 +55,15 @@ sub test_rsync {
     # test sync results
     my ( @expected, @result );
 
-    my $prefix = dirname($source);
+    my $prefix;
+
+    if ( basename($source) =~ qr{\*} ) {
+      $source = dirname($source);
+      $prefix = $source;
+    }
+    else {
+      $prefix = dirname($source);
+    }
 
     # expected results
     find(

--- a/t/rsync.t
+++ b/t/rsync.t
@@ -17,8 +17,10 @@ use File::Find;
 use File::Temp qw(tempdir);
 
 my %source_for = (
-  'rsync with absolute path' => realpath('t/sync'),
-  'rsync with relative path' => 't/sync',
+  'rsync with absolute path'           => realpath('t/sync'),
+  'rsync with relative path'           => 't/sync',
+  'rsync with spaces in absolute path' => realpath('t/sync/dir with spaces'),
+  'rsync with spaces in relative path' => 't/sync/dir with spaces',
 );
 
 plan tests => scalar keys %source_for;


### PR DESCRIPTION
This PR fixes #1075 by fixing the quoting and expansion logic of pathes used with rsync.

In order to do that, it first adds a few more rsync test cases related to quoting, like spaces or wildcards in the path. This makes it a somewhat bigger PR.

It might still need some further refactoring before merging, but I wanted to open it early as a draft, since it already seems to be working and useful.

## Checklist

- [x] changelog entries included
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)