### PR TITLE
Declare dependencies for colored output

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Fix attempt to free unreferenced scalar on Windows
+ - Declare dependencies for colored output
 
  [DOCUMENTATION]
  - Fix rendering of inspect example

--- a/dist.ini
+++ b/dist.ini
@@ -60,6 +60,7 @@ Net::SFTP::Foreign = 0
 
 [OSPrereqs / ~MSWin]
 Net::SSH2 = 0
+Win32::Console::ANSI = 0
 
 [OurPkgVersion]
 overwrite = 1

--- a/lib/Rex/CLI.pm
+++ b/lib/Rex/CLI.pm
@@ -17,8 +17,11 @@ use Time::HiRes    qw(gettimeofday tv_interval);
 use Cwd            qw(getcwd);
 use List::Util     qw(max);
 use Text::Wrap;
+use Term::ANSIColor;
 use Term::ReadKey;
 use Sort::Naturally;
+
+use if $OSNAME eq 'MSWin32', 'Win32::Console::ANSI';
 
 use Rex;
 use Rex::Args;
@@ -32,13 +35,6 @@ use YAML;
 use Data::Dumper;
 
 my $no_color = 0;
-eval "use Term::ANSIColor";
-if ($EVAL_ERROR) { $no_color = 1; }
-
-if ( $OSNAME =~ m/MSWin/ ) {
-  eval "use Win32::Console::ANSI";
-  if ($EVAL_ERROR) { $no_color = 1; }
-}
 
 # preload some modules
 use Rex -base;

--- a/lib/Rex/Logger.pm
+++ b/lib/Rex/Logger.pm
@@ -35,15 +35,11 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use English qw(-no_match_vars);
+use Term::ANSIColor;
+
+use if $OSNAME eq 'MSWin32', 'Win32::Console::ANSI';
 
 our $no_color = 0;
-eval "use Term::ANSIColor";
-if ($EVAL_ERROR) { $no_color = 1; }
-
-if ( $OSNAME =~ m/MSWin/ ) {
-  eval "use Win32::Console::ANSI";
-  if ($EVAL_ERROR) { $no_color = 1; }
-}
 
 my $has_syslog = 0;
 my $log_fh;

--- a/t/os_dependencies.t
+++ b/t/os_dependencies.t
@@ -5,7 +5,7 @@ use Test::More;
 use Rex::Commands;
 
 my $dependency_ref = case $^O, {
-  qr{MSWin} => [qw(Net::SSH2)],
+  qr{MSWin} => [qw(Net::SSH2 Win32::Console::ANSI)],
     default => [qw(Net::OpenSSH Net::SFTP::Foreign IO::Pty)],
 };
 


### PR DESCRIPTION
This PR is a proposal to fix #960 by promoting dependencies related to colored output from being optional:

- Term::ANSIColor to normal dependency
- Win32::Console::ANSI an OS-specific dependency on Windows

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)