### PR TITLE
Improve MD5 calculation logic

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -18,6 +18,7 @@ Revision history for Rex
 
  [REVISION]
  - Set Travis CI root build job options explicitly
+ - Test internal MD5 checksumming methods
 
 1.12.1 2020-08-05 Ferenc Erki <erkiferenc@gmail.com>
  [DOCUMENTATION]

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix fallback MD5 calculation method on OS X
 
  [DOCUMENTATION]
  - Clarify contributing guide

--- a/lib/Rex/Commands/MD5.pm
+++ b/lib/Rex/Commands/MD5.pm
@@ -32,6 +32,7 @@ use warnings;
 
 use Rex::Logger;
 require Rex::Commands;
+require Rex::Commands::Run;
 use Rex::Interface::Exec;
 use Rex::Interface::File;
 use Rex::Interface::Fs;
@@ -105,11 +106,10 @@ sub _binary_md5 {
 
   my $exec = Rex::Interface::Exec->create;
 
-  my $os = $exec->exec("uname -s");
-  if ( $os =~ /bsd/i ) {
+  if ( Rex::Commands::Run::can_run('md5') ) {
     ( undef, $md5 ) = split( / = /, $exec->exec("md5 '$file'") );
   }
-  else {
+  elsif ( Rex::Commands::Run::can_run('md5sum') ) {
     ($md5) = split( /\s/, $exec->exec("md5sum '$file'") );
   }
 

--- a/lib/Rex/Commands/MD5.pm
+++ b/lib/Rex/Commands/MD5.pm
@@ -107,13 +107,11 @@ sub _binary_md5 {
   my $exec = Rex::Interface::Exec->create;
 
   if ( Rex::Commands::Run::can_run('md5') ) {
-    ( undef, $md5 ) = split( / = /, $exec->exec("md5 '$file'") );
+    ($md5) = $exec->exec("md5 '$file'") =~ qr{\s+=\s+([a-f0-9]{32})};
   }
   elsif ( Rex::Commands::Run::can_run('md5sum') ) {
-    ($md5) = split( /\s/, $exec->exec("md5sum '$file'") );
+    ($md5) = $exec->exec("md5sum '$file'") =~ qr{^\\?([a-f0-9]{32})\s+};
   }
-
-  chomp $md5;
 
   return $md5;
 }

--- a/t/md5.t
+++ b/t/md5.t
@@ -1,9 +1,23 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More tests => 3;
 use Rex::Commands::MD5;
 
 my $test_file = Rex::Helper::File::Spec->catfile( 't', 'md5test.bin' );
 
 is( md5($test_file), '93b885adfe0da089cdf634904fd59f71', 'MD5 checksum OK' );
+
+# test internal interfaces
+
+is(
+  Rex::Commands::MD5::_digest_md5($test_file),
+  '93b885adfe0da089cdf634904fd59f71',
+  'MD5 checksum OK via Digest::MD5'
+);
+
+is(
+  Rex::Commands::MD5::_binary_md5($test_file),
+  '93b885adfe0da089cdf634904fd59f71',
+  'MD5 checksum OK via binary'
+);


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR fixes #1187 by refactoring the logic to be much more testable, and by allowing Rex to choose a binary MD5 calculation method as a fallback based on command availability (instead of guessing one based on the OS).

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)