### PR TITLE
Allow custom get_value method defined on custom cmdb module

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ Revision history for Rex
  [MINOR]
 
  [NEW FEATURES]
+ - Allow use a custom get_value method on a CMDB Provider
 
  [REVISION]
 


### PR DESCRIPTION
This PR fixes #1379 by allowing use custom `get_value` on `CMDB`

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [ ] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [ ] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
