### PR TITLE
Fix excessive caching when querying a CMDB item

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Fix gathering OS version for Cygwin
+ - Fix excessive caching when querying a CMDB item
 
  [DOCUMENTATION]
 

--- a/lib/Rex/CMDB.pm
+++ b/lib/Rex/CMDB.pm
@@ -134,23 +134,9 @@ sub cmdb {
 
   return if !cmdb_active();
 
-  $server = $CMDB_PROVIDER->__get_hostname_for($server);
+  $CMDB_PROVIDER->__warm_up_cache_for($server);
 
-  my $value;
-  my $cache     = Rex::get_cache();
-  my $cache_key = "cmdb/$CMDB_PROVIDER/$server";
-
-  if ( $cache->valid($cache_key) ) {
-    $value = $cache->get($cache_key);
-  }
-  else {
-    $value = $CMDB_PROVIDER->get( undef, $server ) || undef;
-    $cache->set( $cache_key, $value );
-  }
-
-  if ($item) {
-    $value = $value->{$item};
-  }
+  my $value = $CMDB_PROVIDER->get( $item, $server );
 
   if ( defined $value ) {
     return Rex::Value->new( value => $value );

--- a/lib/Rex/CMDB/Base.pm
+++ b/lib/Rex/CMDB/Base.pm
@@ -45,4 +45,38 @@ sub __get_hostname_for {
   return $hostname;
 }
 
+sub __warm_up_cache_for {
+  my ( $self, $server ) = @_;
+
+  $server = $self->__get_hostname_for($server);
+  my $cache_key = $self->__cache_key("cmdb/$self/$server");
+
+  if ( !$self->__cache->valid($cache_key) ) {
+    my $cmdb = $self->get( undef, $server ) || undef;
+    $self->__cache->set( $cache_key, $cmdb );
+  }
+
+  return $self->__cache;
+}
+
+sub __cache_key {
+  my ( $self, $key ) = @_;
+
+  if ( defined $key ) {
+    $self->{__cache_key} = $key;
+  }
+
+  return $self->{__cache_key};
+}
+
+sub __cache {
+  my ($self) = @_;
+
+  if ( !defined $self->{__cache} ) {
+    $self->{__cache} = Rex::get_cache();
+  }
+
+  return $self->{__cache};
+}
+
 1;


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1379 by making CMDB caching less greedy to let CMDB providers decide how's it best to return their values.

@gonzalo-radio: this should also help with your custom CMDB provider without introducing a new API, because `$item` is passed to the provider again. So I would close #1380 in favor of this one.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)