### PR TITLE
Remove unused symbol

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Remove unused tasks array
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -319,9 +319,6 @@ sub task {
     push( @_, "" );
   }
 
-  my $ref_to_tasks = qualify_to_ref( 'tasks', $class );
-  push( @{ *{$ref_to_tasks} }, { name => $task_name_save, code => $_[-2] } );
-
   $options->{'dont_register'} ||= $dont_register_tasks;
   my $task_o = Rex::TaskList->create()->create_task( $task_name, @_, $options );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1493 by removing the unused `tasks` array, which has been introduced on 95d3e913367828f0927591b0e8bda897e9150016 and then made obsolete on 48c737b78f69be92d5f31c2c79fe992f83a4e75c (by `get_all_tasks()` from Rex::TaskList).

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)