### PR TITLE
Clarify sync command locality

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,7 @@ Revision history for Rex
 
  [DOCUMENTATION]
  - Clarify PATH settings for executing commands
+ - Clarify sync command locality
 
  [ENHANCEMENTS]
 

--- a/lib/Rex/Commands/Rsync.pm
+++ b/lib/Rex/Commands/Rsync.pm
@@ -69,7 +69,7 @@ use Rex::Interface::Shell;
 
 =head2 sync($source, $dest, $opts)
 
-This function executes rsync to sync $source and $dest. The C<rsync> command is
+This function executes the rsync command I<on the local machine> (where rex is being run) to sync $source and $dest with a remote. The C<rsync> command is
 invoked with the C<--recursive --links --verbose --stats> options set.
 
 If you want to use sudo, you need to disable I<requiretty> option for this user. You can do this with the following snippet in your sudoers configuration.


### PR DESCRIPTION
This PR is a proposal to fix #1025 by describing that the underlying `rsync` command is being run on the local machine where rex is being run.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)