### PR TITLE
Fix test suite warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Return only the first found command
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Interface/Exec/Base.pm
+++ b/lib/Rex/Interface/Exec/Base.pm
@@ -65,16 +65,16 @@ sub can_run {
       return $cache->get($cache_key_name);
     }
 
-    my $output = Rex::Helper::Run::i_run "$check_with_command $command",
+    my @output = Rex::Helper::Run::i_run "$check_with_command $command",
       fail_ok => 1;
 
     next if ( $? != 0 );
 
-    next if ( !is_file($output) );
+    next if ( !is_file( $output[0] ) );
 
-    $cache->set( $cache_key_name, $output );
+    $cache->set( $cache_key_name, $output[0] );
 
-    return $output;
+    return $output[0];
   }
 
   return undef;

--- a/t/0.31.t
+++ b/t/0.31.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 139;
+use Test::More tests => 140;
+use Test::Warnings;
 
 use Rex -feature => '0.31';
 

--- a/t/0.54.t
+++ b/t/0.54.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 13;
+use Test::More tests => 14;
+use Test::Warnings;
 
 use Rex -feature => '0.54';
 

--- a/t/01.t
+++ b/t/01.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 
 use Rex::Commands;
 

--- a/t/args.t
+++ b/t/args.t
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 
 use Rex::Args;
 

--- a/t/auth.t
+++ b/t/auth.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 48;
+use Test::More tests => 49;
+use Test::Warnings;
 
 use Rex::Commands;
 use Rex::Group;

--- a/t/base_virt.t
+++ b/t/base_virt.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 
 use Rex::Virtualization;
 

--- a/t/batch.t
+++ b/t/batch.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 use Rex::Commands;
 use Rex::Batch;
 

--- a/t/before_all_tasks.t
+++ b/t/before_all_tasks.t
@@ -7,6 +7,7 @@ use lib 't/lib';
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 use Test::Deep;
 
 use Rex::Commands;

--- a/t/can_run.t
+++ b/t/can_run.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 4;
+use Test::More tests => 5;
+use Test::Warnings;
 
 use Rex::Commands::Run;
 

--- a/t/case.t
+++ b/t/case.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 7;
+use Test::More tests => 8;
+use Test::Warnings;
 use Rex::Commands;
 
 my $test = "Debian";

--- a/t/cmdb.t
+++ b/t/cmdb.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 
 use Cwd qw(realpath);
 use File::Spec;

--- a/t/cmdb_path.t
+++ b/t/cmdb_path.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 
 use Cwd qw(realpath);
 use File::Spec;

--- a/t/commands.t
+++ b/t/commands.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 18;
+use Test::More tests => 19;
+use Test::Warnings;
 
 use Rex::Commands;
 

--- a/t/commands/evaluate_hostnames.t
+++ b/t/commands/evaluate_hostnames.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 9;
+use Test::More tests => 10;
+use Test::Warnings;
 use Rex::Commands;
 
 my %tests = (

--- a/t/commands/iptables.t
+++ b/t/commands/iptables.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 32;
+use Test::More tests => 33;
+use Test::Warnings;
 
 use Rex::Commands::Iptables;
 

--- a/t/commands_file_template.t
+++ b/t/commands_file_template.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 4;
+use Test::More tests => 5;
+use Test::Warnings;
 
 use File::Basename;
 

--- a/t/config-ssh.t
+++ b/t/config-ssh.t
@@ -6,7 +6,8 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use File::Temp;
-use Test::More tests => 21;
+use Test::More tests => 22;
+use Test::Warnings;
 
 use Rex::Config;
 

--- a/t/config.t
+++ b/t/config.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 10;
+use Test::More tests => 11;
+use Test::Warnings;
 
 use Cwd qw(realpath);
 use Rex::Config;

--- a/t/cron.t
+++ b/t/cron.t
@@ -6,8 +6,9 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 
-$^O =~ m/^MSWin/ ? plan tests => 83 : plan tests => 286;
+$^O =~ m/^MSWin/ ? plan tests => 84 : plan tests => 287;
 
 use Rex::Cron::Base;
 

--- a/t/db.t
+++ b/t/db.t
@@ -7,6 +7,7 @@ our $VERSION = '9999.99.99_99'; # VERSION
 
 BEGIN {
   use Test::More;
+  use Test::Warnings;
   use Data::Dumper;
 
   eval "use DBI; 1" or plan skip_all => "Could not load DBI module";
@@ -29,7 +30,7 @@ my $mysqld = Test::mysqld->new(
   plan skip_all => $Test::mysqld::errstr;
   };
 
-plan tests => 38;
+plan tests => 39;
 
 $dbh = DBI->connect( $mysqld->dsn( dbname => 'test' ), );
 Rex::Commands::DB->import( { dsn => $mysqld->dsn( dbname => 'test' ) } );

--- a/t/df.t
+++ b/t/df.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 36;
+use Test::More tests => 37;
+use Test::Warnings;
 
 use Rex::Commands::Fs;
 

--- a/t/dmi.t
+++ b/t/dmi.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 31;
+use Test::More tests => 32;
+use Test::Warnings;
 
 use Rex::Inventory::DMIDecode;
 

--- a/t/do_task.t
+++ b/t/do_task.t
@@ -6,7 +6,8 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Rex::Commands;
-use Test::More tests => 4;
+use Test::More tests => 5;
+use Test::Warnings;
 
 eval { Rex::Commands::do_task("non_existing_task"); };
 my $result = $@;

--- a/t/env.t
+++ b/t/env.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 1;
+use Test::More tests => 2;
+use Test::Warnings;
 
 use Rex::Commands::Run;
 

--- a/t/file.t
+++ b/t/file.t
@@ -10,7 +10,8 @@ my $cwd = getcwd;
 use File::Spec;
 use File::Temp;
 
-use Test::More tests => 61;
+use Test::More tests => 62;
+use Test::Warnings;
 
 use Rex::Commands::File;
 use Rex::Commands::Fs;

--- a/t/file_hooks.t
+++ b/t/file_hooks.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 use Test::Deep;
 use Test::Output;
 

--- a/t/fs_files.t
+++ b/t/fs_files.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 13;
+use Test::More tests => 14;
+use Test::Warnings;
 
 use Rex::Helper::Path;
 use Rex::Commands::File;

--- a/t/group.t
+++ b/t/group.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 98;
+use Test::More tests => 99;
+use Test::Warnings;
 use Test::Exception;
 
 use Rex -feature => '0.31';

--- a/t/helper_hash.t
+++ b/t/helper_hash.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 6;
+use Test::More tests => 7;
+use Test::Warnings;
 
 use Rex::Helper::Hash;
 

--- a/t/helper_path.t
+++ b/t/helper_path.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 8;
+use Test::More tests => 9;
+use Test::Warnings;
 
 use File::Basename;
 use Cwd 'getcwd';

--- a/t/hooks.t
+++ b/t/hooks.t
@@ -6,7 +6,8 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 BEGIN {
-  use Test::More tests => 8;
+  use Test::More tests => 9;
+  use Test::Warnings qw(:no_end_test had_no_warnings);
   use File::Temp;
   use Rex::Commands;
   use Rex::RunList;
@@ -49,3 +50,5 @@ is $after,                   1, 'after hook';
 is $after_all,               1, 'after ALL hook';
 is $after_task_finished,     1, 'after_task_finished hook';
 is $after_task_finished_all, 1, 'after_task_finished ALL hook';
+
+had_no_warnings();

--- a/t/hooks_in_pkg.t
+++ b/t/hooks_in_pkg.t
@@ -7,6 +7,7 @@ use lib 't/lib';
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 use Test::Deep;
 
 use Rex::Commands;

--- a/t/hooks_in_rexfile.t
+++ b/t/hooks_in_rexfile.t
@@ -9,7 +9,8 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 BEGIN {
-  use Test::More tests => 8;
+  use Test::More tests => 9;
+  use Test::Warnings qw(:no_end_test had_no_warnings);
   use File::Temp;
   use Rex::Commands;
   use Rex::RunList;
@@ -52,3 +53,5 @@ is $after,                   1, 'after hook';
 is $after_all,               1, 'after ALL hook';
 is $after_task_finished,     1, 'after_task_finished hook';
 is $after_task_finished_all, 1, 'after_task_finished ALL hook';
+
+had_no_warnings();

--- a/t/hooks_in_rexfile_tasks_in_pkg.t
+++ b/t/hooks_in_rexfile_tasks_in_pkg.t
@@ -8,7 +8,8 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 BEGIN {
-  use Test::More tests => 8;
+  use Test::More tests => 9;
+  use Test::Warnings qw(:no_end_test had_no_warnings);
   use lib 't/lib';
   use t::tasks::alien;
   use File::Temp;
@@ -52,3 +53,5 @@ is $after,                   1, 'after hook';
 is $after_all,               1, 'after ALL hook';
 is $after_task_finished,     1, 'after_task_finished hook';
 is $after_task_finished_all, 1, 'after_task_finished ALL hook';
+
+had_no_warnings;

--- a/t/host.t
+++ b/t/host.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 10;
+use Test::More tests => 11;
+use Test::Warnings;
 
 use Rex::Commands::Host;
 

--- a/t/include.t
+++ b/t/include.t
@@ -6,7 +6,8 @@ use lib 't/lib';
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 use Test::Deep;
 
 use Rex::Commands;
@@ -29,5 +30,3 @@ cmp_deeply
   \@all_task_names,
   [qw/t:tasks:alien:negotiate t:tasks:cowboy:roundup/],
   "found hidden task";
-
-done_testing();

--- a/t/ini.t
+++ b/t/ini.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 34;
+use Test::More tests => 35;
+use Test::Warnings;
 
 SKIP: {
 

--- a/t/interface_fs_local.t
+++ b/t/interface_fs_local.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 7;
+use Test::More tests => 8;
+use Test::Warnings;
 
 use Rex::Interface::Fs;
 

--- a/t/issue/1008.t
+++ b/t/issue/1008.t
@@ -7,7 +7,8 @@ our $VERSION = '9999.99.99_99'; # VERSION
 
 use Rex::Helper::IP;
 
-use Test::More tests => 16;
+use Test::More tests => 17;
+use Test::Warnings;
 
 my $ok = 0;
 

--- a/t/issue/1439.t
+++ b/t/issue/1439.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 
 require Rex;
 

--- a/t/issue/1583.t
+++ b/t/issue/1583.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 1;
+use Test::More tests => 2;
+use Test::Warnings;
 
 use English qw(-no_match_vars);
 use File::Spec;

--- a/t/issue/513.t
+++ b/t/issue/513.t
@@ -7,7 +7,8 @@ our $VERSION = '9999.99.99_99'; # VERSION
 
 use Rex::CLI;
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 
 my $ok = 0;
 

--- a/t/issue/860.t
+++ b/t/issue/860.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 6;
+use Test::More tests => 7;
+use Test::Warnings qw(:no_end_test had_no_warnings);
 
 use Rex::Args;
 use Rex::RunList;
@@ -109,3 +110,5 @@ is_deeply(
   \%opt_t3,
   "got task3 parameter with 1.4 compatibility"
 );
+
+had_no_warnings();

--- a/t/issue/934.t
+++ b/t/issue/934.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 1;
+use Test::More tests => 2;
+use Test::Warnings qw(:no_end_test had_no_warnings);
 
 use Rex::Args;
 use Rex::RunList;
@@ -37,3 +38,5 @@ before_task_start task1 => sub {
 my $run_list = Rex::RunList->instance;
 $run_list->parse_opts(@ARGV);
 $run_list->run_tasks;
+
+had_no_warnings();

--- a/t/issue/948.t
+++ b/t/issue/948.t
@@ -6,7 +6,8 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Rex::Virtualization;
-use Test::More tests => 6;
+use Test::More tests => 7;
+use Test::Warnings;
 use Data::Dumper;
 use Rex::Helper::Run;
 use Rex::Commands::File;

--- a/t/issue/949.t
+++ b/t/issue/949.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 
 use Rex::Commands;
 use Rex::Virtualization;

--- a/t/issue_539.t
+++ b/t/issue_539.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 16;
+use Test::More tests => 17;
+use Test::Warnings;
 use Rex::Hardware::Network::Linux;
 use Rex::Helper::Hash;
 

--- a/t/last_command_output.t
+++ b/t/last_command_output.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 
 use Rex::Commands;
 use Rex::Commands::Run;

--- a/t/load_rexfile.t
+++ b/t/load_rexfile.t
@@ -7,6 +7,7 @@ use autodie;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 
 use English qw(-no_match_vars);
 use File::Spec;
@@ -39,7 +40,7 @@ closedir $dh;
 
 push @rexfiles, 'no_Rexfile';
 
-plan tests => scalar @rexfiles;
+plan tests => scalar @rexfiles + 1;
 
 for my $rexfile (@rexfiles) {
   subtest "Testing with $rexfile" => sub {

--- a/t/logger.t
+++ b/t/logger.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 8;
+use Test::More tests => 9;
+use Test::Warnings;
 
 use Rex::Helper::Path;
 

--- a/t/md5.t
+++ b/t/md5.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 use File::Temp qw(tempfile);
 use Rex::Commands::MD5;
 

--- a/t/needs.t
+++ b/t/needs.t
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings qw(:no_end_test had_no_warnings);
 use Rex::Commands;
 
 {
@@ -131,4 +132,5 @@ for my $task ( $run_list->tasks ) {
   $run_list->increment_current_index;
 }
 
+had_no_warnings;
 done_testing;

--- a/t/net_interface_centos7.t
+++ b/t/net_interface_centos7.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 6;
+use Test::More tests => 7;
+use Test::Warnings;
 use Rex::Hardware::Network::Linux;
 
 my @in   = eval { local (@ARGV) = ("t/ip.out_centos7"); <>; };

--- a/t/network_linux.t
+++ b/t/network_linux.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 44;
+use Test::More tests => 45;
+use Test::Warnings;
 use Rex::Hardware::Network::Linux;
 use Rex::Helper::Hash;
 

--- a/t/no_tty.t
+++ b/t/no_tty.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 
 use Rex::Commands::Run;
 use Rex::Config;

--- a/t/os_dependencies.t
+++ b/t/os_dependencies.t
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 use Rex::Commands;
 
 my $dependency_ref = case $^O, {
@@ -15,7 +16,7 @@ my $dependency_ref = case $^O, {
 
 my @dependencies = @{$dependency_ref};
 
-plan tests => scalar @dependencies;
+plan tests => @dependencies + 1;
 
 for my $module (@dependencies) {
   ok( eval "use $module; 1;", "$module is available" );

--- a/t/package.t
+++ b/t/package.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 use Test::Deep;
 use Test::Exception;
 

--- a/t/param_lookup.t
+++ b/t/param_lookup.t
@@ -7,7 +7,8 @@ our $VERSION = '9999.99.99_99'; # VERSION
 
 package main;
 
-use Test::More tests => 8;
+use Test::More tests => 9;
+use Test::Warnings;
 use Rex -base;
 use Rex::Resource;
 

--- a/t/param_lookup_cmdb.t
+++ b/t/param_lookup_cmdb.t
@@ -8,6 +8,7 @@ our $VERSION = '9999.99.99_99'; # VERSION
 use Rex -base;
 use Rex::Resource;
 use Test::More;
+use Test::Warnings;
 
 use Rex::CMDB;
 use Rex::Commands;
@@ -21,7 +22,7 @@ set(
   }
 );
 
-use Test::More tests => 1;
+use Test::More tests => 2;
 use Rex -base;
 
 task(

--- a/t/param_lookup_resource.t
+++ b/t/param_lookup_resource.t
@@ -10,6 +10,7 @@ package MyTest;
 use Rex -base;
 use Rex::Resource::Common;
 use Test::More;
+use Test::Warnings;
 
 $::QUIET = 1;
 
@@ -27,6 +28,7 @@ package main;
 
 use Rex -base;
 use Test::More;
+use Test::Warnings;
 
 use Rex::CMDB;
 use Rex::Commands;
@@ -40,7 +42,7 @@ set(
   }
 );
 
-use Test::More tests => 2;
+use Test::More tests => 3;
 use Rex -base;
 
 task(

--- a/t/path.t
+++ b/t/path.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 
 use Rex::Helper::Path;
 

--- a/t/proc.t
+++ b/t/proc.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 use Test::Output;
 use Rex::Inventory::Proc;
 

--- a/t/read_buffers.t
+++ b/t/read_buffers.t
@@ -6,12 +6,13 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 
 if ( $^O =~ m/^MSWin/i ) {
-  plan tests => 1;
+  plan tests => 2;
 }
 else {
-  plan tests => 2;
+  plan tests => 3;
 }
 
 use Rex::Interface::Exec;

--- a/t/report.t
+++ b/t/report.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 use YAML;
 
 use Rex::Commands;

--- a/t/resource.t
+++ b/t/resource.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 11;
+use Test::More tests => 12;
+use Test::Warnings;
 use Rex -base;
 use Rex::Resource;
 use Rex::Resource::Common;
@@ -79,5 +80,3 @@ task(
 );
 
 test1( { file => "/etc/securetty" } );
-
-done_testing();

--- a/t/rsync.t
+++ b/t/rsync.t
@@ -8,6 +8,7 @@ use autodie;
 
 BEGIN {
   use Test::More;
+  use Test::Warnings;
   use Rex::Commands::Run;
 
   can_run('rsync') or plan skip_all => 'Could not find rsync command';
@@ -32,7 +33,7 @@ my %source_for = (
   'rsync with wildcard in relative path' => 't/sync/*',
 );
 
-plan tests => 2 * scalar keys %source_for;
+plan tests => 1 + 2 * scalar keys %source_for;
 
 for my $scenario ( sort keys %source_for ) {
   test_rsync( $scenario, $source_for{$scenario} );

--- a/t/runlist.t
+++ b/t/runlist.t
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings qw(:no_end_test had_no_warnings);
 
 use Rex::Args;
 use Rex::RunList;
@@ -42,4 +43,5 @@ is_deeply [ $tasks[2]->get_args ], [qw//],          "task2 args";
 
 $run_list->run_tasks;
 
+had_no_warnings;
 done_testing;

--- a/t/scm/git.t
+++ b/t/scm/git.t
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 use Test::Exception;
 
 use File::Spec;
@@ -20,7 +21,7 @@ $::QUIET = 1;
 my $git = can_run('git');
 
 if ( defined $git ) {
-  plan tests => 8;
+  plan tests => 9;
 }
 else {
   plan skip_all => 'Can not find git command';

--- a/t/shared.t
+++ b/t/shared.t
@@ -6,7 +6,8 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 BEGIN {
-  use Test::More tests => 18;
+  use Test::More tests => 19;
+  use Test::Warnings qw(:no_end_test had_no_warnings);
   use Test::Deep;
   use Time::HiRes;
   use Rex::Shared::Var;
@@ -81,3 +82,5 @@ is( $hash{multi}->{arr1}->[1], "baz", "multidimension, arr1 - key1" );
 
   cmp_deeply \@array, [qw/0 1 1 1 1 1 1/], 'race condition avoided';
 }
+
+had_no_warnings();

--- a/t/summary.t
+++ b/t/summary.t
@@ -5,7 +5,10 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
+use English qw(-no_match_vars);
+
 use Test::More;
+use if $OSNAME ne 'MSWin32' || $PERL_VERSION gt 'v5.20.0', 'Test::Warnings';
 use Test::Deep;
 
 use Module::Load::Conditional qw(check_install);
@@ -22,7 +25,9 @@ if ( check_install( module => 'Parallel::ForkManager' ) ) {
   push @distributors, 'Parallel_ForkManager';
 }
 
-plan tests => scalar @distributors * 2;
+my $extra_test_count = defined $Test::Warnings::VERSION ? 1 : 0;
+
+plan tests => scalar @distributors * 2 + $extra_test_count;
 
 for my $distributor (@distributors) {
 

--- a/t/symlinks.t
+++ b/t/symlinks.t
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 use File::Spec;
 use File::Temp qw(tempdir);
 

--- a/t/task.t
+++ b/t/task.t
@@ -5,6 +5,7 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 use Test::More;
+use Test::Warnings;
 
 my %have_mods = (
   'Net::SSH2'    => 1,
@@ -24,7 +25,7 @@ unless ( $have_mods{'Net::SSH2'} or $have_mods{'Net::OpenSSH'} ) {
     'SSH module not found. You need Net::SSH2 or Net::OpenSSH to connect to servers via SSH.';
 }
 else {
-  plan tests => 36;
+  plan tests => 37;
 }
 
 use Rex::Task;

--- a/t/task_hosts.t
+++ b/t/task_hosts.t
@@ -7,7 +7,8 @@ our $VERSION = '9999.99.99_99'; # VERSION
 
 package main;
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 
 use Rex::Commands;
 

--- a/t/template.t
+++ b/t/template.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 20;
+use Test::More tests => 21;
+use Test::Warnings;
 
 use Rex::Config;
 use Rex::Commands;

--- a/t/template_ng.t
+++ b/t/template_ng.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 21;
+use Test::More tests => 22;
+use Test::Warnings;
 use Rex::Template::NG;
 use Rex::Commands;
 use Rex::Config;

--- a/t/url_encode.t
+++ b/t/url_encode.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 1;
+use Test::More tests => 2;
+use Test::Warnings;
 
 use Rex::Helper::Encode;
 

--- a/t/virtualization.t
+++ b/t/virtualization.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 3;
+use Test::More tests => 4;
+use Test::Warnings;
 
 use Rex::Commands;
 

--- a/t/waitpid_blocking_sleep_time.t
+++ b/t/waitpid_blocking_sleep_time.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 2;
+use Test::More tests => 3;
+use Test::Warnings;
 
 use Rex -base;
 

--- a/t/write_utf8_files.t
+++ b/t/write_utf8_files.t
@@ -6,6 +6,7 @@ use warnings;
 our $VERSION = '9999.99.99_99'; # VERSION
 
 use Test::More;
+use Test::Warnings;
 use File::Temp qw(tempfile);
 use Carp;
 
@@ -18,7 +19,7 @@ my $file_libmagic_is_available = eval 'use File::LibMagic; 1';
 my $file_command_is_compatible = eval "run qq($command $0), auto_die => 1; 1";
 
 if ( $file_libmagic_is_available || $file_command_is_compatible ) {
-  plan tests => 2;
+  plan tests => 3;
 }
 else {
   plan skip_all =>

--- a/t/xml.t
+++ b/t/xml.t
@@ -5,7 +5,8 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 6;
+use Test::More tests => 7;
+use Test::Warnings;
 use FindBin qw($Bin);
 use Rex::Require;
 


### PR DESCRIPTION
This PR is a proposal to fix #1617 by failing on test suite warnings, and also fix #1618 by taking only the first found command into account when having multiple candidates.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)