### PR TITLE
Split out temp file naming logic

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ Revision history for Rex
  [ENHANCEMENTS]
  - Extend Bash completion with known hosts
  - Support wildcards in get_file_path
+ - Split out temp file naming logic
 
  [MAJOR]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -32,6 +32,7 @@ Revision history for Rex
  - Test rsync with spaces in source path
  - Test rsync with wildcard in source path
  - Add initial test for temp file names
+ - Simplify temp file naming logic
 
 1.11.0 2020-06-05 Ferenc Erki <erkiferenc@gmail.com>
  [BUG FIXES]

--- a/ChangeLog
+++ b/ChangeLog
@@ -31,6 +31,7 @@ Revision history for Rex
  - Add initial rsync tests
  - Test rsync with spaces in source path
  - Test rsync with wildcard in source path
+ - Add initial test for temp file names
 
 1.11.0 2020-06-05 Ferenc Erki <erkiferenc@gmail.com>
  [BUG FIXES]

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -475,13 +475,7 @@ sub file {
     # first upload file to tmp location, to get md5 sum.
     # than we can decide if we need to replace the current (old) file.
 
-    my @splitted_file = split( /[\/\\]/, $file );
-    my $file_name     = ".rex.tmp." . pop(@splitted_file);
-    my $tmp_file_name = (
-      $#splitted_file != -1
-      ? ( join( "/", @splitted_file ) . "/" . $file_name )
-      : $file_name
-    );
+    my $tmp_file_name = get_tmp_file_name($file);
 
     my $fh    = file_write($tmp_file_name);
     my @lines = split( qr{$/}, $option->{"content"} );
@@ -750,6 +744,20 @@ sub file {
     ->report_resource_end( type => "file", name => $file );
 
   return $__ret->{changed};
+}
+
+sub get_tmp_file_name {
+  my $file = shift;
+
+  my @splitted_file = split( /[\/\\]/, $file );
+  my $file_name     = ".rex.tmp." . pop(@splitted_file);
+  my $tmp_file_name = (
+    $#splitted_file != -1
+    ? ( join( "/", @splitted_file ) . "/" . $file_name )
+    : $file_name
+  );
+
+  return $tmp_file_name;
 }
 
 =head2 file_write($file_name)

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -71,6 +71,7 @@ use Rex::FS::File;
 use Rex::Commands::Upload;
 use Rex::Commands::MD5;
 use Rex::File::Parser::Data;
+use Rex::Helper::File::Spec;
 use Rex::Helper::System;
 use Rex::Helper::Path;
 use Rex::Hook;
@@ -749,13 +750,13 @@ sub file {
 sub get_tmp_file_name {
   my $file = shift;
 
-  my @splitted_file = split( /[\/\\]/, $file );
-  my $file_name     = ".rex.tmp." . pop(@splitted_file);
-  my $tmp_file_name = (
-    $#splitted_file != -1
-    ? ( join( "/", @splitted_file ) . "/" . $file_name )
-    : $file_name
-  );
+  my $dirname  = dirname($file);
+  my $filename = ".rex.tmp." . basename($file);
+
+  my $tmp_file_name =
+      $dirname eq '.'
+    ? $filename
+    : Rex::Helper::File::Spec->catfile( $dirname, $filename );
 
   return $tmp_file_name;
 }

--- a/t/file.t
+++ b/t/file.t
@@ -3,8 +3,9 @@ use warnings;
 
 use Cwd 'getcwd';
 my $cwd = getcwd;
+use File::Spec;
 
-use Test::More tests => 57;
+use Test::More tests => 58;
 
 use Rex::Commands::File;
 use Rex::Commands::Fs;
@@ -341,3 +342,17 @@ is(
   "overwrite keys from Rex::Config"
 );
 
+subtest 'get temp file name' => sub {
+  my $testfile          = "temp-$$";
+  my $testfile_absolute = File::Spec->catfile( $tmp_dir, $testfile );
+
+  my %temp_file_for = (
+    $testfile          => ".rex.tmp.$testfile",
+    $testfile_absolute => File::Spec->catfile( $tmp_dir, ".rex.tmp.$testfile" ),
+  );
+
+  for my $filename ( sort keys %temp_file_for ) {
+    my $tempfile = Rex::Commands::File::get_tmp_file_name($filename);
+    is( $tempfile, $temp_file_for{$filename}, 'temp file name matches' );
+  }
+};


### PR DESCRIPTION
This PR fixes #1358 by splitting out the temp file naming logic used by `Rex::Commands::File::file()`.

This reafactoring also made it possible to add tests, and I could right away fix one issue: Rex assumed `/` to be the path separator character when composing these temporary file names.

The fix also simplifies the overall logic, and makes use of previously unused imports as well.

## Checklist

- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit)