### PR TITLE
Gather only files tracked by git

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Revision history for Rex
  [NEW FEATURES]
 
  [REVISION]
+ - Gather only files tracked by git
 
 1.12.0 2020-07-05 Ferenc Erki <erkiferenc@gmail.com>
  [BUG FIXES]

--- a/dist.ini
+++ b/dist.ini
@@ -10,7 +10,7 @@ copyright_holder = Jan Gehring
 -remove = PruneCruft
 -remove = ExtraTests
 
-[GatherDir]
+[Git::GatherDir]
 include_dotfiles = 1
 
 [PruneCruft]


### PR DESCRIPTION
This PR fixes #1378 by letting Dist::Zilla to only gather files for the dist that are tracked by git.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)