### PR TITLE
Fix rendering of inspect example

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Revision history for Rex
  - Fix attempt to free unreferenced scalar on Windows
 
  [DOCUMENTATION]
+ - Fix rendering of inspect example
 
  [ENHANCEMENTS]
 

--- a/lib/Rex/Commands.pm
+++ b/lib/Rex/Commands.pm
@@ -1654,14 +1654,14 @@ sub tmp_dir {
 
 This function dumps the contents of a variable to STDOUT.
 
-task "mytask", "myserver", sub {
-  my $myvar = {
-    name => "foo",
-    sys  => "bar",
-  };
-
-  inspect $myvar;
-};
+ task "mytask", "myserver", sub {
+   my $myvar = {
+     name => "foo",
+     sys  => "bar",
+   };
+ 
+   inspect $myvar;
+ };
 
 =cut
 


### PR DESCRIPTION
This PR is a proposal to fix #1535 by properly indenting the code example of inspect.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)