### PR TITLE
Use set semantics for directory comparisons

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,7 @@ Revision history for Rex
  - Test rsync with wildcard in source path
  - Add initial test for temp file names
  - Simplify temp file naming logic
+ - Use set semantics for directory comparisons
 
 1.11.0 2020-06-05 Ferenc Erki <erkiferenc@gmail.com>
  [BUG FIXES]

--- a/t/rsync.t
+++ b/t/rsync.t
@@ -16,6 +16,7 @@ use Cwd qw(realpath);
 use File::Basename qw(basename dirname);
 use File::Find;
 use File::Temp qw(tempdir);
+use Test::Deep;
 
 my %source_for = (
   'rsync with absolute path'             => realpath('t/sync'),
@@ -47,7 +48,7 @@ sub test_rsync {
 
     my @empty = qw(. ..);
 
-    is_deeply( \@contents, \@empty, "$target is empty" );
+    cmp_deeply( \@contents, set(@empty), "$target is empty" );
 
     # sync contents
     sync $source, $target;
@@ -68,8 +69,7 @@ sub test_rsync {
     # expected results
     find(
       {
-        preprocess => sub { sort @_ },
-        wanted     => sub {
+        wanted => sub {
           s/$prefix//;
           push @expected, $_ if length($_);
         },
@@ -81,8 +81,7 @@ sub test_rsync {
     # actual results
     find(
       {
-        preprocess => sub { sort @_ },
-        wanted     => sub {
+        wanted => sub {
           s/$target//;
           push @result, $_ if length($_);
         },
@@ -91,6 +90,6 @@ sub test_rsync {
       $target
     );
 
-    is_deeply( \@result, \@expected, 'synced dir matches' );
+    cmp_deeply( \@result, set(@expected), 'synced dir matches' );
   }
 }


### PR DESCRIPTION
This PR fixes #1365 by using set semantics when comparing directory contents for the rsync tests.

That is, the order of items doesn't matter, and duplicate items are ignored (assuming a given path can't exist more than once in the file system).

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)