### PR TITLE
Add ability to pass options to openssh via REX_OPENSSH_OPTS

### DIFF
--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -572,6 +572,14 @@ sub get_openssh_opt {
   return %openssh_opt;
 }
 
+sub get_rex_openssh_opt {
+  if ( exists $ENV{REX_OPENSSH_OPTS} ) {
+    my @opts = split / /, $ENV{REX_OPENSSH_OPTS};
+    return @opts;
+  }
+  return 0;
+}
+
 =head2 set_sudo_without_locales
 
 =head2 get_sudo_without_locales

--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -93,6 +93,12 @@ sub connect {
     push @ssh_opts_line, "-o" => $key . "=" . $ssh_opts{$key};
   }
 
+  my @rex_openssh_opts = Rex::Config->get_rex_openssh_opt();
+
+  if ( $rex_openssh_opts[0] != 0 ) {
+    push @ssh_opts_line, @rex_openssh_opts;
+  }
+
   my @connection_props = ( "" . $server ); # stringify server object, so that a dumper don't print out passwords.
   push @connection_props, ( user => $user, port => $port );
 


### PR DESCRIPTION
As an example, per RFC, IPv6 takes precedent over IPv4, but is sometimes broken
in various exciting ways. In that case it would be useful to pass -4 to ssh.

Since all breakage points are hard to predict, it'd make sense to do it like
git, e.g. set REX_OPENSSH_OPTS and avoid further opt parsing.

<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #<!-- issue ID --> by <!-- briefly explaining your changes -->.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [ ] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [ ] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [ ] tests pass on Travis CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [ ] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [ ] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
