### PR TITLE
[doc] Rex::Commands::File: correct optional argument syntax

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Revision history for Rex
  - Detect invalid hostgroup expressions
 
  [DOCUMENTATION]
+ - Clarify optional arguments of file commands
 
  [ENHANCEMENTS]
 

--- a/lib/Rex/Commands/File.pm
+++ b/lib/Rex/Commands/File.pm
@@ -97,7 +97,7 @@ use base qw(Rex::Exporter);
 
 use vars qw(%file_handles);
 
-=head2 template($file, @params)
+=head2 template($file [, %params])
 
 Parse a template and return the content.
 
@@ -290,7 +290,7 @@ sub _get_std_template_vars {
   return %template_vars;
 }
 
-=head2 file($file_name, %options)
+=head2 file($file_name [, %options])
 
 This function is the successor of I<install file>. Please use this function to upload files to your server.
 
@@ -972,7 +972,7 @@ OUT:
     ->report_resource_end( type => "delete_lines_matching", name => $file );
 }
 
-=head2 delete_lines_according_to($search, $file, @options)
+=head2 delete_lines_according_to($search, $file [, @options])
 
 This is the successor of the delete_lines_matching() function. This function also allows the usage of on_change and on_no_change hooks.
 
@@ -1016,7 +1016,7 @@ sub delete_lines_according_to {
 
 }
 
-=head2 append_if_no_such_line($file, $new_line, @regexp)
+=head2 append_if_no_such_line($file, $new_line [, @regexp])
 
 Append $new_line to $file if none in @regexp is found. If no regexp is
 supplied, the line is appended unless there is already an identical line
@@ -1047,7 +1047,7 @@ sub append_if_no_such_line {
   _append_or_update( 'append_if_no_such_line', @_ );
 }
 
-=head2 append_or_amend_line($file, $line, @regexp)
+=head2 append_or_amend_line($file, $line [, @regexp])
 
 Similar to L<append_if_no_such_line>, but if the line in the regexp is
 found, it will be updated. Otherwise, it will be appended.
@@ -1302,7 +1302,7 @@ sub extract {
 
 }
 
-=head2 sed($search, $replace, $file)
+=head2 sed($search, $replace, $file [, %options])
 
 Search some string in a file and replace it.
 


### PR DESCRIPTION
Clarify commands docs taking optional arguments such as append_if_no_such_file

I hope I did all the changes except creating an issue first which I promise to do the next time :-)

https://github.com/RexOps/Rex/pull/1526

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
