### PR TITLE
Fix gathering OS version for Cygwin

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix gathering OS version for Cygwin
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Hardware/Host.pm
+++ b/lib/Rex/Hardware/Host.pm
@@ -335,7 +335,11 @@ sub get_operating_system_version {
     }
   }
   elsif ( $op eq 'Windows' ) {
-    return i_run 'ver';
+    my $command = 'ver';
+
+    if ( can_run($command) ) {
+      return i_run $command;
+    }
   }
 
   return [ i_run("uname -r") ]->[0];


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1448 by trying to use `ver` to determine OS version on Windows only if the command is available. If it's not there, it falls back to the previous generic detection method.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)