### PR TITLE
When using source for a file, we don't create old_md5 for comparison

### DIFF
--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -543,6 +543,10 @@ sub file {
 
   }
   elsif ( exists $option->{"source"} && !$is_directory ) {
+    if ($need_md5) {
+      eval { $old_md5 = md5($file); };
+    }
+
     $option->{source} =
       Rex::Helper::Path::get_file_path( $option->{source}, caller() );
 


### PR DESCRIPTION
This results in on_change always being triggered.

<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure there's an issue where the proposed changes are already discussed. -->

<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till the checklist below is complete, then mark it ready for review. -->

This PR fixes #<!-- issue ID --> by <!-- briefly explaining your changes -->.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [ ] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [ ] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean    <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [ ] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
