### PR TITLE
issue-1606-Add dev-null redirect to suppress error

### DIFF
--- a/lib/Rex/Hardware/Host.pm
+++ b/lib/Rex/Hardware/Host.pm
@@ -110,7 +110,7 @@ sub get_operating_system {
   my $is_lsb = can_run("lsb_release");
 
   if ($is_lsb) {
-    if ( my $ret = i_run "lsb_release -s -i" ) {
+    if ( my $ret = i_run "lsb_release -s -i 2>/dev/null" ) {
       if ( $ret =~ m/SUSE/i ) {
         $ret = "SuSE";
       }


### PR DESCRIPTION
…rs on some systems when running lsb_release

<!-- Thanks for contributing to Rex! -->
<!-- For optimal workflow, please make sure you have read and understood the [Contributing guide](https://github.com/RexOps/Rex/blob/master/CONTRIBUTING.md). -->

<!-- TL; DR: -->
<!-- Make sure there's an issue where the proposed changes are already discussed. -->
<!-- Please open the pull request as a draft first, and wait for automated test results. -->
<!-- Feel free to work on the PR till tests pass, and the checklist below is complete, then mark it ready for review. -->

This PR is a proposal to fix #1606  by adding a redirect to dev-null to suppress output of an unneeded and unwanted message from lsb_release.  By redirecting the output to dev-null, you will again get the desired result, fixing this issue in current versions, such as Debian, where the message is output regardless.

<!-- Ideally, ask for a specific expected course of action, like: -->
Please review and merge. 

## Checklist

- [ x ] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->  Repo was freshly forked and checked out.
- [ x ] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->  Not sure if the change is all that exciting, its just a simple redirect that is needed.  I can add if needed
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [ x ] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)
