### PR TITLE
Test on more Perl versions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -176,7 +176,6 @@ jobs:
           - '5.16'
           - '5.14'
           - '5.12'
-          - '5.10'
         exclude:
           - os: windows
             perl: '5.34' # not released yet
@@ -184,8 +183,6 @@ jobs:
             perl: '5.32' # 5.32 is latest
           - os: windows
             perl: '5.12' # no 64-bit portable binaries
-          - os: windows
-            perl: '5.10' # no 64-bit portable binaries
 
     runs-on: ${{ matrix.os }}-latest
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -164,6 +164,28 @@ jobs:
           - windows
         perl:
           - latest
+          - '5.34'
+          - '5.32'
+          - '5.30'
+          - '5.28'
+          - '5.26'
+          - '5.24'
+          - '5.22'
+          - '5.20'
+          - '5.18'
+          - '5.16'
+          - '5.14'
+          - '5.12'
+          - '5.10'
+        exclude:
+          - os: windows
+            perl: '5.34' # not released yet
+          - os: windows
+            perl: '5.32' # 5.32 is latest
+          - os: windows
+            perl: '5.12' # no 64-bit portable binaries
+          - os: windows
+            perl: '5.10' # no 64-bit portable binaries
 
     runs-on: ${{ matrix.os }}-latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,10 @@ As a general rule, managing an endpoint with Rex is only supported for platforms
 
 ### Supported Perl versions
 
-Rex aims to run even on older Perl versions up to 10 years old. Currently this means 5.10.1. The recommended minimum version of Perl on Windows is 5.20.3.
+Rex aims to run even on older Perl versions up to 10 years old. Currently this means 5.12.5. The recommended minimum version of Perl on Windows is 5.20.3.
 
 On top of the supported minimum version of Perl, the goal is to support the latest versions of all minor Perl 5 releases. That makes the full list the following:
 
-- 5.10.1
 - 5.12.5
 - 5.14.4
 - 5.16.3

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Detect invalid hostgroup expressions
  - Prevent empty log lines upon Rexfile warnings
+ - Fix tests on Strawberry Perl older than 5.18.4
 
  [DOCUMENTATION]
  - Clarify optional arguments of file commands

--- a/ChangeLog
+++ b/ChangeLog
@@ -20,6 +20,7 @@ Revision history for Rex
  [MAJOR]
 
  [MINOR]
+ - Set minimum required Perl version to 5.12.5
 
  [NEW FEATURES]
 

--- a/dist.ini
+++ b/dist.ini
@@ -71,7 +71,7 @@ overwrite = 1
 [RunExtraTests]
 
 [Prereqs]
-perl = 5.010001
+perl = 5.12.5
 YAML = != 1.25
 
 [Prereqs / DevelopRequires]
@@ -110,7 +110,7 @@ File::LibMagic = 0
 Test::mysqld = 0
 
 [Test::MinimumVersion]
-max_target_perl = 5.10.1
+max_target_perl = 5.12.5
 
 [Test::Kwalitee]
 

--- a/t/file_hooks.t
+++ b/t/file_hooks.t
@@ -37,7 +37,7 @@ my %code_for = (
 
 for my $test_case ( keys %code_for ) {
   subtest $test_case => sub {
-    my $test_code = shift;
+    my $test_code = $code_for{$test_case};
 
     $before = $before_change = $after_change = $after = 0;
 
@@ -47,9 +47,7 @@ for my $test_case ( keys %code_for ) {
     is( $before_change, 1, 'before_change hook ran' );
     is( $after_change,  1, 'after_change hook ran' );
     is( $after,         1, 'after hook ran' );
-
-    },
-    $code_for{$test_case};
+  };
 }
 
 sub expected_params {


### PR DESCRIPTION
This PR is a proposal to fix #1560 by enabling tests on older Perl versions, not just the latest available for the given distributions.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] tests pass in CI <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)