### PR TITLE
Skip procfs inventory test if /proc is not readable

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Revision history for Rex
  - Fix registering custom template functions
  - Fix handling of configuration file settings
  - Skip MD5 binary test if there's no binary available
+ - Skip procfs inventory test if /proc is not readable
 
  [DOCUMENTATION]
  - Clarify contributing guide

--- a/t/proc.t
+++ b/t/proc.t
@@ -5,11 +5,14 @@ use Test::More;
 use Test::Output;
 use Rex::Inventory::Proc;
 
-if ( -d '/proc' ) {
-  plan tests => 1;
-}
-else {
+if ( !-d '/proc' ) {
   plan skip_all => 'No procfs found';
 }
+
+if ( !-r '/proc' ) {
+  plan skip_all => 'Procfs is not readable';
+}
+
+plan tests => 1;
 
 stderr_like( sub { Rex::Inventory::Proc->new() }, qr{^$}, 'stderr is empty' );


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1420 by checking if `/proc` is readable before testing inventory functionality related to procfs.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)