### PR TITLE
Set uniform environment for Debian package commands

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ Revision history for Rex
  - Warn if cpuinfo is unreadable
  - Fix file hook options
  - Fix file on_change hook when source option is used
+ - Set uniform environment for Debian package commands
 
  [DOCUMENTATION]
  - Clarify contributing guide

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ Revision history for Rex
  - Fix file hook options
  - Fix file on_change hook when source option is used
  - Set uniform environment for Debian package commands
+ - Disable apt-listbugs
 
  [DOCUMENTATION]
  - Clarify contributing guide

--- a/lib/Rex/Pkg/Debian.pm
+++ b/lib/Rex/Pkg/Debian.pm
@@ -33,9 +33,9 @@ sub new {
       "$env apt-get -o Dpkg::Options::=--force-confold -y install %s=%s",
     update_system      => "$env apt-get -y -qq upgrade",
     dist_update_system => "$env apt-get -y -qq dist-upgrade",
-    remove             => 'apt-get -y remove %s',
-    purge              => 'dpkg --purge %s',
-    update_package_db  => 'apt-get -y update',
+    remove             => "$env apt-get -y remove %s",
+    purge              => "$env dpkg --purge %s",
+    update_package_db  => "$env apt-get -y update",
   };
 
   return $self;

--- a/lib/Rex/Pkg/Debian.pm
+++ b/lib/Rex/Pkg/Debian.pm
@@ -25,18 +25,17 @@ sub new {
 
   bless( $self, $proto );
 
+  my $env = 'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive';
+
   $self->{commands} = {
-    install =>
-      'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold -y install %s',
+    install => "$env apt-get -o Dpkg::Options::=--force-confold -y install %s",
     install_version =>
-      'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -o Dpkg::Options::=--force-confold -y install %s=%s',
-    update_system =>
-      'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y -qq upgrade',
-    dist_update_system =>
-      'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive apt-get -y -qq dist-upgrade',
-    remove            => 'apt-get -y remove %s',
-    purge             => 'dpkg --purge %s',
-    update_package_db => 'apt-get -y update',
+      "$env apt-get -o Dpkg::Options::=--force-confold -y install %s=%s",
+    update_system      => "$env apt-get -y -qq upgrade",
+    dist_update_system => "$env apt-get -y -qq dist-upgrade",
+    remove             => 'apt-get -y remove %s',
+    purge              => 'dpkg --purge %s',
+    update_package_db  => 'apt-get -y update',
   };
 
   return $self;

--- a/lib/Rex/Pkg/Debian.pm
+++ b/lib/Rex/Pkg/Debian.pm
@@ -25,7 +25,8 @@ sub new {
 
   bless( $self, $proto );
 
-  my $env = 'APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive';
+  my $env =
+    'APT_LISTBUGS_FRONTEND=none APT_LISTCHANGES_FRONTEND=none DEBIAN_FRONTEND=noninteractive';
 
   $self->{commands} = {
     install => "$env apt-get -o Dpkg::Options::=--force-confold -y install %s",


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1411 by making sure that the same environment variables are set for all package management commands on Debian. It also disables apt-listbugs to prevent it possibly interfering with unattended package operations by presenting an interactive prompt.

Note: this is a hotfix for the upcoming patch release, so the scope is kept small intentionally. A more complete fix could include adding support to set/override environment variables for all package operation commands, and/or to provide a method in the base class to set environment variables for its operations.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)