### PR TITLE
Do not set by default SSH port when using Net::OpenSSH (fix: 1495)

### DIFF
--- a/lib/Rex/Interface/Connection/OpenSSH.pm
+++ b/lib/Rex/Interface/Connection/OpenSSH.pm
@@ -61,7 +61,7 @@ sub connect {
 
   my $proxy_command = Rex::Config->get_proxy_command( server => $server );
 
-  $port    ||= Rex::Config->get_port( server => $server )    || 22;
+  $port    ||= Rex::Config->get_port( server => $server );
   $timeout ||= Rex::Config->get_timeout( server => $server ) || 3;
 
   $server =
@@ -69,7 +69,9 @@ sub connect {
 
   ( $server, $port ) = Rex::Helper::IP::get_server_and_port( $server, $port );
 
-  Rex::Logger::debug( "Connecting to $server:$port (" . $user . ")" );
+  my $ssh_server_port = $server;  # 'server[:port]' string for debug messages
+  $ssh_server_port .= ":$port" if defined $port;
+  Rex::Logger::debug( "Connecting to $ssh_server_port ( $user )" );
 
   my %ssh_opts = Rex::Config->get_openssh_opt();
   Rex::Logger::debug("get_openssh_opt()");
@@ -110,20 +112,20 @@ sub connect {
   if ( $auth_type && $auth_type eq "pass" ) {
     Rex::Logger::debug(
       Rex::Logger::masq(
-        "OpenSSH: pass_auth: $server:$port - $user - %s", $pass
+        "OpenSSH: pass_auth: $ssh_server_port - $user - %s", $pass
       )
     );
     push @auth_types_to_try, "pass";
   }
   elsif ( $auth_type && $auth_type eq "krb5" ) {
-    Rex::Logger::debug("OpenSSH: krb5_auth: $server:$port - $user");
+    Rex::Logger::debug("OpenSSH: krb5_auth: $ssh_server_port - $user");
     push @auth_types_to_try, "krb5";
 
     # do nothing here
   }
   else { # for key auth, and others
     Rex::Logger::debug(
-      "OpenSSH: key_auth or not defined: $server:$port - $user");
+      "OpenSSH: key_auth or not defined: $ssh_server_port - $user");
     push @auth_types_to_try, "key", "pass";
   }
 
@@ -167,14 +169,14 @@ CONNECT_TRY:
   }
 
   if ( !$self->{ssh} ) {
-    Rex::Logger::info( "Can't connect to $server", "warn" );
+    Rex::Logger::info( "Can't connect to $ssh_server_port", "warn" );
     $self->{connected} = 0;
     return;
   }
 
   if ( $self->{ssh} && $self->{ssh}->error ) {
     Rex::Logger::info(
-      "Can't authenticate against $server (" . $self->{ssh}->error() . ")",
+      "Can't authenticate against $ssh_server_port (" . $self->{ssh}->error() . ")",
       "warn" );
     $self->{connected} = 1;
 
@@ -182,7 +184,7 @@ CONNECT_TRY:
   }
 
   Rex::Logger::debug( "Current Error-Code: " . $self->{ssh}->error() );
-  Rex::Logger::debug("Connected and authenticated to $server.");
+  Rex::Logger::debug("Connected and authenticated to $ssh_server_port.");
 
   $self->{connected} = 1;
   $self->{auth_ret}  = 1;


### PR DESCRIPTION
(R)?ex can't parse complex OpenSSH configuration file,
i.e. with host templates, includes, etc.
Net::OpenSSH use OpenSSH library and handle complex .ssh/config
right like OpenSSH itself.

So if (R)?ex can find port for SSH connection inside
(simple plain) .ssh/config - let's use this port value,
and if it can't - do not force port to 22/tcp so Net::OpenSSH
can try to find it by itself (or failover to the same 22/tcp
inside Net::OpenSSH).