### PR TITLE
Fix skipping tests without git

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix skipping tests without git
 
  [DOCUMENTATION]
 

--- a/t/scm/git.t
+++ b/t/scm/git.t
@@ -5,7 +5,7 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 8;
+use Test::More;
 use Test::Exception;
 
 use File::Spec;
@@ -19,7 +19,10 @@ $::QUIET = 1;
 
 my $git = can_run('git');
 
-if ( !defined $git ) {
+if ( defined $git ) {
+  plan tests => 8;
+}
+else {
   plan skip_all => 'Can not find git command';
 }
 


### PR DESCRIPTION
This PR is a proposal to fix #1588 by avoiding planning tests twice when `git` is missing on the system running the tests.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)