### PR TITLE
Fix missing argument warnings from Text::Wrap

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Revision history for Rex
 
  [BUG FIXES]
  - Fix precedence warning after perl-5.41.4
+ - Fix missing argument warnings from Text::Wrap
 
  [DOCUMENTATION]
 

--- a/dist.ini
+++ b/dist.ini
@@ -76,6 +76,7 @@ overwrite = 1
 
 [Prereqs]
 perl = 5.12.5
+Text::Wrap = != 2023.0509
 YAML = != 1.25
 
 [Prereqs / DevelopRequires]


### PR DESCRIPTION
This PR is a proposal to fix #1626 by ignoring version `2023.0509` of Text::Wrap, which emits “Missing argument in sprintf” warnings.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)