### PR TITLE
Fix local rsync issues

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Revision history for Rex
  - Fix calling get_file_path from Rexfile
  - Fix quoting of rsync parameters
  - Fix local download rsync operations
+ - Fix determining local connections for rsync operations
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Revision history for Rex
  - Avoid caching of Bash completion options to support multiple Rexfiles
  - Fix calling get_file_path from Rexfile
  - Fix quoting of rsync parameters
+ - Fix local download rsync operations
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -123,7 +123,11 @@ sub sync {
       Rex::Helper::IP::get_server_and_port( $server->to_s, 22 );
   }
 
-  my $local_connection = defined $servername ? FALSE : TRUE;
+  my $local_connection = TRUE;
+
+  if ( defined $servername && $servername ne '<local>' ) {
+    $local_connection = FALSE;
+  }
 
   my $auth = $current_connection->{conn}->get_auth;
 

--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -161,10 +161,9 @@ sub sync {
     Rex::Logger::debug("Downloading $source -> $dest");
     push @rsync_cmd, "rsync -rl --verbose --stats $params ";
 
-    $source = $auth->{user} . "\@$servername:$source";
-
     if ( !$local_connection ) {
       push @rsync_cmd, "-e '\%s'";
+      $source = $auth->{user} . "\@$servername:$source";
     }
   }
   else {

--- a/t/rsync.t
+++ b/t/rsync.t
@@ -27,14 +27,15 @@ my %source_for = (
   'rsync with wildcard in relative path' => 't/sync/*',
 );
 
-plan tests => scalar keys %source_for;
+plan tests => 2 * scalar keys %source_for;
 
 for my $scenario ( sort keys %source_for ) {
   test_rsync( $scenario, $source_for{$scenario} );
+  test_rsync( $scenario, $source_for{$scenario}, { download => 1 } );
 }
 
 sub test_rsync {
-  my ( $scenario, $source ) = @_;
+  my ( $scenario, $source, $options ) = @_;
 
   subtest $scenario => sub {
     my $target = tempdir( CLEANUP => 1 );
@@ -51,7 +52,7 @@ sub test_rsync {
     cmp_deeply( \@contents, set(@empty), "$target is empty" );
 
     # sync contents
-    sync $source, $target;
+    sync $source, $target, $options;
 
     # test sync results
     my ( @expected, @result );

--- a/t/rsync.t
+++ b/t/rsync.t
@@ -16,6 +16,7 @@ use Cwd qw(realpath);
 use File::Basename qw(basename dirname);
 use File::Find;
 use File::Temp qw(tempdir);
+use Rex::Task;
 use Test::Deep;
 
 my %source_for = (
@@ -52,7 +53,12 @@ sub test_rsync {
     cmp_deeply( \@contents, set(@empty), "$target is empty" );
 
     # sync contents
-    sync $source, $target, $options;
+    my $task = Rex::Task->new(
+      name => 'rsync_test',
+      func => sub { sync $source, $target, $options },
+    );
+
+    $task->run('<local>');
 
     # test sync results
     my ( @expected, @result );


### PR DESCRIPTION
This PR fixes #1370 by testing for, and fixing the following issues around local rsync operations:

- if `{download => 1}` is in effect, don't prefix source with `user@servername:`
- servername for local connections inside tasks is `<local>`, so check for that too

I open this PR as draft as it most probably needs some clean up (changelog, wording, also more general testing approach for the various options) before merging.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)