### PR TITLE
Fix gathering OS version for Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Fix gathering OS version for Cygwin
  - Fix excessive caching when querying a CMDB item
+ - Fix gathering OS version for Windows
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Hardware/Host.pm
+++ b/lib/Rex/Hardware/Host.pm
@@ -12,6 +12,7 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
+use English qw(-no_match_vars);
 use Rex;
 use Rex::Commands::Run;
 use Rex::Helper::Run;
@@ -335,10 +336,10 @@ sub get_operating_system_version {
     }
   }
   elsif ( $op eq 'Windows' ) {
-    my $command = 'ver';
+    my $version = i_run 'ver', fail_ok => 1;
 
-    if ( can_run($command) ) {
-      return i_run $command;
+    if ( $CHILD_ERROR == 0 ) {
+      return $version;
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1451 by checking the exit code of `ver` command after execution instead of trying to use `can_run` to check command existence before running it (which is normally the preferred way, but...Windows).

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)