### PR TITLE
Revert "Use versioned CI cache keys"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,14 +42,14 @@ jobs:
         uses: actions/cache@v2
         with:
           path: local
-          key: cache-build-modules-${{ secrets.CACHE_VERSION }}-${{ env.OS_VERSION }}-${{ env.PERL_VERSION }}-${{ env.BUILD_TIMESTAMP }}
-          restore-keys: cache-build-modules-${{ secrets.CACHE_VERSION }}-${{ env.OS_VERSION }}-${{ env.PERL_VERSION }}-
+          key: cache-build-modules-${{ env.OS_VERSION }}-${{ env.PERL_VERSION }}-${{ env.BUILD_TIMESTAMP }}
+          restore-keys: cache-build-modules-${{ env.OS_VERSION }}-${{ env.PERL_VERSION }}-
       - name: Cache perlcritic history
         uses: actions/cache@v2
         with:
           path: /tmp/cache/.perlcritic-history
-          key: cache-perlcritic-history-${{ secrets.CACHE_VERSION }}-${{ env.BUILD_TIMESTAMP }}
-          restore-keys: cache-perlcritic-history-${{ secrets.CACHE_VERSION }}-
+          key: cache-perlcritic-history-${{ env.BUILD_TIMESTAMP }}
+          restore-keys: cache-perlcritic-history-
       - name: Log perl information
         run: perl -V
       - name: Install packages


### PR DESCRIPTION
This PR is an attempt to fix #1516 by reverting commit
558aa9a59dfc974e4bcb1e6aba741dcf4f1d157c.

Repository secrets are not passed to pull requests from a fork, so these
were being run with a wrong or clean cache. This has caused skipping
progressive perlcritic tests as well.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] ~~changelog entry included~~ <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
