### PR TITLE
This PR is a proposal to fix #1609 by enabling Augeas errors to be retrieved

### DIFF
--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -369,6 +369,25 @@ Returns the value of the given item.
     }
   }
 
+=item errors
+
+Returns any errors from a previous command (uses the augeas "errors" command)
+
+ my $errors = augeas "errors"
+
+=cut
+
+  elsif ( $action eq "errors" ) {
+
+    if ( $is_ssh || !$has_config_augeas ) {
+      my $result = _run_augtool("errors");
+      return $result->{return};
+    }
+    else {
+      return $aug->error_details;
+    }
+  }
+
   else {
     Rex::Logger::info("Unknown augeas action.");
   }


### PR DESCRIPTION
This PR is a proposal to fix #1609 by enabling Augeas errors to be retrieved

As per #1609 it is not possible to retrieve errors from Augeas if it is failing. This PR adds a new command to be able to retrieve them.

I have not added a test, as there are currently no tests at all for the Augeas command.

I thought about automatically retrieving and adding any error information to a failing Augeas command, but I decided that is over-engineering things too much and that a developer should decide how they want to handle errors and retrieve them manually if they wish to.

Please review and merge, or let me know how to improve it further.