### PR TITLE
Detect invalid hostgroup expressions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Detect invalid hostgroup expressions
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1786,8 +1786,11 @@ sub evaluate_hostname {
   if ( $rule =~ m/,/ ) {
     @ret = _evaluate_hostname_list( $start, $rule, $end );
   }
-  else {
+  elsif ( $rule =~ m/[.]{2}/msx ) {
     @ret = _evaluate_hostname_range( $start, $rule, $end );
+  }
+  else {
+    croak('Invalid hostgroup expression');
   }
 
   return @ret;

--- a/t/group.t
+++ b/t/group.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
 
-use Test::More tests => 97;
+use Test::More tests => 98;
+use Test::Exception;
 
 use Rex -feature => '0.31';
 use Rex::Group;
@@ -72,3 +73,8 @@ ok( $server->function( $function_name, sub { return $function_result } ),
 
 my $function_ref = qualify_to_ref( $function_name, $server );
 is( *{$function_ref}->(), $function_result, 'calling custom function' );
+
+# invalid hostgroup expression
+
+dies_ok( sub { Rex::Commands::evaluate_hostname('s[78]') },
+  'die on invalid hostgroup expression' );


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is an attempt to fix #1483 by calling `croak()` when an unrecognized hostgroup expression is detected.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)