### PR TITLE
Add missing autodie feature

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Revision history for Rex
 
 {{$NEXT}}
  [API CHANGES]
+ - Add autodie feature
 
  [BUG FIXES]
  - Fix gathering OS version for Cygwin

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,12 +2,12 @@ Revision history for Rex
 
 {{$NEXT}}
  [API CHANGES]
- - Add autodie feature
 
  [BUG FIXES]
  - Fix gathering OS version for Cygwin
  - Fix excessive caching when querying a CMDB item
  - Fix gathering OS version for Windows
+ - Add missing autodie feature flag
 
  [DOCUMENTATION]
 

--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -1038,7 +1038,7 @@ versions are activated. Available since version 0.56.
 
 =item autodie
 
-Will enable autodie feature: die on all failed L<filesytem commands|https://metacpan.org/pod/Rex::Commands::Fs>. Available since version 0.56.
+Will enable autodie feature: die on all failed L<filesytem commands|https://metacpan.org/pod/Rex::Commands::Fs>. Available since version 1.13.1.
 
 =item 0.55
 

--- a/lib/Rex.pm
+++ b/lib/Rex.pm
@@ -757,6 +757,12 @@ sub import {
         $found_feature = 1;
       }
 
+      if ( $add eq 'autodie' ) {
+        Rex::Logger::debug('enabling autodie');
+        Rex::Config->set_autodie(1);
+        $found_feature = 1;
+      }
+
       if ( $add eq "no_autodie" ) {
         Rex::Logger::debug("disabling autodie");
         Rex::Config->set_autodie(0);

--- a/t/issue/1439.t
+++ b/t/issue/1439.t
@@ -1,4 +1,4 @@
-package main;
+#!/usr/bin/env perl
 
 use 5.006;
 use strict;
@@ -13,5 +13,3 @@ require Rex;
 ok( !Rex::Config->get_autodie(), 'By default, autodie isn\'t enabled' );
 Rex->import( -feature => 'autodie' );
 ok( Rex::Config->get_autodie(), 'We can enable the autodie feature' );
-
-1;

--- a/t/issue/1439.t
+++ b/t/issue/1439.t
@@ -1,0 +1,17 @@
+package main;
+
+use 5.006;
+use strict;
+use warnings;
+
+our $VERSION = '9999.99.99_99'; # VERSION
+
+use Test::More tests => 2;
+
+require Rex;
+
+ok( !Rex::Config->get_autodie(), 'By default, autodie isn\'t enabled' );
+Rex->import( -feature => 'autodie' );
+ok( Rex::Config->get_autodie(), 'We can enable the autodie feature' );
+
+1;


### PR DESCRIPTION
This PR is an attempt to fix #1439 by adding the autodie feature flag. It replaces my previous attempt in #1447 .
Tests pass, I ran perltidy, and it follows the conventions of the other features.

Should I change the documentation for autodie? The behaviour is enabled in 0.56, but the feature will be new in 1.14.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [ ] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
