### PR TITLE
Fix file hooks when source option is used

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Remove unused tasks array
+ - Fix file hooks when source option is used
 
  [DOCUMENTATION]
  - Update support channels

--- a/t/file_hooks.t
+++ b/t/file_hooks.t
@@ -6,7 +6,7 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
 use Test::Deep;
 use Test::Output;
 
@@ -20,6 +20,7 @@ my ( $before, $before_change, $after_change, $after );
 my $test_file    = File::Temp->new()->filename();
 my $test_mode    = '600';
 my $test_content = 'test content';
+my $test_source  = 't/commands/file/test.tpl';
 
 register_function_hooks {
   before        => { file => \&before_hook, },
@@ -30,6 +31,7 @@ register_function_hooks {
 
 my %code_for = (
   'file content' => sub { file $test_file, content => $test_content },
+  'file source'  => sub { file $test_file, source  => $test_source },
   'file absent'  => sub { file $test_file, ensure  => 'absent' },
 );
 
@@ -58,6 +60,9 @@ sub expected_params {
 
   if ( exists $params->{content} ) {
     $expected_params->{content} = $test_content;
+  }
+  elsif ( exists $params->{source} ) {
+    $expected_params->{source} = $test_source;
   }
   else {
     $expected_params = { ensure => 'absent', };

--- a/t/file_hooks.t
+++ b/t/file_hooks.t
@@ -1,7 +1,12 @@
+#!/usr/bin/env perl
+
+use 5.010;
 use strict;
 use warnings;
 
-use Test::More tests => 22;
+our $VERSION = '9999.99.99_99'; # VERSION
+
+use Test::More tests => 2;
 use Test::Deep;
 use Test::Output;
 
@@ -23,28 +28,61 @@ register_function_hooks {
   after         => { file => \&after_hook, },
 };
 
-sub before_hook {
-  my ( $file, @options ) = @_;
-  my $params = {@options};
+my %code_for = (
+  'file content' => sub { file $test_file, content => $test_content },
+  'file absent'  => sub { file $test_file, ensure  => 'absent' },
+);
 
-  my $expected_params;
+for my $test_case ( keys %code_for ) {
+  subtest $test_case => sub {
+    my $test_code = shift;
+
+    $before = $before_change = $after_change = $after = 0;
+
+    stderr_like { $test_code->() } qr{^$}, 'stderr is empty';
+
+    is( $before,        1, 'before hook ran' );
+    is( $before_change, 1, 'before_change hook ran' );
+    is( $after_change,  1, 'after_change hook ran' );
+    is( $after,         1, 'after hook ran' );
+
+    },
+    $code_for{$test_case};
+}
+
+sub expected_params {
+  my $params = shift;
+  my ( undef, undef, undef, $subroutine ) = caller 1;
+
+  my $expected_params = { ensure => 'present', };
 
   if ( exists $params->{content} ) {
-    $expected_params = {
-      ensure  => 'present',
-      content => $test_content,
-    };
+    $expected_params->{content} = $test_content;
   }
   else {
     $expected_params = { ensure => 'absent', };
   }
 
+  if ( $subroutine ne 'main::before_hook' ) {
+    $expected_params->{mode} = $test_mode;
+  }
+
+  return $expected_params;
+}
+
+sub before_hook {
+  my ( $file, @options ) = @_;
+  my $params = {@options};
+
   $before += 1;
 
   is( $file, $test_file, 'before - filename is correct' );
 
-  cmp_deeply( $params, $expected_params,
-    'before - received expected parameters' );
+  cmp_deeply(
+    $params,
+    expected_params($params),
+    'before - received expected parameters',
+  );
 
   $params->{mode} = $test_mode;
 
@@ -55,28 +93,15 @@ sub before_change_hook {
   my ( $file, @options ) = @_;
   my $params = {@options};
 
-  my $expected_params;
-
-  if ( exists $params->{content} ) {
-    $expected_params = {
-      ensure  => 'present',
-      content => $test_content,
-      mode    => $test_mode,
-    };
-  }
-  else {
-    $expected_params = {
-      ensure => 'absent',
-      mode   => $test_mode,
-    };
-  }
-
   $before_change += 1;
 
   is( $file, $test_file, 'before_change - filename is correct' );
 
-  cmp_deeply( $params, $expected_params,
-    'before_change - received expected parameters' );
+  cmp_deeply(
+    $params,
+    expected_params($params),
+    'before_change - received expected parameters',
+  );
 }
 
 sub after_change_hook {
@@ -84,28 +109,15 @@ sub after_change_hook {
   my $result = pop @options;
   my $params = {@options};
 
-  my $expected_params;
-
-  if ( exists $params->{content} ) {
-    $expected_params = {
-      ensure  => 'present',
-      content => $test_content,
-      mode    => $test_mode,
-    };
-  }
-  else {
-    $expected_params = {
-      ensure => 'absent',
-      mode   => $test_mode,
-    };
-  }
-
   $after_change += 1;
 
   is( $file, $test_file, 'after_change - filename is correct' );
 
-  cmp_deeply( $params, $expected_params,
-    'after_change - received expected parameters' );
+  cmp_deeply(
+    $params,
+    expected_params($params),
+    'after_change - received expected parameters',
+  );
 }
 
 sub after_hook {
@@ -113,37 +125,13 @@ sub after_hook {
   my $result = pop @options;
   my $params = {@options};
 
-  my $expected_params;
-
-  if ( exists $params->{content} ) {
-    $expected_params = {
-      ensure  => 'present',
-      content => $test_content,
-      mode    => $test_mode,
-    };
-  }
-  else {
-    $expected_params = {
-      ensure => 'absent',
-      mode   => $test_mode,
-    };
-  }
-
   $after += 1;
 
   is( $file, $test_file, 'after - filename is correct' );
 
-  cmp_deeply( $params, $expected_params,
-    'after - received expected parameters' );
+  cmp_deeply(
+    $params,
+    expected_params($params),
+    'after - received expected parameters',
+  );
 }
-
-stderr_like( sub { file $test_file, content => $test_content },
-  qr{^$}, 'stderr is empty' );
-
-stderr_like( sub { file $test_file, ensure => 'absent' },
-  qr{^$}, 'stderr is empty' );
-
-is( $before,        2, 'before hook ran' );
-is( $before_change, 2, 'before_change hook ran' );
-is( $after_change,  2, 'after_change hook ran' );
-is( $after,         2, 'after hook ran' );


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1498 by making sure that the file command's `source` option takes the same code path as `content`. This ensures having a temporary file created first, which is then moved to the final location. It also enables `before_change` and `after_change` hooks for the `source` option.

Both of these changes increase the consistency of the file commands behavior across the variety of available options.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)