### PR TITLE
Expect original Rexfile path in messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ Revision history for Rex
  - Correct example for file_read command
 
  [ENHANCEMENTS]
+ - Show Rexfile path in loading messages
 
  [MAJOR]
 

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -767,7 +767,7 @@ sub load_rexfile {
         s{/loader/[^/]+/}{}sxm;
 
         # convert Rexfile to human-friendly name
-        s{__Rexfile__.pm}{Rexfile}msx;
+        s{__Rexfile__.pm}{$rexfile}msx;
 
         Rex::Logger::info( "\t$_", 'warn' );
       }
@@ -785,7 +785,7 @@ sub load_rexfile {
     $e =~ s|/loader/[^/]+/||smg;
 
     # convert Rexfile to human-friendly name
-    $e =~ s{__Rexfile__.pm}{Rexfile}msx;
+    $e =~ s{__Rexfile__.pm}{$rexfile}gmsx;
 
     my @lines = split( $/, $e );
 

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -763,13 +763,9 @@ sub load_rexfile {
       for (@warnings) {
         chomp;
 
-        # remove /loader/.../ prefix before filename
-        s{/loader/[^/]+/}{}sxm;
+        my $message = _tidy_loading_message( $_, $rexfile );
 
-        # convert Rexfile to human-friendly name
-        s{__Rexfile__.pm}{$rexfile}msx;
-
-        Rex::Logger::info( "\t$_", 'warn' );
+        Rex::Logger::info( "\t$message", 'warn' );
       }
     }
 
@@ -780,12 +776,7 @@ sub load_rexfile {
     my $e = $@;
     chomp $e;
 
-    # remove the strange path to the Rexfile which exists because
-    # we load the Rexfile via our custom code block.
-    $e =~ s|/loader/[^/]+/||smg;
-
-    # convert Rexfile to human-friendly name
-    $e =~ s{__Rexfile__.pm}{$rexfile}gmsx;
+    $e = _tidy_loading_message( $e, $rexfile );
 
     my @lines = split( $/, $e );
 
@@ -794,6 +785,13 @@ sub load_rexfile {
 
     exit 1;
   }
+}
+
+sub _tidy_loading_message {
+  my ( $message, $rexfile ) = @_;
+
+  $message =~ s{/loader/[^/]+/__Rexfile__[.]pm}{$rexfile}gmsx;
+  return $message;
 }
 
 sub exit_rex {

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -68,6 +68,7 @@ sub _setup_test {
 
     $expected->{$extension} = -r $file ? cat($file) : $default_content;
     $expected->{$extension} =~ s{%REX_CLI_PATH%}{$rex_cli_path}msx;
+    $expected->{$extension} =~ s{%REXFILE_PATH%}{$rexfile}gmsx;
   }
 
   # reset log

--- a/t/rexfiles/Rexfile_fatal.log
+++ b/t/rexfiles/Rexfile_fatal.log
@@ -1,5 +1,5 @@
 ERROR - Compile time errors:
-ERROR - 	syntax error at Rexfile line 5, near "abc
+ERROR - 	syntax error at %REXFILE_PATH% line 5, near "abc
 ERROR - 	
 ERROR - 	task "
 ERROR - 	Compilation failed in require at %REX_CLI_PATH% line 756.

--- a/t/rexfiles/Rexfile_fatal_print.log
+++ b/t/rexfiles/Rexfile_fatal_print.log
@@ -1,5 +1,5 @@
 ERROR - Compile time errors:
-ERROR - 	syntax error at Rexfile line 8, near "abc
+ERROR - 	syntax error at %REXFILE_PATH% line 8, near "abc
 ERROR - 	
 ERROR - 	print"
 ERROR - 	Compilation failed in require at %REX_CLI_PATH% line 756.

--- a/t/rexfiles/Rexfile_warnings.log
+++ b/t/rexfiles/Rexfile_warnings.log
@@ -1,3 +1,3 @@
 WARN - You have some code warnings:
-WARN - 	This is warning at Rexfile line 5.
-WARN - 	Use of uninitialized value in concatenation (.) or string at Rexfile line 6.
+WARN - 	This is warning at %REXFILE_PATH% line 5.
+WARN - 	Use of uninitialized value in concatenation (.) or string at %REXFILE_PATH% line 6.

--- a/t/rexfiles/Rexfile_warnings_print.log
+++ b/t/rexfiles/Rexfile_warnings_print.log
@@ -1,3 +1,3 @@
 WARN - You have some code warnings:
-WARN - 	This is warning at Rexfile line 5.
-WARN - 	Use of uninitialized value in concatenation (.) or string at Rexfile line 6.
+WARN - 	This is warning at %REXFILE_PATH% line 5.
+WARN - 	Use of uninitialized value in concatenation (.) or string at %REXFILE_PATH% line 6.

--- a/t/rexfiles/Rexfile_warnings_print.stderr
+++ b/t/rexfiles/Rexfile_warnings_print.stderr
@@ -1,4 +1,4 @@
 This is STDERR message
 WARN - You have some code warnings:
-WARN - 	This is warning at Rexfile line 5.
-WARN - 	Use of uninitialized value in concatenation (.) or string at Rexfile line 6.
+WARN - 	This is warning at %REXFILE_PATH% line 5.
+WARN - 	Use of uninitialized value in concatenation (.) or string at %REXFILE_PATH% line 6.


### PR DESCRIPTION
This PR is a proposal to fix #1562 by restoring the original Rexfile path in any potential error or warning messages when it gets loaded.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)