### PR TITLE
Remove unused prerequisite for IO::String

### DIFF
--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -51,7 +51,6 @@ use Rex::Commands::Fs;
 use Rex::Commands::File;
 use Rex::Helper::Path;
 use Rex::Helper::Run;
-use IO::String;
 use Module::Load::Conditional qw(can_load);
 
 my $has_config_augeas =


### PR DESCRIPTION
Also note that IO::String is only necessaryfor Perls before 5.8. Since Rex requires 5.12, this is unnecessary.
