### PR TITLE
Fix macro parsing in CMDB paths

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -1,2 +1,5 @@
 severity = brutal
 [-CodeLayout::RequireTidyCode]
+
+[Subroutines::ProhibitUnusedPrivateSubroutines]
+private_name_regex = _(?!_)\w+

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix CMDB hostname when Rex is being run locally
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,7 @@ Revision history for Rex
  - Fix replacing hostname macro in CMDB paths
  - Fix host information gathering on Windows
  - Fix hostname detection on Windows
+ - Fix CMDB path separators on Windows
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Fix CMDB hostname when Rex is being run locally
+ - Fix replacing hostname macro in CMDB paths
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Fix CMDB hostname when Rex is being run locally
  - Fix replacing hostname macro in CMDB paths
+ - Fix host information gathering on Windows
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Revision history for Rex
  - Fix CMDB hostname when Rex is being run locally
  - Fix replacing hostname macro in CMDB paths
  - Fix host information gathering on Windows
+ - Fix hostname detection on Windows
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -16,6 +16,7 @@ Revision history for Rex
  [NEW FEATURES]
 
  [REVISION]
+ - Add initial CMDB path tests
 
 1.13.0.1-TRIAL 2020-10-13 Ferenc Erki <erkiferenc@gmail.com>
  [BUG FIXES]

--- a/lib/Rex/CMDB.pm
+++ b/lib/Rex/CMDB.pm
@@ -148,9 +148,10 @@ Function to query a CMDB. If this function is called without $item it should ret
 
 sub cmdb {
   my ( $item, $server ) = @_;
-  $server ||= connection->server;
 
   return if !cmdb_active();
+
+  $server = $CMDB_PROVIDER->__get_hostname_for($server);
 
   my $value;
   my $cache     = Rex::get_cache();

--- a/lib/Rex/CMDB/Base.pm
+++ b/lib/Rex/CMDB/Base.pm
@@ -26,9 +26,9 @@ sub new {
 }
 
 sub _parse_path {
-  my ( $self, $path ) = @_;
+  my ( $self, $path, $mapping ) = @_;
 
-  return parse_path($path);
+  return parse_path( $path, $mapping );
 }
 
 sub __get_hostname_for {

--- a/lib/Rex/CMDB/Base.pm
+++ b/lib/Rex/CMDB/Base.pm
@@ -14,6 +14,7 @@ our $VERSION = '9999.99.99_99'; # VERSION
 
 use Rex::Helper::Path;
 use Rex::Hardware;
+use Rex::Hardware::Host;
 
 sub new {
   my $that  = shift;

--- a/lib/Rex/CMDB/Base.pm
+++ b/lib/Rex/CMDB/Base.pm
@@ -13,6 +13,7 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Rex::Helper::Path;
+use Rex::Hardware;
 
 sub new {
   my $that  = shift;
@@ -28,6 +29,19 @@ sub _parse_path {
   my ( $self, $path ) = @_;
 
   return parse_path($path);
+}
+
+sub __get_hostname_for {
+  my ( $self, $server ) = @_;
+
+  my $hostname = $server // Rex::get_current_connection()->{conn}->server->to_s;
+
+  if ( $hostname eq '<local>' ) {
+    my %hw_info = Rex::Hardware->get('Host');
+    $hostname = $hw_info{Host}{hostname};
+  }
+
+  return $hostname;
 }
 
 1;

--- a/lib/Rex/CMDB/YAML.pm
+++ b/lib/Rex/CMDB/YAML.pm
@@ -127,7 +127,7 @@ sub _get_cmdb_files {
     @files = @{ $self->{path} };
   }
 
-  @files = map { $self->_parse_path($_) } @files;
+  @files = map { $self->_parse_path( $_, { hostname => $server } ) } @files;
 
   return @files;
 }

--- a/lib/Rex/CMDB/YAML.pm
+++ b/lib/Rex/CMDB/YAML.pm
@@ -108,7 +108,7 @@ sub get {
 sub _get_cmdb_files {
   my ( $self, $item, $server ) = @_;
 
-  $server //= Rex::get_current_connection()->{conn}->server->to_s;
+  $server = $self->__get_hostname_for($server);
 
   my @files;
 

--- a/lib/Rex/CMDB/YAML.pm
+++ b/lib/Rex/CMDB/YAML.pm
@@ -130,7 +130,11 @@ sub _get_cmdb_files {
     @files = @{ $self->{path} };
   }
 
-  @files = map { $self->_parse_path( $_, { hostname => $server } ) } @files;
+  my $os = Rex::Hardware::Host->get_operating_system();
+
+  @files = map {
+    $self->_parse_path( $_, { hostname => $server, operatingsystem => $os, } )
+  } @files;
 
   return @files;
 }

--- a/lib/Rex/CMDB/YAML.pm
+++ b/lib/Rex/CMDB/YAML.pm
@@ -113,11 +113,14 @@ sub _get_cmdb_files {
   my @files;
 
   if ( !ref $self->{path} ) {
-    my $env       = Rex::Commands::environment();
-    my $yaml_path = $self->{path};
+    my $env          = Rex::Commands::environment();
+    my $server_file  = "$server.yml";
+    my $default_file = 'default.yml';
     @files = (
-      "$yaml_path/$env/$server.yml", "$yaml_path/$env/default.yml",
-      "$yaml_path/$server.yml",      "$yaml_path/default.yml"
+      File::Spec->join( $self->{path}, $env, $server_file ),
+      File::Spec->join( $self->{path}, $env, $default_file ),
+      File::Spec->join( $self->{path}, $server_file ),
+      File::Spec->join( $self->{path}, $default_file ),
     );
   }
   elsif ( ref $self->{path} eq "CODE" ) {

--- a/lib/Rex/Hardware/Host.pm
+++ b/lib/Rex/Hardware/Host.pm
@@ -38,11 +38,9 @@ sub get {
 
   my ( $domain, $hostname );
   if ( $os eq "Windows" ) {
-    my @env = i_run("env");
-    ($hostname) =
-      map { /^COMPUTERNAME=(.*)$/ } split( /\r?\n/, @env );
-    ($domain) =
-      map { /^USERDOMAIN=(.*)$/ } split( /\r?\n/, @env );
+    my @env = i_run('set');
+    ($hostname) = map { /^COMPUTERNAME=(.*)$/ } @env;
+    ($domain)   = map { /^USERDOMAIN=(.*)$/ } @env;
   }
   elsif ( $os eq "NetBSD" || $os eq "OpenBSD" || $os eq 'FreeBSD' ) {
     ( $hostname, $domain ) =

--- a/lib/Rex/Hardware/Host.pm
+++ b/lib/Rex/Hardware/Host.pm
@@ -32,70 +32,71 @@ sub get {
     return $cache->get($cache_key_name);
   }
 
-  if ( Rex::is_ssh || $^O !~ m/^MSWin/i ) {
+  my $bios = Rex::Inventory::Bios::get();
 
-    my $bios = Rex::Inventory::Bios::get();
+  my $os = get_operating_system();
 
-    my $os = get_operating_system();
-
-    my ( $domain, $hostname );
-    if ( $os eq "Windows" ) {
-      my @env = i_run("env");
-      ($hostname) =
-        map { /^COMPUTERNAME=(.*)$/ } split( /\r?\n/, @env );
-      ($domain) =
-        map { /^USERDOMAIN=(.*)$/ } split( /\r?\n/, @env );
-    }
-    elsif ( $os eq "NetBSD" || $os eq "OpenBSD" || $os eq 'FreeBSD' ) {
-      ( $hostname, $domain ) =
-        split( /\./, ( eval { i_run("hostname") } || "unknown.nodomain" ), 2 );
-    }
-    elsif ( $os eq "SunOS" ) {
-      ($hostname) =
-        map { /^([^\.]+)$/ } ( eval { i_run("hostname"); } || "unknown" );
-      ($domain) = eval { i_run("domainname"); } || ("nodomain");
-    }
-    elsif ( $os eq "OpenWrt" ) {
-      ($hostname) = eval { i_run("uname -n"); } || ("unknown");
-      ($domain) =
-        eval { i_run("cat /proc/sys/kernel/domainname"); } || ("unknown");
-    }
-    else {
-      my @out = i_run "hostname -f 2>/dev/null", fail_ok => 1;
-
-      if ( $? == 0 ) {
-        ( $hostname, $domain ) = split( /\./, $out[0], 2 );
-      }
-      else {
-        Rex::Logger::debug(
-          "Error getting hostname and domainname. There is something wrong with your /etc/hosts file."
-        );
-        ($hostname) = eval { i_run("hostname -s"); } || ("unknown");
-        ($domain)   = eval { i_run("hostname -d"); } || ("nodomain");
-      }
-    }
-
-    my $data = {
-
-      manufacturer => $bios->get_system_information()->get_manufacturer() || "",
-      hostname     => $hostname                                           || "",
-      domain       => $domain                                             || "",
-      operatingsystem          => $os                                     || "",
-      operating_system         => $os                                     || "",
-      operatingsystemrelease   => get_operating_system_version(),
-      operating_system_release => get_operating_system_version(),
-      kernelname               => [ i_run "uname -s" ]->[0],
-
-    };
-
-    $cache->set( $cache_key_name, $data );
-
-    return $data;
-
+  my ( $domain, $hostname );
+  if ( $os eq "Windows" ) {
+    my @env = i_run("env");
+    ($hostname) =
+      map { /^COMPUTERNAME=(.*)$/ } split( /\r?\n/, @env );
+    ($domain) =
+      map { /^USERDOMAIN=(.*)$/ } split( /\r?\n/, @env );
+  }
+  elsif ( $os eq "NetBSD" || $os eq "OpenBSD" || $os eq 'FreeBSD' ) {
+    ( $hostname, $domain ) =
+      split( /\./, ( eval { i_run("hostname") } || "unknown.nodomain" ), 2 );
+  }
+  elsif ( $os eq "SunOS" ) {
+    ($hostname) =
+      map { /^([^\.]+)$/ } ( eval { i_run("hostname"); } || "unknown" );
+    ($domain) = eval { i_run("domainname"); } || ("nodomain");
+  }
+  elsif ( $os eq "OpenWrt" ) {
+    ($hostname) = eval { i_run("uname -n"); } || ("unknown");
+    ($domain) =
+      eval { i_run("cat /proc/sys/kernel/domainname"); } || ("unknown");
   }
   else {
-    return { operatingsystem => $^O, };
+    my @out = i_run "hostname -f 2>/dev/null", fail_ok => 1;
+
+    if ( $? == 0 ) {
+      ( $hostname, $domain ) = split( /\./, $out[0], 2 );
+    }
+    else {
+      Rex::Logger::debug(
+        "Error getting hostname and domainname. There is something wrong with your /etc/hosts file."
+      );
+      ($hostname) = eval { i_run("hostname -s"); } || ("unknown");
+      ($domain)   = eval { i_run("hostname -d"); } || ("nodomain");
+    }
   }
+
+  my $kernelname = q();
+
+  if ( can_run('uname') ) {
+    $kernelname = i_run 'uname -s';
+  }
+
+  my $operating_system_version = get_operating_system_version();
+
+  my $data = {
+
+    manufacturer => $bios->get_system_information()->get_manufacturer() || "",
+    hostname     => $hostname                                           || "",
+    domain       => $domain                                             || "",
+    operatingsystem          => $os                                     || "",
+    operating_system         => $os                                     || "",
+    operatingsystemrelease   => $operating_system_version,
+    operating_system_release => $operating_system_version,
+    kernelname               => $kernelname,
+
+  };
+
+  $cache->set( $cache_key_name, $data );
+
+  return $data;
 
 }
 
@@ -334,6 +335,9 @@ sub get_operating_system_version {
     else {
       return "outdated";
     }
+  }
+  elsif ( $op eq 'Windows' ) {
+    return i_run 'ver';
   }
 
   return [ i_run("uname -r") ]->[0];

--- a/lib/Rex/Helper/Path.pm
+++ b/lib/Rex/Helper/Path.pm
@@ -215,25 +215,37 @@ sub resolv_path {
 }
 
 sub parse_path {
-  my ($path) = @_;
-  my %hw;
+  my ($path_with_macro) = @_;
+  my $replacement_for = {};
 
-  require Rex::Commands::Gather;
+  my $replace_macros = sub {
+    my ( $path, $substitution_for ) = @_;
 
-  $hw{server}      = Rex::Commands::connection()->server;
-  $hw{environment} = Rex::Commands::environment();
+    my $macro = join q(|), keys %{$substitution_for};
 
-  $path =~ s/\{(server|environment)\}/$hw{$1}/gms;
+    ( my $substitution = $path ) =~ s/{($macro)}/$substitution_for->{$1}/gmsx;
 
-  if ( $path =~ m/\{([^\}]+)\}/ ) {
+    return $substitution;
+  };
 
-    # if there are still some variables to replace, we need some information of
-    # the system.
-    %hw = Rex::Commands::Gather::get_system_information();
-    $path =~ s/\{([^\}]+)\}/$hw{$1}/gms;
+  $replacement_for->{server}      //= Rex::Commands::connection()->server;
+  $replacement_for->{environment} //= Rex::Commands::environment();
+
+  my $replacement_path =
+    $replace_macros->( $path_with_macro, $replacement_for );
+
+  if ( $replacement_path =~ m/\{([^\}]+)\}/ ) {
+
+    # if there are still some macros to replace, we need some
+    # information of the system
+
+    require Rex::Commands::Gather;
+    my %hw = Rex::Commands::Gather::get_system_information();
+
+    $replacement_path = $replace_macros->( $replacement_path, \%hw );
   }
 
-  return $path;
+  return $replacement_path;
 }
 
 sub resolve_symlink {

--- a/lib/Rex/Helper/Path.pm
+++ b/lib/Rex/Helper/Path.pm
@@ -215,8 +215,7 @@ sub resolv_path {
 }
 
 sub parse_path {
-  my ($path_with_macro) = @_;
-  my $replacement_for = {};
+  my ( $path_with_macro, $replacement_for ) = @_;
 
   my $replace_macros = sub {
     my ( $path, $substitution_for ) = @_;

--- a/t/cmdb.t
+++ b/t/cmdb.t
@@ -1,114 +1,134 @@
+#!/usr/bin/env perl
+
+use 5.006;
 use strict;
 use warnings;
 
+our $VERSION = '9999.99.99_99'; # VERSION
+
 use Test::More tests => 2;
 
+use Cwd qw(realpath);
+use File::Spec;
 use Rex::CMDB;
 use Rex::Commands;
 use Rex::Commands::File;
+use Test::Deep qw(cmp_deeply);
+
+my $cmdb_type = 'YAML';
+my $cmdb_path = realpath( File::Spec->join( 't', 'cmdb' ) );
 
 foreach my $caching (qw(0 1)) {
   my $setting = $caching ? 'enabled' : 'disabled';
 
+  my $server = 'foo';
+
+  my $expected_all = {
+    ntp                 => [qw(ntp1 ntp2)],
+    newntp              => [qw(ntpdefaultfoo01 ntpdefaultfoo02)],
+    dns                 => [qw(1.1.1.1 2.2.2.2)],
+    'MyTest::foo::mode' => '0666',
+    vhost               => {
+      name     => 'foohost',
+      doc_root => '/var/www',
+    },
+    name   => $server,
+    vhost2 => {
+      name     => 'vhost2foo',
+      doc_root => '/var/www',
+    },
+    users => {
+      root => {
+        password => 'proot',
+        id       => '0',
+      },
+      user02 => {
+        password => 'puser02',
+        id       => '600',
+      },
+      user01 => {
+        password => 'puser01',
+        id       => '500',
+      },
+    },
+  };
+
   subtest "Caching ${setting}" => sub {
-    plan tests => 13;
+    plan tests => 5;
 
     Rex::Config->set_use_cache($caching);
 
     set(
       cmdb => {
-        type => "YAML",
-        path => "t/cmdb",
-      }
-    );
-
-    my $ntp = get( cmdb( "ntp", "foo" ) );
-    ok( $ntp->[0] eq "ntp1" && $ntp->[1] eq "ntp2",
-      "got something from default.yml" );
-
-    my $name = get( cmdb( "name", "foo" ) );
-    is( $name, "foo", "got name from foo.yml" );
-
-    my $dns = get( cmdb( "dns", "foo" ) );
-    ok( $dns->[0] eq "1.1.1.1" && $dns->[1] eq "2.2.2.2",
-      "got dns from env/default.yml" );
-
-    my $vhost = get( cmdb( "vhost", "foo" ) );
-    ok( $vhost->{name} eq "foohost" && $vhost->{doc_root} eq "/var/www",
-      "got vhost from env/foo.yml" );
-
-    $ntp = undef;
-    $ntp = get( cmdb("ntp") );
-    ok( $ntp->[0] eq "ntp1" && $ntp->[1] eq "ntp2",
-      "got something from default.yml" );
-
-    $dns = undef;
-    $dns = get( cmdb("dns") );
-    ok( $dns->[0] eq "1.1.1.1" && $dns->[1] eq "2.2.2.2",
-      "got dns from env/default.yml" );
-
-    my $all = get( cmdb( undef, "foo" ) );
-    is( $all->{ntp}->[0], "ntp1",    "got ntp1 from cmdb - all request" );
-    is( $all->{dns}->[1], "2.2.2.2", "got dns2 from cmdb - all request" );
-    is( $all->{vhost}->{name},
-      "foohost", "got vhost name from cmdb - all request" );
-    is( $all->{name}, "foo", "got name from cmdb - all request" );
-
-    Rex::Config->set_register_cmdb_template(1);
-    my $content = 'Hello this is <%= $::name %>';
-    is(
-      template( \$content, __no_sys_info__ => 1 ),
-      "Hello this is defaultname",
-      "get keys from CMDB"
-    );
-
-    is(
-      template( \$content, { name => "baz", __no_sys_info__ => 1 } ),
-      "Hello this is baz",
-      "overwrite keys from CMDB"
-    );
-
-    set(
-      cmdb => {
-        type           => "YAML",
-        path           => "t/cmdb",
-        merge_behavior => 'LEFT_PRECEDENT',
-      }
-    );
-
-    my $foo_all = get( cmdb( undef, "foo" ) );
-    is_deeply(
-      $foo_all,
-      {
-        'ntp'    => [ 'ntp1',            'ntp2' ],
-        'newntp' => [ 'ntpdefaultfoo01', 'ntpdefaultfoo02', 'ntp1', 'ntp2' ],
-        'dns'    => [ '1.1.1.1',         '2.2.2.2' ],
-        'MyTest::foo::mode' => '0666',
-        'vhost'             => {
-          'name'     => 'foohost',
-          'doc_root' => '/var/www'
-        },
-        'name'   => 'foo',
-        'vhost2' => {
-          'name'     => 'vhost2foo',
-          'doc_root' => '/var/www'
-        },
-        'users' => {
-          'root' => {
-            'password' => 'proot',
-            'id'       => '0'
-          },
-          'user02' => {
-            'password' => 'puser02',
-            'id'       => '600'
-          },
-          'user01' => {
-            'password' => 'puser01',
-            'id'       => '500'
-          }
-        }
+        type => $cmdb_type,
+        path => $cmdb_path,
       },
-      "DeepMerge CMDB"
     );
-  }
+
+    subtest 'getting item for server foo' => sub {
+      my $ntp = get( cmdb( 'ntp', $server ) );
+      cmp_deeply( $ntp, [qw(ntp1 ntp2)],
+        'arrayref server item from default.yml' );
+
+      my $name = get( cmdb( 'name', $server ) );
+      is( $name, $server, 'scalar server item from foo.yml' );
+
+      my $dns = get( cmdb( 'dns', $server ) );
+      cmp_deeply( $dns, [qw(1.1.1.1 2.2.2.2)],
+        'arrayref server item from env/default.yml' );
+
+      my $vhost = get( cmdb( 'vhost', $server ) );
+      cmp_deeply(
+        $vhost,
+        { name => 'foohost', doc_root => '/var/www', },
+        'hashref server item from env/foo.yml'
+      );
+    };
+
+    subtest 'getting item' => sub {
+      my $ntp = get( cmdb('ntp') );
+      cmp_deeply( $ntp, [qw(ntp1 ntp2)], 'arrayref item from default.yml' );
+
+      my $dns = get( cmdb('dns') );
+      cmp_deeply( $dns, [qw(1.1.1.1 2.2.2.2)],
+        'arrayref item from env/default.yml' );
+    };
+
+    subtest 'getting server' => sub {
+      my $all = get( cmdb( undef, $server ) );
+      cmp_deeply( $all, $expected_all, 'combined CMDB for server foo' );
+    };
+
+    subtest 'CMDB variables in templates' => sub {
+      Rex::Config->set_register_cmdb_template(1);
+
+      my $content = 'Hello this is <%= $::name %>';
+
+      is(
+        template( \$content, __no_sys_info__ => 1 ),
+        'Hello this is defaultname',
+        'get keys from CMDB'
+      );
+
+      is(
+        template( \$content, { name => 'baz', __no_sys_info__ => 1 } ),
+        'Hello this is baz',
+        'overwrite keys from CMDB'
+      );
+    };
+
+    subtest 'CMDB merging strategy' => sub {
+      set(
+        cmdb => {
+          type           => $cmdb_type,
+          path           => $cmdb_path,
+          merge_behavior => 'LEFT_PRECEDENT',
+        },
+      );
+
+      my $foo_all = get( cmdb( undef, $server ) );
+      $expected_all->{newntp} = [qw(ntpdefaultfoo01 ntpdefaultfoo02 ntp1 ntp2)];
+      cmp_deeply( $foo_all, $expected_all, 'DeepMerge CMDB' );
+    };
+  };
 }

--- a/t/cmdb_path.t
+++ b/t/cmdb_path.t
@@ -1,0 +1,120 @@
+#!/usr/bin/env perl
+
+use 5.010;
+use strict;
+use warnings;
+
+our $VERSION = '9999.99.99_99'; # VERSION
+
+use Test::More tests => 3;
+
+use Cwd qw(realpath);
+use File::Spec;
+use Rex::CMDB;
+use Rex::Commands;
+use Rex::Hardware;
+use Test::Deep qw(cmp_deeply);
+
+my $cmdb_path           = realpath( File::Spec->join( 't', 'cmdb' ) );
+my %hw_info             = Rex::Hardware->get('Host');
+my $os                  = Rex::Hardware::Host->get_operating_system();
+my $environment         = environment;
+my @test_servers        = ( undef, 'foo' );
+my $cmdb_type           = 'YAML';
+my $host_macro_filename = '{hostname}.yml';
+my $default_filename    = 'default.yml';
+
+sub get_host_filename {
+  my $server   = shift;
+  my $hostname = $server // $hw_info{Host}{hostname};
+  return ( $hostname, "$hostname.yml" );
+}
+
+subtest 'Set CMDB path as scalar' => sub {
+  my $cmdb_provider = set(
+    cmdb => {
+      type => $cmdb_type,
+      path => $cmdb_path,
+    },
+  );
+
+  for my $server (@test_servers) {
+    my ( $hostname, $host_filename ) = get_host_filename($server);
+
+    my @cmdb_files     = $cmdb_provider->_get_cmdb_files( undef, $server );
+    my @expected_files = (
+      File::Spec->join( $cmdb_path, $environment, $host_filename ),
+      File::Spec->join( $cmdb_path, $environment, $default_filename ),
+      File::Spec->join( $cmdb_path, $host_filename ),
+      File::Spec->join( $cmdb_path, $default_filename ),
+    );
+
+    cmp_deeply( \@cmdb_files, \@expected_files,
+      "scalar CMDB path for $hostname" );
+  }
+};
+
+subtest 'Set CMDB path as array reference' => sub {
+  my $os_macro  = '{operatingsystem}';
+  my $env_macro = '{environment}';
+
+  my $cmdb_provider = set(
+    cmdb => {
+      type => $cmdb_type,
+      path => [
+        File::Spec->join( $cmdb_path, $os_macro,  $host_macro_filename ),
+        File::Spec->join( $cmdb_path, $os_macro,  $default_filename ),
+        File::Spec->join( $cmdb_path, $env_macro, $host_macro_filename ),
+        File::Spec->join( $cmdb_path, $env_macro, $default_filename ),
+        File::Spec->join( $cmdb_path, $host_macro_filename ),
+        File::Spec->join( $cmdb_path, $default_filename ),
+      ],
+    },
+  );
+
+  for my $server (@test_servers) {
+    my ( $hostname, $host_filename ) = get_host_filename($server);
+
+    my @cmdb_files     = $cmdb_provider->_get_cmdb_files( undef, $server );
+    my @expected_files = (
+      File::Spec->join( $cmdb_path, $os,          $host_filename ),
+      File::Spec->join( $cmdb_path, $os,          $default_filename ),
+      File::Spec->join( $cmdb_path, $environment, $host_filename ),
+      File::Spec->join( $cmdb_path, $environment, $default_filename ),
+      File::Spec->join( $cmdb_path, $host_filename ),
+      File::Spec->join( $cmdb_path, $default_filename ),
+    );
+
+    cmp_deeply( \@cmdb_files, \@expected_files,
+      "arrayref CMDB path for $hostname" );
+  }
+};
+
+subtest 'Set CMDB path as code reference' => sub {
+  my $cmdb_provider = set(
+    cmdb => {
+      type => $cmdb_type,
+      path => sub {
+        my ( $provider, $item, $server ) = @_;
+        my @files = (
+          File::Spec->join( $cmdb_path, $host_macro_filename ),
+          File::Spec->join( $cmdb_path, $default_filename ),
+        );
+        return @files;
+      },
+    },
+  );
+
+  for my $server (@test_servers) {
+    my ( $hostname, $host_filename ) = get_host_filename($server);
+
+    my @cmdb_files     = $cmdb_provider->_get_cmdb_files( undef, $server );
+    my @expected_files = (
+      File::Spec->join( $cmdb_path, $host_filename ),
+      File::Spec->join( $cmdb_path, $default_filename ),
+    );
+
+    cmp_deeply( \@cmdb_files, \@expected_files,
+      "coderef CMDB path for $hostname" );
+  }
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to address various issues:

- fix #1376 by adding an initial test for CMDB paths (set as scalar, arrayref or coderef)
- fix #1374 and close #1375 by making it possible to override replacement values for macros
- fix #1444 by using the local hostname during CMDB queries instead of the internal `<local>` representation

It also fixes various Windows issues related to the above:

- fix host information gathering (hostname, domainname, kernelname, OS version, etc.)
- fix hostname detection
- fix CMDB path separators

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)