### PR TITLE
Proposed path and test for issue #1401

### DIFF
--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -184,7 +184,11 @@ sub run {
     if !exists $option->{auto_die};
 
   # check if $cmd is an eplicit path
-  if ( $cmd =~ /(^(?:[.]{1,2}|[~])?[/].+[/])(.+)/xsm ) {
+  if ( $cmd =~ m{(^
+                 (?:[.]{1,2}|[~])?
+                 [/].+[/])
+                (.+)
+               }xsm ) {
     my ( $head, $tail ) = ( $1, $2 );
     if ( $tail =~ /(.+?)([ ].*)/sxm ) {
       $cmd = qq("$head$1"$2);

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -184,9 +184,9 @@ sub run {
     if !exists $option->{auto_die};
 
   # check if $cmd is an eplicit path
-  if ( $cmd =~ /(^(?:\.{1,2}|\~)?\/.+\/)(.+)/xsm ) {
+  if ( $cmd =~ /(^(?:[.]{1,2}|[~])?[/].+[/])(.+)/xsm ) {
     my ( $head, $tail ) = ( $1, $2 );
-    if ( $tail =~ /(.+?)(\ .*)/sxm ) {
+    if ( $tail =~ /(.+?)([ ].*)/sxm ) {
       $cmd = qq("$head$1"$2);
     }
     else {

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -190,8 +190,13 @@ sub run {
   if (  ( $cmd =~ m{^(?:[.]{1,2}|[~]|[A-Z]:|[\\/])}xsm )
     and ( $cmd !~ m{[\\^]\s|["']}xsm ) )
   {
-    my $split = qr{(?=\s(?:[.]{1,2}|[~]|[A-Z]:|[\\/]))}xsm;
-    my @cmd   = split $split, $cmd;
+
+    #https://stackoverflow.com/questions/4094699\
+    #/how-does-the-windows-command-interpreter-cmd-exe-parse-scripts\
+    #/4095133#4095133
+    my $split = qr{(?=\s(?:[.]{1,2}|[~]|[A-Z]:|[\\/])|\b[\d]?[()?*[\]&|<>])}xsm;
+
+    my @cmd = split $split, $cmd;
     $cmd[0] =~ s{(.*[\\/][^\s]*)}{"$1"}xsm;
     $cmd = join q{}, @cmd;
   }

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -188,9 +188,9 @@ sub run {
 
   if ( $cmd =~ m{^(?:[.]{1,2}|[~]|[A-Z]:|[\\/])}xsm ) {
     my $split = qr{(?=\s(?:[.]{1,2}|[~]|[A-Z]:|[\\/]))}mxs;
-    my @cmd = split $split, $cmd;
-    $cmd[0] = qq{"$cmd[0]"} ;
-    $cmd = join q{}, @cmd;
+    my @cmd   = split $split, $cmd;
+    $cmd[0] = qq{"$cmd[0]"};
+    $cmd    = join q{}, @cmd;
   }
 
   my $res_cmd = $cmd;

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -182,12 +182,12 @@ sub run {
   $option->{auto_die} = Rex::Config->get_exec_autodie()
     if !exists $option->{auto_die};
 
-#  check if $cmd is an eplicit path 
-   if ( $cmd =~ m"(^(?:\.{1,2}|\~)?/.+/)(.+)" ) {
-     my ($head,$tail) = ($1,$2);
-     my $end = ($tail =~ s/(.+?)( .+)/$1/ )?$2:'';
-     $cmd = '"'.$head.$tail.'"'.$end #quote the path of comand in a compatible way
-   }
+  # check if $cmd is an eplicit path
+  if ( $cmd =~ m"(^(?:\.{1,2}|\~)?/.+/)(.+)" ) {
+    my ( $head, $tail ) = ( $1, $2 );
+    my $end = ( $tail =~ s/(.+?)( .+)/$1/ ) ? $2 : '';
+    $cmd = '"' . $head . $tail . '"' . $end # quote the path of comand in a compatible way
+  }
 
   my $res_cmd = $cmd;
 

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -186,19 +186,21 @@ sub run {
   # We only process cmd is an explicit path that means
   # that starts with . .. <letter>: and / or \
   # and aren't scaped spaces or quotes
-
-  if (  ( $cmd =~ m{^(?:[.]{1,2}|[~]|[A-Z]:|[\\/])}xsm )
-    and ( $cmd !~ m{[\\^]\s|["']}xsm ) )
   {
+    my $path_start = qr{(?:[.]{1,2}|[~]|\p{IsAlphabetic}:|[\\/])}msx;
+    if ( ( $cmd =~ m{^$path_start}xsm )
+      && ( $cmd !~ m{[\\^]\s|["']}xsm ) )
+    {
 
-    #https://stackoverflow.com/questions/4094699\
-    #/how-does-the-windows-command-interpreter-cmd-exe-parse-scripts\
-    #/4095133#4095133
-    my $split = qr{(?=\s(?:[.]{1,2}|[~]|[A-Z]:|[\\/])|\b[\d]?[()?*[\]&|<>])}xsm;
+      #https://stackoverflow.com/questions/4094699\
+      #/how-does-the-windows-command-interpreter-cmd-exe-parse-scripts\
+      #/4095133#4095133
+      my $split = qr{(?=\s$path_start|\b\d?[()?*[\]&|<>])}xsm;
 
-    my @cmd = split $split, $cmd;
-    $cmd[0] =~ s{(.*[\\/][^\s]*)}{"$1"}xsm;
-    $cmd = join q{}, @cmd;
+      my @cmd = split $split, $cmd;
+      $cmd[0] =~ s{(.*[\\/]\S*)}{"$1"}xsm;
+      $cmd = join q{}, @cmd;
+    }
   }
 
   my $res_cmd = $cmd;

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -183,10 +183,14 @@ sub run {
     if !exists $option->{auto_die};
 
   # check if $cmd is an eplicit path
-  if ( $cmd =~ m"(^(?:\.{1,2}|\~)?/.+/)(.+)" ) {
+  if ( $cmd =~ /(^(?:\.{1,2}|\~)?\/.+\/)(.+)/xsm ) {
     my ( $head, $tail ) = ( $1, $2 );
-    my $end = ( $tail =~ s/(.+?)( .+)/$1/ ) ? $2 : '';
-    $cmd = '"' . $head . $tail . '"' . $end # quote the path of comand in a compatible way
+    if ( $tail =~ /(.+?)(\ .*)/sxm ) {
+      $cmd = qq("$head$1"$2);
+    }
+    else {
+      $cmd = qq("$head$tail");
+    }
   }
 
   my $res_cmd = $cmd;

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -182,6 +182,13 @@ sub run {
   $option->{auto_die} = Rex::Config->get_exec_autodie()
     if !exists $option->{auto_die};
 
+#  check if $cmd is an eplicit path 
+   if ( $cmd =~ m"(^(?:\.{1,2}|\~)?/.+/)(.+)" ) {
+     my ($head,$tail) = ($1,$2);
+     my $end = ($tail =~ s/(.+?)( .+)/$1/ )?$2:'';
+     $cmd = '"'.$head.$tail.'"'.$end #quote the path of comand in a compatible way
+   }
+
   my $res_cmd = $cmd;
 
   if ( exists $option->{only_notified} && $option->{only_notified} ) {

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -183,22 +183,14 @@ sub run {
   $option->{auto_die} = Rex::Config->get_exec_autodie()
     if !exists $option->{auto_die};
 
-  # check if $cmd is an eplicit path
-  if (
-    $cmd =~ m{(^
-                 (?:[.]{1,2}|[~])?
-                 [/].+[/])
-                (.+)
-               }xsm
-    )
-  {
-    my ( $head, $tail ) = ( $1, $2 );
-    if ( $tail =~ /(.+?)([ ].*)/sxm ) {
-      $cmd = qq("$head$1"$2);
-    }
-    else {
-      $cmd = qq("$head$tail");
-    }
+  # We only process cmd is an explicit path that means
+  # that starts with . .. <letter>: and / or \
+
+  if ( $cmd =~ m{^(?:[.]{1,2}|[~]|[A-Z]:|[\\/])}xsm ) {
+    my $split = qr{(?=\s(?:[.]{1,2}|[~]|[A-Z]:|[\\/]))}mxs;
+    my @cmd = split $split, $cmd;
+    $cmd[0] = qq{"$cmd[0]"} ;
+    $cmd = join q{}, @cmd;
   }
 
   my $res_cmd = $cmd;

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -184,11 +184,14 @@ sub run {
     if !exists $option->{auto_die};
 
   # check if $cmd is an eplicit path
-  if ( $cmd =~ m{(^
+  if (
+    $cmd =~ m{(^
                  (?:[.]{1,2}|[~])?
                  [/].+[/])
                 (.+)
-               }xsm ) {
+               }xsm
+    )
+  {
     my ( $head, $tail ) = ( $1, $2 );
     if ( $tail =~ /(.+?)([ ].*)/sxm ) {
       $cmd = qq("$head$1"$2);

--- a/lib/Rex/Commands/Run.pm
+++ b/lib/Rex/Commands/Run.pm
@@ -185,12 +185,15 @@ sub run {
 
   # We only process cmd is an explicit path that means
   # that starts with . .. <letter>: and / or \
+  # and aren't scaped spaces or quotes
 
-  if ( $cmd =~ m{^(?:[.]{1,2}|[~]|[A-Z]:|[\\/])}xsm ) {
-    my $split = qr{(?=\s(?:[.]{1,2}|[~]|[A-Z]:|[\\/]))}mxs;
+  if (  ( $cmd =~ m{^(?:[.]{1,2}|[~]|[A-Z]:|[\\/])}xsm )
+    and ( $cmd !~ m{[\\^]\s|["']}xsm ) )
+  {
+    my $split = qr{(?=\s(?:[.]{1,2}|[~]|[A-Z]:|[\\/]))}xsm;
     my @cmd   = split $split, $cmd;
-    $cmd[0] = qq{"$cmd[0]"};
-    $cmd    = join q{}, @cmd;
+    $cmd[0] =~ s{(.*[\\/][^\s]*)}{"$1"}xsm;
+    $cmd = join q{}, @cmd;
   }
 
   my $res_cmd = $cmd;

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -1,31 +1,45 @@
-use Test::More tests => 4;
+use Test::More tests => 6;
 
 use Rex::Commands::Run;
 
 $::QUIET = 1;
 
-SKIP: {
-  skip 'Do not run tests on Windows', 4 if $^O =~ m/^MSWin/mxsi;
+my $win = $^O =~ m/^MSWin/mxsi;
 
-  my $path = '/tmp/inexistent path with spaces/';
-  my $tail = 'hello';
-  my $parm = 'hello Rex';
-  my $s    = run "$path$tail";
-  like( $s, qr{$path}ms,
-    "The inexistent path or file is not reported correctly" );
+my $path = './inexistent path with spaces/';
+ok( !-e $path, qq("$path" not exists) );
 
-  mkdir $path;
-  symlink( '/bin/echo', "$path$tail" );
-  $s = run "$path$tail $parm";
-  like( $s, qr{$parm}sm, qq($path$tail $parm didn't work) );
+my $tail      = 'hello';
+my $parm      = 'Rex';
+my $s         = run "$path$tail $parm";
+my $notExists = ($win and !-e $path) ? $s : qq{$path$tail};
 
-  $s = run "$path$tail /$parm";
-  like( $s, qr{$path}sm, "/slash on parms and the comand didn't fail?" );
+like( $s, qr{$notExists}sm,
+  qq{windows dont return "$path/$tail" on the message} );
 
-  $s = run qq("$path$tail" /$parm);
-  like( $s, qr{/$parm}sm, "Quoted command failed" );
+ok( mkdir($path), qq{creating "$path"} );
 
-  unlink $path . $tail;
-  rmdir $path;
+if ($win) {
 
+  #On windows we create hello.bat contaning echo %1
+  open my $hello, '>', qq{$path$tail.bat};
+  print $hello "echo %1\n";
+  close $hello;
 }
+else {
+  #hello is a sybolic link to /usr/bin/echo
+  symlink "/usr/bin/echo", qq{$path$tail};
+}
+
+$s = run "$path$tail $parm";
+like( $s, qr{$parm}sm, qq{$path$tail $parm didn't work} );
+
+$s = run "$path$tail /$parm";
+like( $s, qr{$parm}sm, "/slash on parms and the comand didn't fail?" );
+
+$s = run qq("$path$tail" /$parm);
+like( $s, qr{/$parm}sm, "Quoted commands pass" );
+
+unlink "$path$tail" . ($win?q{.bat}:q{});
+rmdir $path;
+

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -11,19 +11,19 @@ SKIP: {
   my $tail = 'hello';
   my $parm = 'hello Rex';
   my $s    = run "$path$tail";
-  like( $s, qr{$path}mxs,
+  like( $s, qr{$path}ms,
     "The inexistent path or file is not reported correctly" );
 
   mkdir $path;
   symlink( '/bin/echo', "$path$tail" );
   $s = run "$path$tail $parm";
-  like( $s, qr{^$parm}sxm, qq($path$tail $parm didn't work) );
+  like( $s, qr{$parm}sm, qq($path$tail $parm didn't work) );
 
   $s = run "$path$tail /$parm";
-  like( $s, qr{$path}sxm, "/slash on parms and the comand didn't fail?" );
+  like( $s, qr{$path}sm, "/slash on parms and the comand didn't fail?" );
 
   $s = run qq("$path$tail" /$parm);
-  like( $s, qr{^/$parm}sxm, "Quoted command failed" );
+  like( $s, qr{/$parm}sm, "Quoted command failed" );
 
   unlink $path . $tail;
   rmdir $path;

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -1,3 +1,5 @@
+use 5.010;
+
 use Test::More tests => 7;
 
 use Rex::Commands::Run;
@@ -7,11 +9,11 @@ $::QUIET = 1;
 my $win = $^O =~ m/^MSWin/mxsi;
 
 my $path = './inexistent path with spaces/';
-ok( !-e $path, qq("$path" not exists) );
+ok( !-e $path, qq{"$path" not exists} );
 
 my $tail      = 'hello';
 my $parm      = 'Rex is wonderfull';
-my $s         = run "$path$tail $parm";
+my $s         = run qq{$path$tail $parm};
 my $notExists = ( $win and !-e $path ) ? $s : qq{$path$tail};
 
 like( $s, qr{$notExists}sm,
@@ -27,29 +29,33 @@ if ($win) {
   close $hello;
 }
 else {
-  #hello is a sybolic link to /usr/bin/echo
-  symlink "/usr/bin/echo", qq{$path$tail};
+  #hello is a sybolic link to echo
+  my $echo = '/bin/echo';
+  if ( !-X $echo ) {
+    substr $echo, 0, 0, q{/usr};
+  }
+  symlink $echo, qq{$path$tail};
 }
 
-$s = run "$path$tail $parm";
-like( $s, qr{$parm}sm, qq{$path$tail $parm didn't work} );
+$s = run qq{$path$tail $parm};
+like( $s, qr{$parm}sm, qq{"$path$tail $parm"  ok} );
 
-$s = run "$path$tail /$parm";
-like( $s, qr{$parm}sm, "/slash on parms and the comand didn't fail?" );
+$s = run qq{$path$tail /$parm};
+like( $s, qr{$parm}sm, '/slash on parms ok' );
 
-$s = run qq("$path$tail" $parm);
-like( $s, qr{$parm}sm, "Quoted commands pass" );
+$s = run qq{"$path$tail" $parm};
+like( $s, qr{$parm}sm, "Quoted commands ok" );
 my $mpath = $path;
 
 if ($win) {
   $mpath =~ s{/}{\\}gsmx;
-  $s = run qq($mpath$tail $parm);
-  like( $s, qr{$parm}sm, "($mpath$tail $parm) windows format pass" );
+  $s = run qq{$mpath$tail $parm};
+  like( $s, qr{$parm}sm, "($mpath$tail $parm) windows path ok" );
 }
 else {
   $mpath =~ s{(\s)}{\\$1}gsmx;
-  $s = run qq($mpath$tail $parm);
-  like( $s, qr{$parm}sm, "($mpath$tail $parm) scaped espaces pass" );
+  $s = run qq{$mpath$tail $parm};
+  like( $s, qr{$parm}sm, "($mpath$tail $parm) back slash escapes ok" );
 }
 
 unlink "$path$tail" . ( $win ? q{.bat} : q{} );

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -5,25 +5,25 @@ use Rex::Commands::Run;
 $::QUIET = 1;
 
 SKIP: {
-  skip 'Do not run tests on Windows', 4 if $^O =~ m/^MSWin/i;
+  skip 'Do not run tests on Windows', 4 if $^O =~ m/^MSWin/mxsi;
 
   my $path = '/tmp/inexistent path with spaces/';
   my $tail = 'hello';
   my $parm = 'hello Rex';
   my $s    = run "$path$tail";
-  like( $s, qr/$path/,
+  like( $s, qr{$path}mxs,
     "The inexistent path or file is not reported correctly" );
 
   mkdir $path;
   symlink( '/bin/echo', "$path$tail" ) or die $!;
   $s = run "$path$tail $parm";
-  like( $s, qr(^$parm), qq($path$tail $parm didn't work) );
+  like( $s, qr{^$parm}sxm, qq($path$tail $parm didn't work) );
 
   $s = run "$path$tail /$parm";
-  like( $s, qr($path), "/slash on parms and the comand didn't fail?" );
+  like( $s, qr{$path}sxm, "/slash on parms and the comand didn't fail?" );
 
   $s = run qq("$path$tail" /$parm);
-  like( $s, qr(^/$parm), "Quoted command failed" );
+  like( $s, qr{^/$parm}sxm, "Quoted command failed" );
 
   unlink $path . $tail;
   rmdir $path;

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -10,17 +10,22 @@ SKIP: {
   my $path = '/tmp/inexistent path with spaces/';
   my $tail = 'hello';
   my $parm = 'hello Rex';
-  my $s = run "$path$tail";
-  like( $s, qr/$path/, "The inexistent path or file is not reported correctly" );
+  my $s    = run "$path$tail";
+  like( $s, qr/$path/,
+    "The inexistent path or file is not reported correctly" );
+
   mkdir $path;
-  symlink( '/bin/echo',"$path$tail" ) or die $!;
+  symlink( '/bin/echo', "$path$tail" ) or die $!;
   $s = run "$path$tail $parm";
   like( $s, qr/^$parm/, "`$path$tail $parm` didn't work" );
+
   $s = run "$path$tail /$parm";
-  like( $s,qr/$path/,"/slash on parms and the comand didn't fail?");
+  like( $s, qr/$path/, "/slash on parms and the comand didn't fail?" );
+
   $s = run "\"$path$tail\" /$parm";
-  like($s,qr|^/$parm|,"Quotend command failed");
-  unlink $path.$tail;
+  like( $s, qr|^/$parm|, "Quotend command failed" );
+
+  unlink $path . $tail;
   rmdir $path;
 
 }

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -12,7 +12,7 @@ ok( !-e $path, qq("$path" not exists) );
 my $tail      = 'hello';
 my $parm      = 'Rex';
 my $s         = run "$path$tail $parm";
-my $notExists = ($win and !-e $path) ? $s : qq{$path$tail};
+my $notExists = ( $win and !-e $path ) ? $s : qq{$path$tail};
 
 like( $s, qr{$notExists}sm,
   qq{windows dont return "$path/$tail" on the message} );
@@ -40,6 +40,6 @@ like( $s, qr{$parm}sm, "/slash on parms and the comand didn't fail?" );
 $s = run qq("$path$tail" /$parm);
 like( $s, qr{/$parm}sm, "Quoted commands pass" );
 
-unlink "$path$tail" . ($win?q{.bat}:q{});
+unlink "$path$tail" . ( $win ? q{.bat} : q{} );
 rmdir $path;
 

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -17,13 +17,13 @@ SKIP: {
   mkdir $path;
   symlink( '/bin/echo', "$path$tail" ) or die $!;
   $s = run "$path$tail $parm";
-  like( $s, qr/^$parm/, "`$path$tail $parm` didn't work" );
+  like( $s, qr(^$parm), qq($path$tail $parm didn't work) );
 
   $s = run "$path$tail /$parm";
-  like( $s, qr/$path/, "/slash on parms and the comand didn't fail?" );
+  like( $s, qr($path), "/slash on parms and the comand didn't fail?" );
 
-  $s = run "\"$path$tail\" /$parm";
-  like( $s, qr|^/$parm|, "Quotend command failed" );
+  $s = run qq("$path$tail" /$parm);
+  like( $s, qr(^/$parm), "Quoted command failed" );
 
   unlink $path . $tail;
   rmdir $path;

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -1,4 +1,8 @@
+use strict;
+use warnings;
 use 5.010;
+use autodie;
+use English qw($OSNAME -no_match_vars);
 
 use Test::More tests => 7;
 
@@ -6,26 +10,29 @@ use Rex::Commands::Run;
 
 $::QUIET = 1;
 
-my $win = $^O =~ m/^MSWin/mxsi;
+my $win = $OSNAME =~ m/^MSWin/mxsi;
 
 my $path = './inexistent path with spaces/';
 ok( !-e $path, qq{"$path" not exists} );
 
-my $tail      = 'hello';
-my $parm      = 'Rex is wonderfull';
-my $s         = run qq{$path$tail $parm};
-my $notExists = ( $win and !-e $path ) ? $s : qq{$path$tail};
+my $tail       = 'hello';
+my $parm       = 'Rex is wonderfull';
+my $t_cmd      = qq{$path$tail $parm};
+my $s          = run $t_cmd;
+my $not_exists = ( $win && !-e $path ) ? $s : qq{$path$tail};
 
-like( $s, qr{$notExists}sm,
-  qq{windows dont return "$path/$tail" on the message} );
+like( $s, qr{(?-x:$not_exists)}smx,
+  qq{windows dont return "$path$tail" on the message} );
 
 ok( mkdir($path), qq{creating "$path"} );
+my $cmd = $path . $tail;
 
 if ($win) {
 
   #On windows we create hello.bat contaning echo %1
-  open my $hello, '>', qq{$path$tail.bat};
-  print $hello "echo %*\n";
+  $cmd .= q{bat};
+  open my $hello, '>', $cmd;
+  print {$hello} "echo %*\n";
   close $hello;
 }
 else {
@@ -34,30 +41,32 @@ else {
   if ( !-X $echo ) {
     substr $echo, 0, 0, q{/usr};
   }
-  symlink $echo, qq{$path$tail};
+  symlink $echo, $cmd;
 }
 
-$s = run qq{$path$tail $parm};
-like( $s, qr{$parm}sm, qq{"$path$tail $parm"  ok} );
+my $result = qr{(?-x:$parm)}smx;
+
+$s = run $t_cmd;
+like( $s, $result, qq{"$t_cmd"  ok} );
 
 $s = run qq{$path$tail /$parm};
-like( $s, qr{$parm}sm, '/slash on parms ok' );
+like( $s, $result, '/slash on parms ok' );
 
 $s = run qq{"$path$tail" $parm};
-like( $s, qr{$parm}sm, "Quoted commands ok" );
+like( $s, $result, 'Quoted commands ok' );
 my $mpath = $path;
 
 if ($win) {
   $mpath =~ s{/}{\\}gsmx;
   $s = run qq{$mpath$tail $parm};
-  like( $s, qr{$parm}sm, "($mpath$tail $parm) windows path ok" );
+  like( $s, $result, "($mpath$tail $parm) windows path ok" );
 }
 else {
   $mpath =~ s{(\s)}{\\$1}gsmx;
-  $s = run qq{$mpath$tail $parm};
-  like( $s, qr{$parm}sm, "($mpath$tail $parm) back slash escapes ok" );
+  $mpath .= $tail;
+  $s = run qq{$mpath $parm};
+  like( $s, $result, "($mpath $parm) back slash escapes ok" );
 }
 
-unlink "$path$tail" . ( $win ? q{.bat} : q{} );
+unlink $cmd;
 rmdir $path;
-

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -1,4 +1,4 @@
-use Test::More tests => 6;
+use Test::More tests => 7;
 
 use Rex::Commands::Run;
 
@@ -10,7 +10,7 @@ my $path = './inexistent path with spaces/';
 ok( !-e $path, qq("$path" not exists) );
 
 my $tail      = 'hello';
-my $parm      = 'Rex';
+my $parm      = 'Rex is wonderfull';
 my $s         = run "$path$tail $parm";
 my $notExists = ( $win and !-e $path ) ? $s : qq{$path$tail};
 
@@ -23,7 +23,7 @@ if ($win) {
 
   #On windows we create hello.bat contaning echo %1
   open my $hello, '>', qq{$path$tail.bat};
-  print $hello "echo %1\n";
+  print $hello "echo %*\n";
   close $hello;
 }
 else {
@@ -37,8 +37,20 @@ like( $s, qr{$parm}sm, qq{$path$tail $parm didn't work} );
 $s = run "$path$tail /$parm";
 like( $s, qr{$parm}sm, "/slash on parms and the comand didn't fail?" );
 
-$s = run qq("$path$tail" /$parm);
-like( $s, qr{/$parm}sm, "Quoted commands pass" );
+$s = run qq("$path$tail" $parm);
+like( $s, qr{$parm}sm, "Quoted commands pass" );
+my $mpath = $path;
+
+if ($win) {
+  $mpath =~ s{/}{\\}gsmx;
+  $s = run qq($mpath$tail $parm);
+  like( $s, qr{$parm}sm, "($mpath$tail $parm) windows format pass" );
+}
+else {
+  $mpath =~ s{(\s)}{\\$1}gsmx;
+  $s = run qq($mpath$tail $parm);
+  like( $s, qr{$parm}sm, "($mpath$tail $parm) scaped espaces pass" );
+}
 
 unlink "$path$tail" . ( $win ? q{.bat} : q{} );
 rmdir $path;

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -15,7 +15,7 @@ SKIP: {
     "The inexistent path or file is not reported correctly" );
 
   mkdir $path;
-  symlink( '/bin/echo', "$path$tail" ) or die $!;
+  symlink( '/bin/echo', "$path$tail" );
   $s = run "$path$tail $parm";
   like( $s, qr{^$parm}sxm, qq($path$tail $parm didn't work) );
 

--- a/t/issue/1401.t
+++ b/t/issue/1401.t
@@ -1,0 +1,26 @@
+use Test::More tests => 4;
+
+use Rex::Commands::Run;
+
+$::QUIET = 1;
+
+SKIP: {
+  skip 'Do not run tests on Windows', 4 if $^O =~ m/^MSWin/i;
+
+  my $path = '/tmp/inexistent path with spaces/';
+  my $tail = 'hello';
+  my $parm = 'hello Rex';
+  my $s = run "$path$tail";
+  like( $s, qr/$path/, "The inexistent path or file is not reported correctly" );
+  mkdir $path;
+  symlink( '/bin/echo',"$path$tail" ) or die $!;
+  $s = run "$path$tail $parm";
+  like( $s, qr/^$parm/, "`$path$tail $parm` didn't work" );
+  $s = run "$path$tail /$parm";
+  like( $s,qr/$path/,"/slash on parms and the comand didn't fail?");
+  $s = run "\"$path$tail\" /$parm";
+  like($s,qr|^/$parm|,"Quotend command failed");
+  unlink $path.$tail;
+  rmdir $path;
+
+}


### PR DESCRIPTION
This PR solves the issue #1401 on commands with explicit paths *nix stile.

The added code only acts on  commands that start with "/", "./", "../" or "~/"
it quotes with '"' from the start of the command to the first space after the last slash.
Command strings like '/bin/ls /etc/host /etc/hostname' will fail unless the command is  properly quoted or preceded with an space or an envirment variable assinament but I think it will resolve most of the cases

---

EDIT by @ferki:

Let's add this section to follow the original PR template which helps to track the state of the PR:

This PR is an attempt to fix #1401 by finding the longest path prefix of commands passed to `run`, and then quoting them.

## Checklist

- [ ] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [ ] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [ ] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [ ] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [ ] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)