### PR TITLE
Report coverage to Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,15 @@ jobs:
         - cpanm DBI IPC::Shareable Parallel::ForkManager Digest::HMAC_SHA1
         - cpanm String::Escape XML::LibXML Net::SFTP::Foreign IO::Pty
         - cpanm File::LibMagic Test::mysqld Expect
+        - cpanm Devel::Cover::Report::Coveralls
       install:
         - dzil build --in build --notgz
       script:
-        - cd build && prove --timer --lib --recurse --jobs $(nproc) --shuffle t/ xt/
+        - cd build
+        - HARNESS_PERL_SWITCHES=-MDevel::Cover=+ignore,^t/ prove --timer --lib --recurse --jobs $(nproc) --shuffle t/
+        - prove --timer --lib --recurse --jobs $(nproc) --shuffle xt/
+      after_success:
+        - cover -report coveralls
     - stage: test
       os: windows
       language: shell

--- a/ChangeLog
+++ b/ChangeLog
@@ -22,6 +22,7 @@ Revision history for Rex
  [REVISION]
  - Set Travis CI root build job options explicitly
  - Test internal MD5 checksumming methods
+ - Report coverage to Coveralls
 
 1.12.1 2020-08-05 Ferenc Erki <erkiferenc@gmail.com>
  [DOCUMENTATION]


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR fixes #1408 by allowing Travis CI to report coverage information to coveralls.io.

It excludes coverage for the test files themselves (excluding `t/` and `xt/`), and only sends reports upon successful builds.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)