### PR TITLE
Fix checking test git repository

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix checking test git repository
 
  [DOCUMENTATION]
 

--- a/t/scm/git.t
+++ b/t/scm/git.t
@@ -96,7 +96,7 @@ sub git_repo_ok {
     "$directory has .git subdirectory"
   );
 
-  lives_ok { i_run qq(git -C $directory rev-parse --git-dir) }
+  lives_ok { i_run 'git rev-parse --git-dir', cwd => $directory }
   "$directory looks like a git repository now";
 
   return;


### PR DESCRIPTION
This PR is a proposal to fix #1595 by `cd`-ing into the test directory instead of relying `git -C`.

This is a follow-up on a similar change via #1591.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)