### PR TITLE
Fix parsing debconf values containing colons

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix parsing debconf values containing colons
 
  [DOCUMENTATION]
  - Remove misleading sudo command variant

--- a/lib/Rex/PkgConf/Debian.pm
+++ b/lib/Rex/PkgConf/Debian.pm
@@ -38,9 +38,10 @@ sub get_options {
   my %config;
   for my $line (@lines) {
 
-    # Expecting: * postfix/relayhost: smtp.example.com
+    # Example line:
+    # * keyboard-configuration/optionscode: grp:caps_toggle,grp_led:scroll
     Rex::Logger::debug("Parsing line $line");
-    if ( $line =~ m!^(\*?)\s+(.+):\s*(.*)! ) {
+    if ( $line =~ m!^(\*?)\s+([^:]+):\s*(.*)! ) {
       my ( $already_set, $question, $value ) = ( $1, $2, $3, $4 );
       Rex::Logger::debug(
         "Found configuration question $question with value $value");


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1454 by matching any characters except `:` in the debconf question names.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)