### PR TITLE
Require minimum version of List::MoreUtils

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Fix MD5 checksumming if filename looks like md5 output
  - Fix fallback hostname detection on Linux
+ - Require minimum version of List::MoreUtils
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Group.pm
+++ b/lib/Rex/Group.pm
@@ -17,7 +17,7 @@ use attributes;
 use Rex::Group::Entry::Server;
 
 use vars qw(%groups);
-use List::MoreUtils qw(uniq);
+use List::MoreUtils 0.416 qw(uniq);
 use Data::Dumper;
 
 sub new {

--- a/lib/Rex/Group/Entry/Server.pm
+++ b/lib/Rex/Group/Entry/Server.pm
@@ -19,7 +19,7 @@ use Data::Dumper;
 use Sort::Naturally;
 use Symbol;
 
-use List::MoreUtils qw(uniq);
+use List::MoreUtils 0.416 qw(uniq);
 
 use overload
   'eq'  => sub { shift->is_eq(@_); },


### PR DESCRIPTION
This PR is a hotfix attempt for #1436 by requiring at least version 0.416 of List::MoreUtils.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)