### PR TITLE
Fix #1521 lib/Rex/CLI.pm: Use $SIG{__WARN__} when loading Rexfile instead of stderr redirection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ Revision history for Rex
 
  [REVISION]
  - Fix handling of warnings during Rexfile loading
+ - Mask internal naming in Rexfile loading output
 
 1.13.4 2021-07-05 Ferenc Erki <erkiferenc@gmail.com>
  [DOCUMENTATION]

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ Revision history for Rex
  [NEW FEATURES]
 
  [REVISION]
+ - Fix handling of warnings during Rexfile loading
 
 1.13.4 2021-07-05 Ferenc Erki <erkiferenc@gmail.com>
  [DOCUMENTATION]

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Detect invalid hostgroup expressions
+ - Prevent empty log lines upon Rexfile warnings
 
  [DOCUMENTATION]
  - Clarify optional arguments of file commands

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -28,7 +28,6 @@ vars\..*
 passwd
 upload
 .*\.conf
-.*\.log
 ^images
 projects
 Rex\-\d+.*

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -761,6 +761,9 @@ sub load_rexfile {
     if (@warnings) {
       Rex::Logger::info( "You have some code warnings:", 'warn' );
       for (@warnings) {
+
+        # remove /loader/.../ prefix before filename
+        s{/loader/[^/]+/}{}sxm;
         Rex::Logger::info( "\t$_", 'warn' );
       }
     }

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -761,6 +761,7 @@ sub load_rexfile {
     if (@warnings) {
       Rex::Logger::info( "You have some code warnings:", 'warn' );
       for (@warnings) {
+        chomp;
 
         # remove /loader/.../ prefix before filename
         s{/loader/[^/]+/}{}sxm;

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -69,7 +69,7 @@ sub __run__ {
   %opts = Rex::Args->getopts;
 
   if ( $opts{'Q'} ) {
-    my ( $stdout, $stderr );
+    my $stdout;
     open( my $newout, '>', \$stdout );
     select $newout;
     close(STDERR);

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -744,14 +744,11 @@ sub load_rexfile {
       }
     };
 
-    my ( $stdout, $stderr, $default_stderr );
-    open $default_stderr, ">&", STDERR;
-
-    # we close STDERR here because we don't want to see the
-    # normal perl error message on the screen. Instead we print
-    # the error message in the catch-if below.
-    local *STDERR;
-    open( STDERR, ">>", \$stderr );
+    # we don't want to see the
+    # normal perl warning message on the screen. Instead we print
+    # the warning message in the catch-if below
+    my @warnings;
+    local $SIG{__WARN__} = sub { push @warnings, $_[0] };
 
     # we can't use $rexfile here, because if the variable contains dots
     # the perl interpreter try to load the file directly without using @INC
@@ -761,13 +758,11 @@ sub load_rexfile {
     # update %INC so that we can later use it to find the rexfile
     $INC{"__Rexfile__.pm"} = $rexfile;
 
-    # reopen STDERR
-    open STDERR, ">&", $default_stderr;
-
-    if ($stderr) {
-      my @lines = split( $/, $stderr );
+    if (@warnings) {
       Rex::Logger::info( "You have some code warnings:", 'warn' );
-      Rex::Logger::info( "\t$_",                         'warn' ) for @lines;
+      for (@warnings) {
+        Rex::Logger::info( "\t$_", 'warn' );
+      }
     }
 
     1;

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -764,6 +764,10 @@ sub load_rexfile {
 
         # remove /loader/.../ prefix before filename
         s{/loader/[^/]+/}{}sxm;
+
+        # convert Rexfile to human-friendly name
+        s{__Rexfile__.pm}{Rexfile}msx;
+
         Rex::Logger::info( "\t$_", 'warn' );
       }
     }
@@ -778,6 +782,9 @@ sub load_rexfile {
     # remove the strange path to the Rexfile which exists because
     # we load the Rexfile via our custom code block.
     $e =~ s|/loader/[^/]+/||smg;
+
+    # convert Rexfile to human-friendly name
+    $e =~ s{__Rexfile__.pm}{Rexfile}msx;
 
     my @lines = split( $/, $e );
 

--- a/lib/Rex/Logger.pm
+++ b/lib/Rex/Logger.pm
@@ -60,11 +60,6 @@ Setting this variable to 1 will enable debug logging.
 
 our $debug = 0;
 
-# we store the default handle to stderr
-# so that we can restore the handle inside the logging functions
-my $DEFAULT_STDERR;
-open $DEFAULT_STDERR, ">&", STDERR;
-
 =item $silent
 
 If you set this variable to 1 nothing will be logged.
@@ -125,9 +120,6 @@ sub info {
 
   return if $silent;
 
-  local *STDERR;
-  open STDERR, ">&", $DEFAULT_STDERR;
-
   if ( defined($type) ) {
     $msg = format_string( $msg, uc($type) );
   }
@@ -185,9 +177,6 @@ sub debug {
   my ($msg) = @_;
   return if $silent;
   return unless $debug;
-
-  local *STDERR;
-  open STDERR, ">&", $DEFAULT_STDERR;
 
   $msg = format_string( $msg, "DEBUG" );
 

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -151,6 +151,8 @@ sub _get_log {
 }
 
 sub _reset_test {
+  Rex::TaskList->create->clear_tasks();
+
   $exit_was_called = undef;
 
   # reset log

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -1,0 +1,226 @@
+#!/usr/bin/env perl
+use 5.010001;
+use strict;
+use warnings;
+
+our $VERSION = '9999.99.99_99'; # VERSION
+
+use Test::More;
+use Test::Output;
+use File::Temp;
+use File::Spec;
+
+use Rex::CLI;
+## no critic (RequireTrailingCommaAtNewline);
+## no critic (ProhibitPostfixControls, WhileDiamondDefaultAssignment);
+## no critic (ProhibitPunctuationVars, ProhibitPackageVars);
+## no critic (RequireCheckedSyscalls, RequireCheckedClose);
+## no critic (RegularExpressions);
+## no critic (Carping, ProhibitNoWarnings, DuplicateLiteral);
+
+#diag 'create some rexfiles to test...';
+my $fh      = undef;
+my $testdir = File::Temp->newdir( 'rextest.XXXX', TMPDIR => 1, CLEANUP => 1 );
+while (<DATA>) {
+  last if /^__END__$/;
+  if (/^@@ *(\S+)$/) {
+
+    #diag "prepare file $1";
+    close $fh if $fh;
+    open $fh, '>', File::Spec->catfile( $testdir, $1 ) or die $!;
+    next;
+  }
+  print {$fh} $_ if $fh;
+}
+close $fh if $fh;
+
+our $exit_was_called = undef;
+
+# we must disable Rex::CLI::exit() sub imported from Rex::Commands
+no warnings 'redefine';
+local *Rex::CLI::exit = sub { $exit_was_called = 1 };
+use warnings 'redefine';
+
+#
+# enable this to debug!
+#
+$::QUIET = 1;
+
+#$Rex::Logger::no_color = 1;
+my $logfile = File::Spec->catfile( $testdir, 'log' );
+Rex::Config->set_log_filename($logfile);
+
+# NOW TEST
+
+# No Rexfile warning (via Rex::Logger)
+Rex::CLI::load_rexfile( File::Spec->catfile( $testdir, 'no_Rexfile' ) );
+my $content = _get_log();
+like( $content, qr/WARN - No Rexfile found/,
+  'No Rexfile warning (via logger)' );
+
+# Valid Rexfile
+_reset_test();
+output_like {
+  Rex::CLI::load_rexfile( File::Spec->catfile( $testdir, 'Rexfile_noerror' ) );
+}
+qr/^$/, qr/^$/, 'No stdout/stderr messages on valid Rexfile';
+$content = _get_log();
+is( $content, q{}, 'No warnings on valid Rexfile (via logger)' );
+
+# Rexfile with warnings
+_reset_test();
+output_like {
+  Rex::CLI::load_rexfile( File::Spec->catfile( $testdir, 'Rexfile_warnings' ) );
+}
+qr/^$/, qr/^$/, 'No stdout/stderr messages on Rexfile with warnings';
+$content = _get_log();
+ok( !$exit_was_called, 'sub load_rexfile() not exit' );
+like(
+  $content,
+  qr/WARN - You have some code warnings/,
+  'Code warnings via logger'
+);
+like( $content, qr/This is warning/, 'warn() warning via logger' );
+like(
+  $content,
+  qr/Use of uninitialized value \$undef/,
+  'perl warning via logger'
+);
+unlike(
+  $content,
+  qr#at /loader/0x#,
+  'loader prefix is filtered in warnings report'
+);
+
+# Rexfile with fatal errors
+_reset_test();
+output_like {
+  Rex::CLI::load_rexfile( File::Spec->catfile( $testdir, 'Rexfile_fatal' ) );
+}
+qr/^$/, qr/^$/, 'No stdout/stderr messages on Rexfile with errors';
+$content = _get_log();
+ok( $exit_was_called, 'sub load_rexfile() aborts' );
+like( $content, qr/ERROR - Compile time errors/, 'Fatal errors via logger' );
+like( $content, qr/syntax error at/, 'syntax error is fatal error via logger' );
+unlike(
+  $content,
+  qr#at /loader/0x#,
+  'loader prefix is filtered in errors report'
+);
+
+# Now print messages to STDERR/STDOUT
+# Valid Rexfile
+_reset_test();
+output_like {
+  Rex::CLI::load_rexfile(
+    File::Spec->catfile( $testdir, 'Rexfile_noerror_print' ) );
+}
+qr/^This is STDOUT message$/, qr/^This is STDERR message$/,
+  'Correct stdout/stderr messages printed from valid Rexfile';
+$content = _get_log();
+is( $content, q{},
+  'No warnings via logger on valid Rexfile that print messages' );
+
+# Rexfile with warnings
+_reset_test();
+output_like {
+  Rex::CLI::load_rexfile(
+    File::Spec->catfile( $testdir, 'Rexfile_warnings_print' ) );
+}
+qr/^This is STDOUT message$/, qr/^This is STDERR message$/,
+  'Correct stdout/stderr messages printed from Rexfile with warnings';
+$content = _get_log();
+like(
+  $content,
+  qr/WARN - You have some code warnings/,
+  'Code warnings exist via logger'
+);
+
+# Rexfile with fatal errors
+_reset_test();
+output_like {
+  Rex::CLI::load_rexfile(
+    File::Spec->catfile( $testdir, 'Rexfile_fatal_print' ) );
+}
+qr/^$/, qr/^$/,
+  'No stdout/stderr messages printed from Rexfile that has errors';
+$content = _get_log();
+ok( $exit_was_called, 'sub load_rexfile() aborts' );
+like(
+  $content,
+  qr/ERROR - Compile time errors/,
+  'Fatal errors exist via logger'
+);
+
+done_testing;
+
+# from logger.t
+sub _get_log {
+  ## no critic (LocalVars)
+  local $/;
+
+  open my $fh, '<', $logfile or die $!;
+  my $loglines = <$fh>;
+  close $fh;
+
+  return $loglines;
+}
+
+sub _reset_test {
+  $exit_was_called = undef;
+
+  # reset log
+  open my $fh, '>', $logfile or die $!;
+  close $fh;
+
+  # reset require
+  delete $INC{'__Rexfile__.pm'};
+
+  return;
+}
+
+__DATA__
+@@ Rexfile_noerror
+use Rex;
+user 'testuser';
+task test => sub { say "test1" };
+
+@@ Rexfile_warnings
+use Rex;
+use warnings;
+warn 'This is warning';
+my $undef; my $warn = 'warn'.$undef;
+user 'testuser';
+task test => sub { say "test2" };
+
+@@ Rexfile_fatal
+use Rex;
+aaaabbbbcccc
+task test => sub { say "test3" };
+
+@@ Rexfile_noerror_print
+use Rex;
+user 'testuser';
+print STDERR 'This is STDERR message';
+print STDOUT 'This is STDOUT message';
+task test2 => sub { say "test4" };
+
+@@ Rexfile_warnings_print
+use Rex;
+use warnings;
+warn 'This is warning';
+my $undef; my $warn = 'warn'.$undef;
+print STDERR 'This is STDERR message';
+print STDOUT 'This is STDOUT message';
+user 'testuser';
+task test2 => sub { say "test5" };
+
+@@ Rexfile_fatal_print
+use Rex;
+print STDERR 'This is STDERR message';
+print STDOUT 'This is STDOUT message';
+aaaabbbbcccc
+print STDERR 'This is STDERR message';
+print STDOUT 'This is STDOUT message';
+task test2 => sub { say "test6" };
+

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -1,16 +1,18 @@
 #!/usr/bin/env perl
+
 use 5.010001;
 use strict;
 use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More;
-use Test::Output;
-use File::Temp;
-use File::Spec;
+use Test::More tests => 21;
 
+use File::Spec;
+use File::Temp;
 use Rex::CLI;
+use Test::Output;
+
 ## no critic (ProhibitPostfixControls, WhileDiamondDefaultAssignment);
 ## no critic (ProhibitPunctuationVars, ProhibitPackageVars);
 ## no critic (RequireCheckedSyscalls, RequireCheckedClose);
@@ -150,8 +152,6 @@ like(
   qr/ERROR - Compile time errors/,
   'Fatal errors exist via logger'
 );
-
-done_testing;
 
 # from logger.t
 sub _get_log {

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -11,6 +11,7 @@ use Test::More tests => 21;
 use File::Spec;
 use File::Temp;
 use Rex::CLI;
+use Rex::Commands::File;
 use Test::Output;
 
 ## no critic (ProhibitPunctuationVars);
@@ -40,9 +41,11 @@ Rex::Config->set_log_filename($logfile);
 
 # No Rexfile warning (via Rex::Logger)
 Rex::CLI::load_rexfile( File::Spec->catfile( $testdir, 'no_Rexfile' ) );
-my $content = _get_log();
-like( $content, qr/WARN - No Rexfile found/,
-  'No Rexfile warning (via logger)' );
+like(
+  cat($logfile),
+  qr/WARN - No Rexfile found/,
+  'No Rexfile warning (via logger)'
+);
 
 # Valid Rexfile
 _reset_test();
@@ -50,8 +53,7 @@ output_like {
   Rex::CLI::load_rexfile( File::Spec->catfile( $testdir, 'Rexfile_noerror' ) );
 }
 qr/^$/, qr/^$/, 'No stdout/stderr messages on valid Rexfile';
-$content = _get_log();
-is( $content, q{}, 'No warnings on valid Rexfile (via logger)' );
+is( cat($logfile), q{}, 'No warnings on valid Rexfile (via logger)' );
 
 # Rexfile with warnings
 _reset_test();
@@ -59,21 +61,20 @@ output_like {
   Rex::CLI::load_rexfile( File::Spec->catfile( $testdir, 'Rexfile_warnings' ) );
 }
 qr/^$/, qr/^$/, 'No stdout/stderr messages on Rexfile with warnings';
-$content = _get_log();
 ok( !$exit_was_called, 'sub load_rexfile() not exit' );
 like(
-  $content,
+  cat($logfile),
   qr/WARN - You have some code warnings/,
   'Code warnings via logger'
 );
-like( $content, qr/This is warning/, 'warn() warning via logger' );
+like( cat($logfile), qr/This is warning/, 'warn() warning via logger' );
 like(
-  $content,
+  cat($logfile),
   qr/Use of uninitialized value \$undef/,
   'perl warning via logger'
 );
 unlike(
-  $content,
+  cat($logfile),
   qr#at /loader/0x#,
   'loader prefix is filtered in warnings report'
 );
@@ -84,12 +85,19 @@ output_like {
   Rex::CLI::load_rexfile( File::Spec->catfile( $testdir, 'Rexfile_fatal' ) );
 }
 qr/^$/, qr/^$/, 'No stdout/stderr messages on Rexfile with errors';
-$content = _get_log();
 ok( $exit_was_called, 'sub load_rexfile() aborts' );
-like( $content, qr/ERROR - Compile time errors/, 'Fatal errors via logger' );
-like( $content, qr/syntax error at/, 'syntax error is fatal error via logger' );
+like(
+  cat($logfile),
+  qr/ERROR - Compile time errors/,
+  'Fatal errors via logger'
+);
+like(
+  cat($logfile),
+  qr/syntax error at/,
+  'syntax error is fatal error via logger'
+);
 unlike(
-  $content,
+  cat($logfile),
   qr#at /loader/0x#,
   'loader prefix is filtered in errors report'
 );
@@ -103,8 +111,7 @@ output_like {
 }
 qr/^This is STDOUT message$/, qr/^This is STDERR message$/,
   'Correct stdout/stderr messages printed from valid Rexfile';
-$content = _get_log();
-is( $content, q{},
+is( cat($logfile), q{},
   'No warnings via logger on valid Rexfile that print messages' );
 
 # Rexfile with warnings
@@ -115,9 +122,8 @@ output_like {
 }
 qr/^This is STDOUT message$/, qr/^This is STDERR message$/,
   'Correct stdout/stderr messages printed from Rexfile with warnings';
-$content = _get_log();
 like(
-  $content,
+  cat($logfile),
   qr/WARN - You have some code warnings/,
   'Code warnings exist via logger'
 );
@@ -130,25 +136,12 @@ output_like {
 }
 qr/^$/, qr/^$/,
   'No stdout/stderr messages printed from Rexfile that has errors';
-$content = _get_log();
 ok( $exit_was_called, 'sub load_rexfile() aborts' );
 like(
-  $content,
+  cat($logfile),
   qr/ERROR - Compile time errors/,
   'Fatal errors exist via logger'
 );
-
-# from logger.t
-sub _get_log {
-  ## no critic (LocalVars)
-  local $/;
-
-  open my $fh, '<', $logfile or die $!;
-  my $loglines = <$fh>;
-  close $fh;
-
-  return $loglines;
-}
 
 sub _reset_test {
   Rex::TaskList->create->clear_tasks();

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -11,7 +11,6 @@ use File::Temp;
 use File::Spec;
 
 use Rex::CLI;
-## no critic (RequireTrailingCommaAtNewline);
 ## no critic (ProhibitPostfixControls, WhileDiamondDefaultAssignment);
 ## no critic (ProhibitPunctuationVars, ProhibitPackageVars);
 ## no critic (RequireCheckedSyscalls, RequireCheckedClose);

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -13,27 +13,12 @@ use File::Temp;
 use Rex::CLI;
 use Test::Output;
 
-## no critic (ProhibitPostfixControls, WhileDiamondDefaultAssignment);
 ## no critic (ProhibitPunctuationVars);
 ## no critic (RequireCheckedSyscalls, RequireCheckedClose);
 ## no critic (RegularExpressions);
 ## no critic (Carping, ProhibitNoWarnings, DuplicateLiteral);
 
-#diag 'create some rexfiles to test...';
-my $fh      = undef;
-my $testdir = File::Temp->newdir( 'rextest.XXXX', TMPDIR => 1, CLEANUP => 1 );
-while (<DATA>) {
-  last if /^__END__$/;
-  if (/^@@ *(\S+)$/) {
-
-    #diag "prepare file $1";
-    close $fh if $fh;
-    open $fh, '>', File::Spec->catfile( $testdir, $1 ) or die $!;
-    next;
-  }
-  print {$fh} $_ if $fh;
-}
-close $fh if $fh;
+my $testdir = File::Spec->join( 't', 'rexfiles' );
 
 my $exit_was_called;
 
@@ -48,7 +33,7 @@ use warnings 'redefine';
 $::QUIET = 1;
 
 #$Rex::Logger::no_color = 1;
-my $logfile = File::Spec->catfile( $testdir, 'log' );
+my $logfile = File::Temp->new->filename;
 Rex::Config->set_log_filename($logfile);
 
 # NOW TEST
@@ -177,49 +162,3 @@ sub _reset_test {
 
   return;
 }
-
-__DATA__
-@@ Rexfile_noerror
-use Rex;
-user 'testuser';
-task test => sub { say "test1" };
-
-@@ Rexfile_warnings
-use Rex;
-use warnings;
-warn 'This is warning';
-my $undef; my $warn = 'warn'.$undef;
-user 'testuser';
-task test => sub { say "test2" };
-
-@@ Rexfile_fatal
-use Rex;
-aaaabbbbcccc
-task test => sub { say "test3" };
-
-@@ Rexfile_noerror_print
-use Rex;
-user 'testuser';
-print STDERR 'This is STDERR message';
-print STDOUT 'This is STDOUT message';
-task test2 => sub { say "test4" };
-
-@@ Rexfile_warnings_print
-use Rex;
-use warnings;
-warn 'This is warning';
-my $undef; my $warn = 'warn'.$undef;
-print STDERR 'This is STDERR message';
-print STDOUT 'This is STDOUT message';
-user 'testuser';
-task test2 => sub { say "test5" };
-
-@@ Rexfile_fatal_print
-use Rex;
-print STDERR 'This is STDERR message';
-print STDOUT 'This is STDOUT message';
-aaaabbbbcccc
-print STDERR 'This is STDERR message';
-print STDOUT 'This is STDOUT message';
-task test2 => sub { say "test6" };
-

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -3,6 +3,7 @@
 use 5.010001;
 use strict;
 use warnings;
+use autodie;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
@@ -14,10 +15,8 @@ use Rex::CLI;
 use Rex::Commands::File;
 use Test::Output;
 
-## no critic (ProhibitPunctuationVars);
-## no critic (RequireCheckedSyscalls, RequireCheckedClose);
 ## no critic (RegularExpressions);
-## no critic (Carping, ProhibitNoWarnings, DuplicateLiteral);
+## no critic (ProhibitNoWarnings, DuplicateLiteral);
 
 my $testdir = File::Spec->join( 't', 'rexfiles' );
 
@@ -149,7 +148,7 @@ sub _reset_test {
   $exit_was_called = undef;
 
   # reset log
-  open my $fh, '>', $logfile or die $!;
+  open my $fh, '>', $logfile;
   close $fh;
 
   # reset require

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -14,7 +14,7 @@ use Rex::CLI;
 use Test::Output;
 
 ## no critic (ProhibitPostfixControls, WhileDiamondDefaultAssignment);
-## no critic (ProhibitPunctuationVars, ProhibitPackageVars);
+## no critic (ProhibitPunctuationVars);
 ## no critic (RequireCheckedSyscalls, RequireCheckedClose);
 ## no critic (RegularExpressions);
 ## no critic (Carping, ProhibitNoWarnings, DuplicateLiteral);
@@ -35,7 +35,7 @@ while (<DATA>) {
 }
 close $fh if $fh;
 
-our $exit_was_called = undef;
+my $exit_was_called;
 
 # we must disable Rex::CLI::exit() sub imported from Rex::Commands
 no warnings 'redefine';

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -13,10 +13,11 @@ use File::Spec;
 use File::Temp;
 use Rex::CLI;
 use Rex::Commands::File;
+use Sub::Override;
 use Test::Output;
 
 ## no critic (RegularExpressions);
-## no critic (ProhibitNoWarnings, DuplicateLiteral);
+## no critic (DuplicateLiteral);
 
 $Rex::Logger::format = '%l - %s';
 
@@ -26,10 +27,8 @@ my $empty        = q();
 
 my ( $exit_was_called, $expected );
 
-# we must disable Rex::CLI::exit() sub imported from Rex::Commands
-no warnings 'redefine';
-local *Rex::CLI::exit = sub { $exit_was_called = 1 };
-use warnings 'redefine';
+my $override =
+  Sub::Override->new( 'Rex::CLI::exit' => sub { $exit_was_called = 1 } );
 
 #
 # enable this to debug!

--- a/t/rexfiles/Rexfile_fatal
+++ b/t/rexfiles/Rexfile_fatal
@@ -1,4 +1,5 @@
 use Rex;
-aaaabbbbcccc
-task test => sub { say "test3" };
 
+abc
+
+task 'test', sub { };

--- a/t/rexfiles/Rexfile_fatal
+++ b/t/rexfiles/Rexfile_fatal
@@ -1,0 +1,4 @@
+use Rex;
+aaaabbbbcccc
+task test => sub { say "test3" };
+

--- a/t/rexfiles/Rexfile_fatal.log
+++ b/t/rexfiles/Rexfile_fatal.log
@@ -1,0 +1,5 @@
+ERROR - Compile time errors:
+ERROR - 	syntax error at Rexfile line 5, near "abc
+ERROR - 	
+ERROR - 	task "
+ERROR - 	Compilation failed in require at %REX_CLI_PATH% line 756.

--- a/t/rexfiles/Rexfile_fatal_print
+++ b/t/rexfiles/Rexfile_fatal_print
@@ -1,0 +1,8 @@
+use Rex;
+print STDERR 'This is STDERR message';
+print STDOUT 'This is STDOUT message';
+aaaabbbbcccc
+print STDERR 'This is STDERR message';
+print STDOUT 'This is STDOUT message';
+task test2 => sub { say "test6" };
+

--- a/t/rexfiles/Rexfile_fatal_print
+++ b/t/rexfiles/Rexfile_fatal_print
@@ -1,8 +1,11 @@
 use Rex;
-print STDERR 'This is STDERR message';
-print STDOUT 'This is STDOUT message';
-aaaabbbbcccc
-print STDERR 'This is STDERR message';
-print STDOUT 'This is STDOUT message';
-task test2 => sub { say "test6" };
 
+print STDERR "This is STDERR message\n";
+print STDOUT "This is STDOUT message\n";
+
+abc
+
+print STDERR "This is STDERR message\n";
+print STDOUT "This is STDOUT message\n";
+
+task 'test', sub { };

--- a/t/rexfiles/Rexfile_fatal_print.log
+++ b/t/rexfiles/Rexfile_fatal_print.log
@@ -1,0 +1,5 @@
+ERROR - Compile time errors:
+ERROR - 	syntax error at Rexfile line 8, near "abc
+ERROR - 	
+ERROR - 	print"
+ERROR - 	Compilation failed in require at %REX_CLI_PATH% line 756.

--- a/t/rexfiles/Rexfile_noerror
+++ b/t/rexfiles/Rexfile_noerror
@@ -1,4 +1,3 @@
 use Rex;
-user 'testuser';
-task test => sub { say "test1" };
 
+task 'test', sub { };

--- a/t/rexfiles/Rexfile_noerror
+++ b/t/rexfiles/Rexfile_noerror
@@ -1,0 +1,4 @@
+use Rex;
+user 'testuser';
+task test => sub { say "test1" };
+

--- a/t/rexfiles/Rexfile_noerror_print
+++ b/t/rexfiles/Rexfile_noerror_print
@@ -1,0 +1,6 @@
+use Rex;
+user 'testuser';
+print STDERR 'This is STDERR message';
+print STDOUT 'This is STDOUT message';
+task test2 => sub { say "test4" };
+

--- a/t/rexfiles/Rexfile_noerror_print
+++ b/t/rexfiles/Rexfile_noerror_print
@@ -1,6 +1,6 @@
 use Rex;
-user 'testuser';
-print STDERR 'This is STDERR message';
-print STDOUT 'This is STDOUT message';
-task test2 => sub { say "test4" };
 
+print STDERR "This is STDERR message\n";
+print STDOUT "This is STDOUT message\n";
+
+task 'test', sub { };

--- a/t/rexfiles/Rexfile_noerror_print.stderr
+++ b/t/rexfiles/Rexfile_noerror_print.stderr
@@ -1,0 +1,1 @@
+This is STDERR message

--- a/t/rexfiles/Rexfile_noerror_print.stdout
+++ b/t/rexfiles/Rexfile_noerror_print.stdout
@@ -1,0 +1,1 @@
+This is STDOUT message

--- a/t/rexfiles/Rexfile_warnings
+++ b/t/rexfiles/Rexfile_warnings
@@ -1,7 +1,8 @@
 use Rex;
-use warnings;
-warn 'This is warning';
-my $undef; my $warn = 'warn'.$undef;
-user 'testuser';
-task test => sub { say "test2" };
 
+use warnings;
+
+warn 'This is warning';
+my $warn = 'warn' . undef;
+
+task 'test', sub { };

--- a/t/rexfiles/Rexfile_warnings
+++ b/t/rexfiles/Rexfile_warnings
@@ -1,0 +1,7 @@
+use Rex;
+use warnings;
+warn 'This is warning';
+my $undef; my $warn = 'warn'.$undef;
+user 'testuser';
+task test => sub { say "test2" };
+

--- a/t/rexfiles/Rexfile_warnings.log
+++ b/t/rexfiles/Rexfile_warnings.log
@@ -1,0 +1,3 @@
+WARN - You have some code warnings:
+WARN - 	This is warning at Rexfile line 5.
+WARN - 	Use of uninitialized value in concatenation (.) or string at Rexfile line 6.

--- a/t/rexfiles/Rexfile_warnings_print
+++ b/t/rexfiles/Rexfile_warnings_print
@@ -1,9 +1,11 @@
 use Rex;
-use warnings;
-warn 'This is warning';
-my $undef; my $warn = 'warn'.$undef;
-print STDERR 'This is STDERR message';
-print STDOUT 'This is STDOUT message';
-user 'testuser';
-task test2 => sub { say "test5" };
 
+use warnings;
+
+warn 'This is warning';
+my $warn = 'warn' . undef;
+
+print STDERR "This is STDERR message\n";
+print STDOUT "This is STDOUT message\n";
+
+task 'test', sub { };

--- a/t/rexfiles/Rexfile_warnings_print
+++ b/t/rexfiles/Rexfile_warnings_print
@@ -1,0 +1,9 @@
+use Rex;
+use warnings;
+warn 'This is warning';
+my $undef; my $warn = 'warn'.$undef;
+print STDERR 'This is STDERR message';
+print STDOUT 'This is STDOUT message';
+user 'testuser';
+task test2 => sub { say "test5" };
+

--- a/t/rexfiles/Rexfile_warnings_print.log
+++ b/t/rexfiles/Rexfile_warnings_print.log
@@ -1,0 +1,3 @@
+WARN - You have some code warnings:
+WARN - 	This is warning at Rexfile line 5.
+WARN - 	Use of uninitialized value in concatenation (.) or string at Rexfile line 6.

--- a/t/rexfiles/Rexfile_warnings_print.stderr
+++ b/t/rexfiles/Rexfile_warnings_print.stderr
@@ -1,0 +1,4 @@
+This is STDERR message
+WARN - You have some code warnings:
+WARN - 	This is warning at Rexfile line 5.
+WARN - 	Use of uninitialized value in concatenation (.) or string at Rexfile line 6.

--- a/t/rexfiles/Rexfile_warnings_print.stdout
+++ b/t/rexfiles/Rexfile_warnings_print.stdout
@@ -1,0 +1,1 @@
+This is STDOUT message

--- a/t/rexfiles/no_Rexfile.log
+++ b/t/rexfiles/no_Rexfile.log
@@ -1,0 +1,4 @@
+WARN - No Rexfile found.
+WARN - Create a file named 'Rexfile' in this directory,
+WARN - or specify the file you want to use with:
+WARN -    rex -f file_to_use task_to_run


### PR DESCRIPTION
This PR is an attempt to fix #1521
Also test for load_rexfile() is added.

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
