### PR TITLE
Redirect dmidecode STDERR output

### DIFF
--- a/lib/Rex/Inventory/DMIDecode.pm
+++ b/lib/Rex/Inventory/DMIDecode.pm
@@ -133,7 +133,7 @@ sub _read_dmidecode {
       return;
     }
 
-    eval { @lines = i_run "dmidecode"; };
+    eval { @lines = i_run "dmidecode", stderr_to_stdout => 1; };
 
     if ($@) {
       Rex::Logger::debug("Error running dmidecode");


### PR DESCRIPTION
When running dmidecode as non-privileged user, it complains on unsufficient privileges to STDERR.
Redirect all output to STDOUT.
