### PR TITLE
update Rex::Hardware::VirtInfo to work in a cross platform manner

### DIFF
--- a/lib/Rex/Hardware/VirtInfo.pm
+++ b/lib/Rex/Hardware/VirtInfo.pm
@@ -5,6 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
+use English qw(-no_match_vars);
+
 use Rex;
 use Rex::Helper::Run;
 use Rex::Commands::Fs;
@@ -24,14 +26,14 @@ sub get {
     return $cache->get($cache_key_name);
   }
 
-  if ( Rex::is_ssh || $^O !~ m/^MSWin/i ) {
+  if ( Rex::is_ssh || $OSNAME !~ m/^MSWin/i ) {
 
     my (
       $product_name, $bios_vendor, $sys_vendor,
       $self_status,  $cpuinfo,     $modules
     ) = ( '', '', '', '', '', '' );
 
-    if ( $^O eq 'linux' ) {
+    if ( $OSNAME eq 'linux' ) {
       $product_name =
         i_run "cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null",
         fail_ok => 1;
@@ -51,17 +53,17 @@ sub get {
 
     $self_status = i_run "cat /proc/self/status 2>/dev/null", fail_ok => 1;
 
-    if ( $^O eq 'linux' ) {
+    if ( $OSNAME eq 'linux' ) {
       $cpuinfo = i_run "cat /proc/cpuinfo 2>/dev/null", fail_ok => 1;
     }
     else {
       $cpuinfo = i_run "dmidecode -t processor 2>/dev/null", fail_ok => 1;
     }
 
-    if ( $^O eq 'linux' ) {
+    if ( $OSNAME eq 'linux' ) {
       $modules = i_run "cat /proc/modules 2>/dev/null", fail_ok => 1;
     }
-    elsif ( $^O eq 'freebsd' ) {
+    elsif ( $OSNAME eq 'freebsd' ) {
       $modules = i_run "/sbin/kldstat 2>/dev/null", fail_ok => 1;
     }
 
@@ -145,56 +147,56 @@ sub get {
       }
     }
 
-    elsif ( $^O eq 'linux' && $cpuinfo =~ /model name.*QEMU Virtual CPU/ ) {
+    elsif ( $OSNAME eq 'linux' && $cpuinfo =~ /model name.*QEMU Virtual CPU/ ) {
       $virtualization_type = "kvm";
       $virtualization_role = "guest";
     }
 
-    elsif ( $^O ne 'linux' && $cpuinfo =~ /Manufacturer.*QEMU Virtual CPU/ ) {
+    elsif ( $OSNAME ne 'linux' && $cpuinfo =~ /Manufacturer.*QEMU Virtual CPU/ ) {
       $virtualization_type = "qemu";
       $virtualization_role = "guest";
     }
 
-    elsif ( $^O eq 'linux'
+    elsif ( $OSNAME eq 'linux'
       && $cpuinfo =~ /vendor_id.*User Mode Linux|model name.*UML/ )
     {
       $virtualization_type = "uml";
       $virtualization_role = "guest";
     }
 
-    elsif ( $^O ne 'linux'
+    elsif ( $OSNAME ne 'linux'
       && $cpuinfo =~ /Manufacturer.*User Mode Linux|model name.*UML/ )
     {
       $virtualization_type = "uml";
       $virtualization_role = "guest";
     }
 
-    elsif ( $^O eq 'linux' && $cpuinfo =~ /vendor_id.*PowerVM Lx86/ ) {
+    elsif ( $OSNAME eq 'linux' && $cpuinfo =~ /vendor_id.*PowerVM Lx86/ ) {
       $virtualization_type = "powervm_lx86";
       $virtualization_role = "guest";
     }
 
-    elsif ( $^O ne 'linux' && $cpuinfo =~ /Manufacturer.*PowerVM Lx86/ ) {
+    elsif ( $OSNAME ne 'linux' && $cpuinfo =~ /Manufacturer.*PowerVM Lx86/ ) {
       $virtualization_type = "powervm_lx86";
       $virtualization_role = "guest";
     }
 
-    elsif ( $^O eq 'linux' && $cpuinfo =~ /vendor_id.*IBM\/S390/ ) {
+    elsif ( $OSNAME eq 'linux' && $cpuinfo =~ /vendor_id.*IBM\/S390/ ) {
       $virtualization_type = "ibm_systemz";
       $virtualization_role = "guest";
     }
 
-    elsif ( $^O ne 'linux' && $cpuinfo =~ /Manufacturer.*IBM\/S390/ ) {
+    elsif ( $OSNAME ne 'linux' && $cpuinfo =~ /Manufacturer.*IBM\/S390/ ) {
       $virtualization_type = "ibm_systemz";
       $virtualization_role = "guest";
     }
 
-    elsif ( $modules =~ /kvm/ && $^O eq 'linux' ) {
+    elsif ( $OSNAME eq 'linux' && $modules =~ /kvm/ ) {
       $virtualization_type = "kvm";
       $virtualization_role = "host";
     }
 
-    elsif ( $modules =~ /\ vmm\.ko/s && $^O eq 'freebsd' ) {
+    elsif ( $OSNAME eq 'linux' && $modules =~ /\ vmm\.ko/s ) {
       $virtualization_type = "bhyve";
       $virtualization_role = "host";
     }

--- a/lib/Rex/Hardware/VirtInfo.pm
+++ b/lib/Rex/Hardware/VirtInfo.pm
@@ -96,7 +96,7 @@ sub get {
       $virtualization_role = "guest";
     }
 
-    elsif ( $product_name =~ /BHYVE/ ) {
+    elsif ( $product_name =~ /BHYVE/s ) {
       $virtualization_type = "bhyve";
       $virtualization_role = "guest";
     }
@@ -111,7 +111,7 @@ sub get {
       $virtualization_role = "guest";
     }
 
-    elsif ( $bios_vendor =~ /BHYVE/ ) {
+    elsif ( $bios_vendor =~ /BHYVE/s ) {
       $virtualization_type = "bhyve";
       $virtualization_role = "guest";
     }
@@ -194,7 +194,7 @@ sub get {
       $virtualization_role = "host";
     }
 
-    elsif ( $modules =~ /vmm/ && $^O eq 'freebsd' ) {
+    elsif ( $modules =~ /\ vmm\.ko/s && $^O eq 'freebsd' ) {
       $virtualization_type = "bhyve";
       $virtualization_role = "host";
     }

--- a/lib/Rex/Hardware/VirtInfo.pm
+++ b/lib/Rex/Hardware/VirtInfo.pm
@@ -31,35 +31,38 @@ sub get {
       $self_status,  $cpuinfo,     $modules
     ) = ( '', '', '', '', '', '' );
 
-    if ($^O eq 'linux') {
-        $product_name =
-          i_run "cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null",
-          fail_ok => 1;
-        $bios_vendor =
-            i_run "cat /sys/devices/virtual/dmi/id/bios_vendor 2>/dev/null",
-            fail_ok => 1;
-        $sys_vendor =
-              i_run "cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null",
-              fail_ok => 1;
-    } else {
-        my $bios = Rex::Inventory::Bios::get();
-        $bios_vendor = $bios->get_bios()->get_vendor;
-        $product_name = $bios->get_system_information()->get_product_name;
-        $sys_vendor = $bios->get_system_information()->get_manufacturer;
+    if ( $^O eq 'linux' ) {
+      $product_name =
+        i_run "cat /sys/devices/virtual/dmi/id/product_name 2>/dev/null",
+        fail_ok => 1;
+      $bios_vendor =
+        i_run "cat /sys/devices/virtual/dmi/id/bios_vendor 2>/dev/null",
+        fail_ok => 1;
+      $sys_vendor =
+        i_run "cat /sys/devices/virtual/dmi/id/sys_vendor 2>/dev/null",
+        fail_ok => 1;
+    }
+    else {
+      my $bios = Rex::Inventory::Bios::get();
+      $bios_vendor  = $bios->get_bios()->get_vendor;
+      $product_name = $bios->get_system_information()->get_product_name;
+      $sys_vendor   = $bios->get_system_information()->get_manufacturer;
     }
 
     $self_status = i_run "cat /proc/self/status 2>/dev/null", fail_ok => 1;
 
     if ( $^O eq 'linux' ) {
-        $cpuinfo     = i_run "cat /proc/cpuinfo 2>/dev/null",     fail_ok => 1;
-    } else {
-        $cpuinfo     = i_run "dmidecode -t processor 2>/dev/null",     fail_ok => 1;
+      $cpuinfo = i_run "cat /proc/cpuinfo 2>/dev/null", fail_ok => 1;
+    }
+    else {
+      $cpuinfo = i_run "dmidecode -t processor 2>/dev/null", fail_ok => 1;
     }
 
     if ( $^O eq 'linux' ) {
-        $modules     = i_run "cat /proc/modules 2>/dev/null",     fail_ok => 1;
-    } elsif ( $^O eq 'freebsd' ) {
-        $modules     = i_run "/sbin/kldstat 2>/dev/null",     fail_ok => 1;
+      $modules = i_run "cat /proc/modules 2>/dev/null", fail_ok => 1;
+    }
+    elsif ( $^O eq 'freebsd' ) {
+      $modules = i_run "/sbin/kldstat 2>/dev/null", fail_ok => 1;
     }
 
     my ( $virtualization_type, $virtualization_role ) = ( '', '' );
@@ -147,27 +150,31 @@ sub get {
       $virtualization_role = "guest";
     }
 
-     elsif ( $^O ne 'linux' && $cpuinfo =~ /Manufacturer.*QEMU Virtual CPU/ ) {
+    elsif ( $^O ne 'linux' && $cpuinfo =~ /Manufacturer.*QEMU Virtual CPU/ ) {
       $virtualization_type = "qemu";
       $virtualization_role = "guest";
     }
 
-    elsif ($^O eq 'linux' && $cpuinfo =~ /vendor_id.*User Mode Linux|model name.*UML/ ) {
+    elsif ( $^O eq 'linux'
+      && $cpuinfo =~ /vendor_id.*User Mode Linux|model name.*UML/ )
+    {
       $virtualization_type = "uml";
       $virtualization_role = "guest";
     }
 
-    elsif ($^O ne 'linux' && $cpuinfo =~ /Manufacturer.*User Mode Linux|model name.*UML/ ) {
+    elsif ( $^O ne 'linux'
+      && $cpuinfo =~ /Manufacturer.*User Mode Linux|model name.*UML/ )
+    {
       $virtualization_type = "uml";
       $virtualization_role = "guest";
     }
 
-    elsif ( $^O eq 'linux' &&  $cpuinfo =~ /vendor_id.*PowerVM Lx86/ ) {
-     $virtualization_type = "powervm_lx86";
-     $virtualization_role = "guest";
+    elsif ( $^O eq 'linux' && $cpuinfo =~ /vendor_id.*PowerVM Lx86/ ) {
+      $virtualization_type = "powervm_lx86";
+      $virtualization_role = "guest";
     }
 
-	elsif ( $^O ne 'linux' &&  $cpuinfo =~ /Manufacturer.*PowerVM Lx86/ ) {
+    elsif ( $^O ne 'linux' && $cpuinfo =~ /Manufacturer.*PowerVM Lx86/ ) {
       $virtualization_type = "powervm_lx86";
       $virtualization_role = "guest";
     }
@@ -177,7 +184,7 @@ sub get {
       $virtualization_role = "guest";
     }
 
-	elsif ( $^O ne 'linux' && $cpuinfo =~ /Manufacturer.*IBM\/S390/ ) {
+    elsif ( $^O ne 'linux' && $cpuinfo =~ /Manufacturer.*IBM\/S390/ ) {
       $virtualization_type = "ibm_systemz";
       $virtualization_role = "guest";
     }

--- a/lib/Rex/Hardware/VirtInfo.pm
+++ b/lib/Rex/Hardware/VirtInfo.pm
@@ -46,9 +46,9 @@ sub get {
     }
     else {
       my $bios = Rex::Inventory::Bios::get();
-      $bios_vendor  = $bios->get_bios()->get_vendor;
-      $product_name = $bios->get_system_information()->get_product_name;
-      $sys_vendor   = $bios->get_system_information()->get_manufacturer;
+      $bios_vendor  = $bios->get_bios()->get_vendor || '';
+      $product_name = $bios->get_system_information()->get_product_name || '';
+      $sys_vendor   = $bios->get_system_information()->get_manufacturer || '';
     }
 
     $self_status = i_run "cat /proc/self/status 2>/dev/null", fail_ok => 1;
@@ -99,8 +99,8 @@ sub get {
     }
 
     elsif ( $product_name =~ /BHYVE/s ) {
-      $virtualization_type = "bhyve";
-      $virtualization_role = "guest";
+      $virtualization_type = 'bhyve';
+      $virtualization_role = 'guest';
     }
 
     elsif ( $bios_vendor =~ /Xen/ ) {
@@ -114,8 +114,8 @@ sub get {
     }
 
     elsif ( $bios_vendor =~ /BHYVE/s ) {
-      $virtualization_type = "bhyve";
-      $virtualization_role = "guest";
+      $virtualization_type = 'bhyve';
+      $virtualization_role = 'guest';
     }
 
     elsif ( $sys_vendor =~ /Microsoft Corporation/ ) {
@@ -147,13 +147,8 @@ sub get {
       }
     }
 
-    elsif ( $OSNAME eq 'linux' && $cpuinfo =~ /model name.*QEMU Virtual CPU/ ) {
+    elsif ( $cpuinfo =~ /model name.*QEMU Virtual CPU/ ) {
       $virtualization_type = "kvm";
-      $virtualization_role = "guest";
-    }
-
-    elsif ( $OSNAME ne 'linux' && $cpuinfo =~ /Manufacturer.*QEMU Virtual CPU/ ) {
-      $virtualization_type = "qemu";
       $virtualization_role = "guest";
     }
 
@@ -196,9 +191,9 @@ sub get {
       $virtualization_role = "host";
     }
 
-    elsif ( $OSNAME eq 'linux' && $modules =~ /\ vmm\.ko/s ) {
-      $virtualization_type = "bhyve";
-      $virtualization_role = "host";
+    elsif ( $OSNAME eq 'freebsd' && $modules =~ /\ vmm\.ko/s ) {
+      $virtualization_type = 'bhyve';
+      $virtualization_role = 'host';
     }
 
     elsif ( $modules =~ /vboxdrv/ ) {

--- a/lib/Rex/Hardware/VirtInfo.pm
+++ b/lib/Rex/Hardware/VirtInfo.pm
@@ -76,6 +76,11 @@ sub get {
       $virtualization_role = "guest";
     }
 
+    elsif ( $product_name =~ /BHYVE/ ) {
+      $virtualization_type = "bhyve";
+      $virtualization_role = "guest";
+    }
+
     elsif ( $bios_vendor =~ /Xen/ ) {
       $virtualization_type = "xen";
       $virtualization_role = "guest";
@@ -83,6 +88,11 @@ sub get {
 
     elsif ( $bios_vendor =~ /innotek GmbH/ ) {
       $virtualization_type = "virtualbox";
+      $virtualization_role = "guest";
+    }
+
+    elsif ( $bios_vendor =~ /BHYVE/ ) {
+      $virtualization_type = "bhyve";
       $virtualization_role = "guest";
     }
 
@@ -135,8 +145,13 @@ sub get {
       $virtualization_role = "guest";
     }
 
-    elsif ( $modules =~ /kvm/ ) {
+    elsif ( $modules =~ /kvm/ && $^O eq 'linux' ) {
       $virtualization_type = "kvm";
+      $virtualization_role = "host";
+    }
+
+    elsif ( $modules =~ /vmm/ && $^O eq 'freebsd' ) {
+      $virtualization_type = "bhyve";
       $virtualization_role = "host";
     }
 


### PR DESCRIPTION
Previously Rex::Hardware::VirtInfo made heavy use of linuxisms and was not cross platform friendly.

This update uses /proc on Linux and dmidecode else where. For modules on FreeBSD kldstat is used. Unforftunately not aware of a good cross platform equivalent of the self_status check.

Also kvm module is now only looked for on Linux with vmm(bhyve) being looked for on FreeBSD.

Tested as working on FreeBSD bhyve host and guest as well as Linux kvm host.

<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is a proposal to fix #<!-- issue ID --> by <!-- briefly explaining your changes -->.

<!-- Ideally, ask for a specific expected course of action, like: -->
<!-- Please review and merge, or let me know how to improve it further. -->

## Checklist

- [X] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [ ] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [ ] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [X] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [ ] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
