### PR TITLE
Fix test warnings on Perl before 5.16.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Revision history for Rex
  - Detect invalid hostgroup expressions
  - Prevent empty log lines upon Rexfile warnings
  - Fix tests on Strawberry Perl older than 5.18.4
+ - Fix test warnings on Perl before 5.16.0
 
  [DOCUMENTATION]
  - Clarify optional arguments of file commands

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -13,6 +13,9 @@ BEGIN {
 
 $::QUIET = 1;
 
+$before_task_start_all = $before_task_start = $before_all = $before = $after =
+  $after_all = $after_task_finished = $after_task_finished_all = 0;
+
 timeout 1;
 
 task foo => sub { return "yo" };

--- a/t/hooks_in_rexfile.t
+++ b/t/hooks_in_rexfile.t
@@ -16,6 +16,9 @@ BEGIN {
 
 $::QUIET = 1;
 
+$before_task_start_all = $before_task_start = $before_all = $before = $after =
+  $after_all = $after_task_finished = $after_task_finished_all = 0;
+
 timeout 1;
 
 task foo => sub { return "yo" };

--- a/t/hooks_in_rexfile_tasks_in_pkg.t
+++ b/t/hooks_in_rexfile_tasks_in_pkg.t
@@ -17,6 +17,9 @@ BEGIN {
 
 $::QUIET = 1;
 
+$before_task_start_all = $before_task_start = $before_all = $before = $after =
+  $after_all = $after_task_finished = $after_task_finished_all = 0;
+
 timeout 1;
 
 before_task_start ALL => sub { $before_task_start_all += 1; };

--- a/t/hooks_in_rexfile_tasks_in_pkg.t
+++ b/t/hooks_in_rexfile_tasks_in_pkg.t
@@ -1,5 +1,8 @@
 package Rex::CLI;
 
+use 5.006;
+use warnings;
+
 BEGIN {
   use Test::More tests => 8;
   use lib 't/lib';


### PR DESCRIPTION
This PR is a proposal to fix #1567 by making hook test boilerplate more consistent, and making sure that shared variables have an initial value other than `undef`.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)