### PR TITLE
Fix fallback hostname detection on Linux

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Fix MD5 checksumming if filename looks like md5 output
+ - Fix fallback hostname detection on Linux
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Hardware/Host.pm
+++ b/lib/Rex/Hardware/Host.pm
@@ -60,16 +60,17 @@ sub get {
         eval { i_run("cat /proc/sys/kernel/domainname"); } || ("unknown");
     }
     else {
-      my @out =
-        eval { i_run("hostname -f 2>/dev/null"); } || ("unknown.nodomain");
-      ( $hostname, $domain ) =
-        split( /\./, $out[0], 2 );
+      my @out = i_run "hostname -f 2>/dev/null", fail_ok => 1;
 
-      if ( !$hostname || $hostname eq "" ) {
+      if ( $? == 0 ) {
+        ( $hostname, $domain ) = split( /\./, $out[0], 2 );
+      }
+      else {
         Rex::Logger::debug(
           "Error getting hostname and domainname. There is something wrong with your /etc/hosts file."
         );
-        ($hostname) = eval { i_run("hostname"); } || ("unknown");
+        ($hostname) = eval { i_run("hostname -s"); } || ("unknown");
+        ($domain)   = eval { i_run("hostname -d"); } || ("nodomain");
       }
     }
 


### PR DESCRIPTION
This PR is an attempt to fix #1432 by making sure that the fallback hostname/domainname detection logic is executed in case the preferred method fails.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)