### PR TITLE
Add initial Augeas tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -79,6 +79,8 @@ jobs:
           name: build.tar
       - name: Extract build tarball
         run: tar xvf build.tar
+      - name: Install packages
+        run: sudo apt-get install -y augeas-tools
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Extract build tarball
         run: tar xvf build.tar
       - name: Install packages
-        run: sudo apt-get install -y augeas-tools
+        run: sudo apt-get install -y augeas-tools libaugeas-dev
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1
@@ -127,7 +127,7 @@ jobs:
       - name: Extract build tarball
         run: tar xvf build.tar
       - name: Install packages
-        run: sudo apt-get install -y aspell
+        run: sudo apt-get install -y aspell libaugeas-dev
       - name: Setup Perl
         id: perl
         uses: shogo82148/actions-setup-perl@v1

--- a/ChangeLog
+++ b/ChangeLog
@@ -17,6 +17,7 @@ Revision history for Rex
 
  [NEW FEATURES]
  - Add config option to prepend Augeas commands
+ - Add config option to control local Augeas backend
 
  [REVISION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -15,6 +15,7 @@ Revision history for Rex
  [MINOR]
 
  [NEW FEATURES]
+ - Add config option to prepend Augeas commands
 
  [REVISION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Return only the first found command
+ - Fix inconsistent augtool wrapper usage
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Return only the first found command
  - Fix inconsistent augtool wrapper usage
+ - Fix Config::Augeas detection
 
  [DOCUMENTATION]
 

--- a/dist.ini
+++ b/dist.ini
@@ -120,6 +120,11 @@ File::LibMagic = 0
 Test::mysqld = 0
 DBD::mysql = 0
 
+[OptionalFeature / use_config_augeas]
+-relationship = suggests
+-description = Run Augeas commands with Config::Augeas
+Config::Augeas = 0
+
 [Test::MinimumVersion]
 max_target_perl = 5.12.5
 

--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -52,16 +52,10 @@ use Rex::Commands::File;
 use Rex::Helper::Path;
 use Rex::Helper::Run;
 use IO::String;
+use Module::Load::Conditional qw(can_load);
 
-my $has_config_augeas = 0;
-
-BEGIN {
-  use Rex::Require;
-  if ( Config::Augeas->is_loadable ) {
-    Config::Augeas->use;
-    $has_config_augeas = 1;
-  }
-}
+my $has_config_augeas =
+  can_load( modules => { 'Config::Augeas' => undef } ) ? 1 : 0;
 
 @EXPORT = qw(augeas);
 

--- a/lib/Rex/Commands/Augeas.pm
+++ b/lib/Rex/Commands/Augeas.pm
@@ -274,8 +274,8 @@ Dump the contents of a file to STDOUT.
     my $aug_key = $file;
 
     if ( $is_ssh || !$has_config_augeas ) {
-      my @list = i_exec "augtool", "print", $aug_key;
-      print join( "\n", @list ) . "\n";
+      my $output = _run_augtool("print $aug_key");
+      say $output->{'return'};
     }
     else {
       $aug->print($aug_key);

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -73,7 +73,7 @@ our (
   $use_template_ng,             $use_rex_kvm_agent,
   $autodie,                     $task_chaining_cmdline_args,
   $waitpid_blocking_sleep_time, $write_utf8_files,
-  $default_auth,
+  $default_auth,                $augeas_commands_prepend,
 );
 
 # some defaults
@@ -1630,6 +1630,28 @@ sub set_default_auth {
 
 sub get_default_auth {
   return $default_auth // 1;
+}
+
+=head2 set_augeas_commands_prepend
+
+=head2 get_augeas_commands_prepend
+
+Sets and gets the value of the C<$augeas_commands_prepend> configuration variable.
+
+This controls the list of commands Rex should prepend at the beginning of the command file for Augeas operations.
+
+Default is C<[]>.
+
+=cut
+
+sub set_augeas_commands_prepend {
+  my $self = shift;
+  $augeas_commands_prepend = shift;
+  return $augeas_commands_prepend;
+}
+
+sub get_augeas_commands_prepend {
+  return $augeas_commands_prepend // [];
 }
 
 =head2 register_set_handler($handler_name, $code)

--- a/lib/Rex/Config.pm
+++ b/lib/Rex/Config.pm
@@ -74,6 +74,7 @@ our (
   $autodie,                     $task_chaining_cmdline_args,
   $waitpid_blocking_sleep_time, $write_utf8_files,
   $default_auth,                $augeas_commands_prepend,
+  $local_augeas_backend,
 );
 
 # some defaults
@@ -1652,6 +1653,28 @@ sub set_augeas_commands_prepend {
 
 sub get_augeas_commands_prepend {
   return $augeas_commands_prepend // [];
+}
+
+=head2 set_local_augeas_backend
+
+=head2 get_local_augeas_backend
+
+Sets and gets the value of the C<$local_augeas_backend> configuration variable.
+
+This controls which Augeas backend to use for local operations, C<augtool> or C<Config::Augeas>.
+
+Default is C<Config::Augeas>.
+
+=cut
+
+sub set_local_augeas_backend {
+  my $self = shift;
+  $local_augeas_backend = shift;
+  return $local_augeas_backend;
+}
+
+sub get_local_augeas_backend {
+  return $local_augeas_backend // 'Config::Augeas';
 }
 
 =head2 register_set_handler($handler_name, $code)

--- a/t/augeas.t
+++ b/t/augeas.t
@@ -1,0 +1,73 @@
+#!/usr/bin/env perl
+
+use v5.12.5;
+use warnings;
+
+our $VERSION = '9999.99.99_99'; # VERSION
+
+use Test::More;
+use Test::Warnings;
+use Test::Output;
+
+use File::Temp qw(tmpnam);
+use Rex::Commands::Augeas;
+use Rex::Commands::Run;
+
+if ( can_run('augtool') ) {
+  plan tests => 2;
+}
+else {
+  plan skip_all => 'Could not find augtool command';
+}
+
+my $file       = tmpnam();
+my $test_value = 'rex';
+
+subtest 'Simplelines lens' => sub {
+  plan tests => 7;
+
+  Rex::Config->set_augeas_commands_prepend(
+    [ "transform Simplelines incl $file", 'load', ] );
+
+  my $path = '/files' . $file . '/1';
+
+  is( -e $file, undef, 'test file does not exist yet' );
+
+  # modify
+
+  augeas modify => $path => $test_value;
+
+  is( -e $file, 1, 'test file created' );
+
+  # exists
+
+  my $has_first_entry = augeas exists => $path;
+
+  is( $has_first_entry, 1, 'first entry exists' );
+
+  # get
+
+  my $retrieved_value = augeas get => $path;
+
+  is( $retrieved_value, $test_value, 'test value retrieved' );
+
+  # dump
+
+  stdout_is(
+    sub { augeas dump => $path },
+    qq($path = "$test_value"\n),
+    'correct dump output'
+  );
+
+  # remove
+
+  augeas remove => $path;
+
+  my $still_has_first_entry = augeas exists => $path;
+
+  is( $still_has_first_entry, 0, 'first entry removed' );
+
+  unlink $file;
+
+  is( -e $file, undef, 'test file cleaned up' );
+};


### PR DESCRIPTION
This PR is a proposal related to #1609, and aimed at adding initial Augeas tests – including making the current implementation testable, and fixing an initial set of previously hidden bugs too.

The overall goal is to make it easier to maintain Rex::Commands::Augeas in the future by establishing its expected behavior.

In case you use Rex to interact with Augeas, please consider reviewing the changes, and leave notes or questions.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)