### PR TITLE
Fix file on_change hook when source option is used

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -41,6 +41,7 @@ Revision history for Rex
  - List suggested development dependencies
  - Test cpuinfo inventory
  - Add initial file hook tests
+ - Add file on_change tests for source option
 
 1.12.1 2020-08-05 Ferenc Erki <erkiferenc@gmail.com>
  [DOCUMENTATION]

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,7 @@ Revision history for Rex
  - Skip MD5 binary test if there's no binary available
  - Warn if cpuinfo is unreadable
  - Fix file hook options
+ - Fix file on_change hook when source option is used
 
  [DOCUMENTATION]
  - Clarify contributing guide

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -550,6 +550,8 @@ sub file {
 
     # HOOKS: for this case you have to use the upload hooks!
     $__ret = upload $option->{"source"}, "$file", force => 1;
+
+    $need_md5 = 0 if $__ret->{changed} == 0;
   }
 
   if ( exists $option->{"ensure"} ) {

--- a/t/file.t
+++ b/t/file.t
@@ -4,8 +4,9 @@ use warnings;
 use Cwd 'getcwd';
 my $cwd = getcwd;
 use File::Spec;
+use File::Temp;
 
-use Test::More tests => 58;
+use Test::More tests => 59;
 
 use Rex::Commands::File;
 use Rex::Commands::Fs;
@@ -355,4 +356,23 @@ subtest 'get temp file name' => sub {
     my $tempfile = Rex::Commands::File::get_tmp_file_name($filename);
     is( $tempfile, $temp_file_for{$filename}, 'temp file name matches' );
   }
+};
+
+subtest 'on_change hook with source option' => sub {
+  my $testfile1 = File::Temp->new()->filename;
+  my $testfile2 = File::Temp->new()->filename;
+
+  my $changed;
+
+  file $testfile1, content => 'change', on_change => sub { $changed += 1 };
+
+  is( $changed, 1, 'on_change when creating a new file with content' );
+
+  file $testfile2, source => $testfile1, on_change => sub { $changed += 1 };
+
+  is( $changed, 2, 'on_change when creating a new file with source' );
+
+  file $testfile2, source => $testfile1, on_change => sub { $changed += 1 };
+
+  is( $changed, 2, 'on_change when uploading the same file again' );
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1425 by testing file `on_change` hooks together with the `source` option, and respecting the returned results of the `upload` call.

Also closes #1399 in favor of this approach.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)