### PR TITLE
Fix MD5 checksumming when multiple perls are available

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,8 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix MD5 checksumming when default perl does not have Digest::MD5 or
+ incompatible with the perl running rex
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Commands/MD5.pm
+++ b/lib/Rex/Commands/MD5.pm
@@ -38,6 +38,7 @@ use Rex::Interface::File;
 use Rex::Interface::Fs;
 use Rex::Helper::Path;
 use Rex::Helper::Run;
+use English qw(-no_match_vars);
 
 require Rex::Exporter;
 use base qw(Rex::Exporter);
@@ -86,10 +87,12 @@ sub _digest_md5 {
   my $file = shift;
   my $md5;
 
+  my $perl = Rex::is_local() ? $EXECUTABLE_NAME : 'perl';
+
   my $command =
     ( $^O =~ m/^MSWin/i && Rex::is_local() )
-    ? qq(perl -MDigest::MD5 -e "open my \$fh, '<', \$ARGV[0] or die 'Cannot open ' . \$ARGV[0]; binmode \$fh; print Digest::MD5->new->addfile(\$fh)->hexdigest;" "$file")
-    : qq(perl -MDigest::MD5 -e 'open my \$fh, "<", \$ARGV[0] or die "Cannot open " . \$ARGV[0]; binmode \$fh; print Digest::MD5->new->addfile(\$fh)->hexdigest;' '$file');
+    ? qq("$perl" -MDigest::MD5 -e "open my \$fh, '<', \$ARGV[0] or die 'Cannot open ' . \$ARGV[0]; binmode \$fh; print Digest::MD5->new->addfile(\$fh)->hexdigest;" "$file")
+    : qq('$perl' -MDigest::MD5 -e 'open my \$fh, "<", \$ARGV[0] or die "Cannot open " . \$ARGV[0]; binmode \$fh; print Digest::MD5->new->addfile(\$fh)->hexdigest;' '$file');
 
   my $result = i_run( $command, fail_ok => 1 );
 

--- a/t/md5.t
+++ b/t/md5.t
@@ -15,23 +15,20 @@ my ( $fh, $test_file ) = tempfile(
 print $fh "\x00";
 close($fh);
 
-is( md5($test_file), '93b885adfe0da089cdf634904fd59f71', 'MD5 checksum OK' );
+my $expected_checksum = '93b885adfe0da089cdf634904fd59f71';
+
+is( md5($test_file), $expected_checksum, 'MD5 checksum OK' );
 
 # test internal interfaces
 
-is(
-  Rex::Commands::MD5::_digest_md5($test_file),
-  '93b885adfe0da089cdf634904fd59f71',
-  'MD5 checksum OK via Digest::MD5'
-);
+is( Rex::Commands::MD5::_digest_md5($test_file),
+  $expected_checksum, 'MD5 checksum OK via Digest::MD5' );
 
 SKIP: {
-  skip 'No MD5 binary seems to be available', 1
-    if !defined Rex::Commands::MD5::_binary_md5($test_file);
+  my $checksum_via_binary = Rex::Commands::MD5::_binary_md5($test_file);
 
-  is(
-    Rex::Commands::MD5::_binary_md5($test_file),
-    '93b885adfe0da089cdf634904fd59f71',
-    'MD5 checksum OK via binary'
-  );
+  skip 'No MD5 binary seems to be available', 1
+    if !defined $checksum_via_binary;
+
+  is( $checksum_via_binary, $expected_checksum, 'MD5 checksum OK via binary' );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1440 by making sure that the perl executable that is used for MD5 checksum calculation locally is the same perl that is used to run rex in the first place.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)