### PR TITLE
Hide Perlish error when Rexfile loading fails

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,7 @@ Revision history for Rex
 
  [ENHANCEMENTS]
  - Show Rexfile path in loading messages
+ - Hide internal details when Rexfile loading fails
 
  [MAJOR]
 

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -778,10 +778,23 @@ sub load_rexfile {
 
     $e = _tidy_loading_message( $e, $rexfile );
 
-    my @lines = split( $/, $e );
+    my ( @error_lines, @debug_lines );
+
+    for my $line ( split $/, $e ) {
+      $line =~ m{CLI[.]pm[ ]line[ ]\d+}msx
+        ? push @debug_lines, $line
+        : push @error_lines, $line;
+    }
 
     Rex::Logger::info( "Compile time errors:", 'error' );
-    Rex::Logger::info( "\t$_",                 'error' ) for @lines;
+
+    for my $error_line (@error_lines) {
+      Rex::Logger::info( "\t$error_line", 'error' );
+    }
+
+    for my $debug_line (@debug_lines) {
+      Rex::Logger::debug("\t$debug_line");
+    }
 
     exit 1;
   }

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -67,7 +67,6 @@ sub _setup_test {
     my $default_content = $extension eq 'stderr' ? $expected->{log} : $empty;
 
     $expected->{$extension} = -r $file ? cat($file) : $default_content;
-    $expected->{$extension} =~ s{%REX_CLI_PATH%}{$rex_cli_path}msx;
     $expected->{$extension} =~ s{%REXFILE_PATH%}{$rexfile}gmsx;
   }
 

--- a/t/rexfiles/Rexfile_fatal.log
+++ b/t/rexfiles/Rexfile_fatal.log
@@ -2,4 +2,3 @@ ERROR - Compile time errors:
 ERROR - 	syntax error at %REXFILE_PATH% line 5, near "abc
 ERROR - 	
 ERROR - 	task "
-ERROR - 	Compilation failed in require at %REX_CLI_PATH% line 756.

--- a/t/rexfiles/Rexfile_fatal_print.log
+++ b/t/rexfiles/Rexfile_fatal_print.log
@@ -2,4 +2,3 @@ ERROR - Compile time errors:
 ERROR - 	syntax error at %REXFILE_PATH% line 8, near "abc
 ERROR - 	
 ERROR - 	print"
-ERROR - 	Compilation failed in require at %REX_CLI_PATH% line 756.


### PR DESCRIPTION
This PR is a proposal to fix #477 by showing less useful Perlish error messages only in the debug output when Rexfile loading fails.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)