### PR TITLE
POD: Make @regexp optional in syntax

### DIFF
--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -1016,7 +1016,7 @@ sub delete_lines_according_to {
 
 }
 
-=head2 append_if_no_such_line($file, $new_line, @regexp)
+=head2 append_if_no_such_line($file, $new_line[, @regexp])
 
 Append $new_line to $file if none in @regexp is found. If no regexp is
 supplied, the line is appended unless there is already an identical line


### PR DESCRIPTION
Docs: made `@regexp` argument optional in the syntax since:

> If no regexp is supplied, the line is appended unless there is already an identical line in $file.

It confused me to pass a third argument reading the function POD in MetaCPAN.

cf. `extract($file [, %options])` ibid.

https://metacpan.org/pod/Rex::Commands::File#append_if_no_such_line($file,-$new_line,-@regexp)

This PR is an attempt to fix `append_if_no_such_line` function documentation.

## Checklist

- [ ] based on top of latest source code
- [ ] changelog entry included (minor change)
- [ ] tests pass in CI (documentation change)
- [ ] git history is clean
- [ ] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
