### PR TITLE
Fix changing directory into git test repository

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Fix skipping tests without git
+ - Fix changing directory into git test repository
 
  [DOCUMENTATION]
 

--- a/t/scm/git.t
+++ b/t/scm/git.t
@@ -77,12 +77,12 @@ subtest 'clone into existing directory', sub {
 sub prepare_test_repo {
   my $directory = shift;
 
-  i_run qq(git -C $directory init);
+  i_run 'git init', cwd => $directory;
 
-  i_run qq(git -C $directory config user.name Rex);
-  i_run qq(git -C $directory config user.email noreply\@rexify.org);
+  i_run 'git config user.name Rex',                 cwd => $directory;
+  i_run 'git config user.email noreply@rexify.org', cwd => $directory;
 
-  i_run qq(git -C $directory commit --allow-empty -m commit);
+  i_run 'git commit --allow-empty -m commit', cwd => $directory;
 
   return;
 }


### PR DESCRIPTION
This PR is a proposal to fix #1589 by changing directory into the git test repository explicitly instead of using `git -C`.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)