### PR TITLE
Fix precedence warning after perl-5.41.4

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix precedence warning after perl-5.41.4
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Shared/Var/Array.pm
+++ b/lib/Rex/Shared/Var/Array.pm
@@ -80,7 +80,7 @@ sub PUSH {
   __lock sub {
     my $ref = __retrieve;
 
-    if ( !ref( $ref->{ $self->{varname} }->{data} ) eq "ARRAY" ) {
+    if ( ref( $ref->{ $self->{varname} }->{data} ) ne "ARRAY" ) {
       $ref->{ $self->{varname} }->{data} = [];
     }
 
@@ -97,7 +97,7 @@ sub UNSHIFT {
   __lock sub {
     my $ref = __retrieve;
 
-    if ( !ref( $ref->{ $self->{varname} }->{data} ) eq "ARRAY" ) {
+    if ( ref( $ref->{ $self->{varname} }->{data} ) ne "ARRAY" ) {
       $ref->{ $self->{varname} }->{data} = [];
     }
 


### PR DESCRIPTION
This PR is a proposal to fix #1624 by replacing the affected comparisons (which also fixes the related ValuesAndExpressions::NotWithCompare perlcritic violations.)

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [ ] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)