### PR TITLE
Fix #1508 - the `needs()` function should propagate calling task's params/args down to needed tasks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Detect invalid hostgroup expressions
+ - Propagate args/params down to "needed" tasks launched by needs()
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1066,11 +1066,11 @@ sub needs {
     my $suffix    = $self . ":";
     if ( @args && grep ( /^\Q$task_name\E$/, @args ) ) {
       Rex::Logger::debug( "Calling " . $task_o->name );
-      $task_o->run( "<func>", params => \@task_args, args => \%task_opts );
+      $task_o->run( "<func>", params => \%task_opts, args => \@task_args );
     }
     elsif ( !@args ) {
       Rex::Logger::debug( "Calling " . $task_o->name );
-      $task_o->run( "<func>", params => \@task_args, args => \%task_opts );
+      $task_o->run( "<func>", params => \%task_opts, args => \@task_args );
     }
   }
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1064,11 +1064,7 @@ sub needs {
     my $task_o    = $tl->get_task($task);
     my $task_name = $task_o->name;
     my $suffix    = $self . ":";
-    if ( @args && grep ( /^\Q$task_name\E$/, @args ) ) {
-      Rex::Logger::debug( "Calling " . $task_o->name );
-      $task_o->run( "<func>", params => \%task_opts, args => \@task_args );
-    }
-    elsif ( !@args ) {
+    if ( !@args || grep ( /^\Q$task_name\E$/, @args ) ) {
       Rex::Logger::debug( "Calling " . $task_o->name );
       $task_o->run( "<func>", params => \%task_opts, args => \@task_args );
     }

--- a/t/issue/1508.t
+++ b/t/issue/1508.t
@@ -1,0 +1,167 @@
+
+=head1 NAME 
+
+issue/1508.t  - Check that the `needs()` function correctly propogates run-time task arguments
+
+=head1 DESCRIPTION
+
+Check that the `needs()` function does indeed correctly propogate 
+run-time task arguments (%params and @args) from the calling task down to the "needed" tasks.
+
+=head1 DETAILS
+
+  * AUTHOR / DATE : [tabulon]@[2021-09-26]
+  * RELATES-TO    : [github issue #1508](https://github.com/RexOps/Rex/issues/1508#issue-1007457392)
+  * INSPIRED from : t/needs.t
+
+=cut
+
+use Test::More;
+use Rex::Commands;
+
+{
+
+  package T; # Helper package (for cutting down boilerplate in tests)
+  use Storable;
+
+  sub track_taskrun {
+    my %opts = ref $_[-1] eq 'HASH'
+      ? %{
+      ;
+      pop
+      }
+      : ();
+    my $argv    = $opts{argv};
+    my @prereqs = (@_);
+    for (@prereqs) {
+      my $file = "${_}.txt";
+      Storable::store( $argv, $file );
+    }
+  }
+
+  sub check_needed {
+    my %opts = ref $_[-1] eq 'HASH'
+      ? %{
+      ;
+      pop
+      }
+      : ();
+    my $argv      = $opts{argv};
+    my $do_unlink = delete $opts{unlink} // 1;
+    my @prereqs   = (@_);
+
+    for (@prereqs) {
+      my $file = "${_}.txt";
+
+      -f "$file" or die;
+      my $propagated_argv = Storable::retrieve("$file");
+      Test::More::_deep_check( $propagated_argv, $argv ) or die;
+
+      unlink("$file") if ($do_unlink);
+    }
+  }
+}
+
+{
+
+  package MyTest;
+  use strict;
+  use warnings;
+  use Rex::Commands;
+
+  $::QUIET = 1;
+
+  task test1 => sub {
+    T::track_taskrun( test1 => { argv => \@_ } );
+  };
+
+  task test2 => sub {
+    T::track_taskrun( test2 => { argv => \@_ } );
+  };
+
+  1;
+}
+
+{
+
+  package Nested::Module;
+
+  use strict;
+  use warnings;
+
+  use Rex::Commands;
+
+  task test => sub {
+    T::track_taskrun( test => { argv => \@_ } );
+  };
+}
+
+{
+
+  package Rex::Module;
+
+  use strict;
+  use warnings;
+
+  use Rex::Commands;
+
+  task test => sub {
+    T::track_taskrun( test => { argv => \@_ } );
+  };
+}
+
+task test => sub {
+  needs MyTest;
+
+  T::check_needed( $_, { argv => \@_ } ) for (qw/test1 test2/);
+};
+
+task test2 => sub {
+  needs MyTest "test2";
+
+  T::check_needed( $_, { argv => \@_ } ) for (qw/test2/);
+};
+
+task test3 => sub {
+  needs "test4";
+
+  T::check_needed( $_, { argv => \@_ } ) for (qw/test4/);
+};
+
+task test4 => sub {
+  T::track_taskrun( test4 => { argv => \@_ } );
+};
+
+task test5 => sub {
+  needs Nested::Module test;
+
+  T::check_needed( $_, { argv => \@_ } ) for (qw/test/);
+};
+
+task test6 => sub {
+  needs Rex::Module "test";
+
+  T::check_needed( $_, { argv => \@_ } ) for (qw/test /);
+};
+
+TODO: {
+  local $TODO = "Issue 1508: The needs() function should propogate parameters/args";
+
+  my $task_list = Rex::TaskList->create;
+  my $run_list  = Rex::RunList->instance;
+  $run_list->parse_opts(qw/test test2 test3 test5 test6/);
+
+  for my $task ( $run_list->tasks ) {
+    my $name = $task->name;
+    my %prms = ( "${name}_greet" => "Hello ${name}" );
+    my @args = ( "${name}.arg.0", "${name}.arg.1", "${name}.arg.2" );
+
+    $task_list->run($task);
+
+    my @summary = $task_list->get_summary;
+    is_deeply $summary[-1]->{exit_code}, 0, $task->name;
+    $run_list->increment_current_index;
+  }
+}
+
+done_testing;

--- a/t/issue/1508.t
+++ b/t/issue/1508.t
@@ -144,9 +144,9 @@ task test6 => sub {
   T::check_needed( $_, { argv => \@_ } ) for (qw/test /);
 };
 
-TODO: {
-  local $TODO = "Issue 1508: The needs() function should propogate parameters/args";
 
+
+{
   my $task_list = Rex::TaskList->create;
   my $run_list  = Rex::RunList->instance;
   $run_list->parse_opts(qw/test test2 test3 test5 test6/);


### PR DESCRIPTION
<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

# PR for fixing #1508 - the `needs()`function should propagate calling task's params/args down to needed tasks

Hi,

This PR is an attempt to fix #1508 by correcting what appears to be a typo (or copy/paste error) in the body of the `needs()` function in `Rex::Commands`.

The bug appears to have been introduced initially by PR #1157 (the fix for #1066 ) with 48c737b.

Notice how params and args were mixed up (interchanged) when being passed down  -- within the `needs()` function.

Two alternate fixes are proposed (in commits 2 & 3), which may be cherry-picked, or just applied in series, which amounts to picking the latter.

Please review and merge, or let me know how to improve it further.

## Open questions

While this is clearly bug fix, it can't be ruled out that some code out in the wild may have come to rely on the incorrect behavior during the time of its existence.
(since around 2017).

Therefore, it might perhaps be safer to introduce a "feature switch" for introducing this fix... if the maintainers deem that necessary.

This PR does NOT include such a feature switch, as I guess (perhaps wrongly) that most people might have already turned to using `run_task` in the mean time, 
because of glitches like this with the `need()` function, some of which appear to have already been handled by #1188, but not this one.

That's only a guess, though...

## Bundled commits

1. Add tests (marked as TODO) related to the bug (#1508). See below 
2. Fix #1508, by correcting a typo in a couple places       _(quick fix, with minimal changes in code)_
3. Fix #1508 by correcting a typo + minimal code cleanup    _(alternate fix)_
4. Update ChangeLog, remove "TODO" mark from tests related to #1508

## How to test

```bash
$ prove -v t/issue/1508.t   # for this issue
$ prove t/**/*.t            # for non-regression
```

As long as the related tests remain marked as "TODO", 
they will not report failures during normal test runs.

To see their true pass/fail status, you have to pass
the '-v' option to `prove`.

The last commit removes the "TODO" mark from tests. 
Once that commit is merged, the '-v' switch is no longer needed.


## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [ ] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)