### PR TITLE
Expect no warnings when splitting path of rootdir

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Fix attempt to free unreferenced scalar on Windows
  - Declare dependencies for colored output
+ - Fix warning when trying to create root directory
 
  [DOCUMENTATION]
  - Fix rendering of inspect example

--- a/lib/Rex/Commands/Fs.pm
+++ b/lib/Rex/Commands/Fs.pm
@@ -319,29 +319,7 @@ sub mkdir {
     &chmod( $mode, $dir )  if $mode;
   }
   else {
-    my @splitted_dir;
-
-    if ( Rex::is_ssh == 0 && $^O =~ m/^MSWin/ ) {
-
-      # special case for local windows runs
-      @splitted_dir = map { "\\$_"; } split( /[\\\/]/, $dir );
-      if ( $splitted_dir[0] =~ m/([a-z]):/i ) {
-        $splitted_dir[0] = "$1:\\";
-      }
-      else {
-        $splitted_dir[0] =~ s/^\\//;
-      }
-    }
-    else {
-      @splitted_dir = map { "/$_"; } split( /\//, $dir );
-
-      unless ( $splitted_dir[0] eq "/" ) {
-        $splitted_dir[0] = "." . $splitted_dir[0];
-      }
-      else {
-        shift @splitted_dir;
-      }
-    }
+    my @splitted_dir = __splitdir($dir);
 
     my $str_part = "";
     for my $part (@splitted_dir) {
@@ -397,6 +375,35 @@ sub mkdir {
     ->report_resource_end( type => "mkdir", name => $dir );
 
   return 1;
+}
+
+sub __splitdir {
+  my $dir = shift;
+  my @splitted_dir;
+
+  if ( Rex::is_ssh == 0 && $^O =~ m/^MSWin/ ) {
+
+    # special case for local windows runs
+    @splitted_dir = map { "\\$_"; } split( /[\\\/]/, $dir );
+    if ( $splitted_dir[0] =~ m/([a-z]):/i ) {
+      $splitted_dir[0] = "$1:\\";
+    }
+    else {
+      $splitted_dir[0] =~ s/^\\//;
+    }
+  }
+  else {
+    @splitted_dir = map { "/$_"; } split( /\//, $dir );
+
+    unless ( $splitted_dir[0] eq "/" ) {
+      $splitted_dir[0] = "." . $splitted_dir[0];
+    }
+    else {
+      shift @splitted_dir;
+    }
+  }
+
+  return @splitted_dir;
 }
 
 =head3 chown($owner, $path)

--- a/t/fs.t
+++ b/t/fs.t
@@ -3,11 +3,13 @@
 use v5.12.5;
 use warnings;
 
-use Test::More tests => 3;
+use Test::More tests => 5;
 
+use File::Spec;
 use File::Temp;
 use Rex::Commands::Fs;
 use Test::Exception;
+use Test::Warnings;
 
 subtest 'stat fails for a nonexistent file', sub {
   plan tests => 2;
@@ -46,3 +48,10 @@ for my $case ( keys %path_for ) {
     ok( !-e $path, "$path doesn't exist anymore" );
   };
 }
+
+subtest 'no warnings for splitting the path of the root directory', sub {
+  plan tests => 1;
+
+  ok( Rex::Commands::Fs::__splitdir( File::Spec->rootdir() ),
+    'splitting up path of the root directory' );
+};


### PR DESCRIPTION
This PR is a proposal to fix #1491 by fixing a warning when to calling `mkdir` on a root directory.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)