### PR TITLE
Fix Rexfile loading tests after perl-5.37.9

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Fix switching working directory to another drive
  - Fix git cloning into an existing empty directory
+ - Fix Rexfile loading tests after perl-5.37.9
 
  [DOCUMENTATION]
 

--- a/t/rexfiles/Rexfile_fatal.log
+++ b/t/rexfiles/Rexfile_fatal.log
@@ -2,3 +2,4 @@ ERROR - Compile time errors:
 ERROR - 	syntax error at %REXFILE_PATH% line 5, near "abc
 ERROR - 	
 ERROR - 	task "
+ERROR - 	Execution of %REXFILE_PATH% aborted due to compilation errors.

--- a/t/rexfiles/Rexfile_fatal_print.log
+++ b/t/rexfiles/Rexfile_fatal_print.log
@@ -2,3 +2,4 @@ ERROR - Compile time errors:
 ERROR - 	syntax error at %REXFILE_PATH% line 8, near "abc
 ERROR - 	
 ERROR - 	print"
+ERROR - 	Execution of %REXFILE_PATH% aborted due to compilation errors.


### PR DESCRIPTION
This PR is a proposal to fix #1585 by expecting an extra line of error output upon Rexfile load failures when perl-5.37.9 or later is used.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)