### PR TITLE
Fix memory detection warnings on Solaris

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,7 @@ Revision history for Rex
  [BUG FIXES]
  - Fix precedence warning after perl-5.41.4
  - Fix missing argument warnings from Text::Wrap
+ - Fix memory detection warnings on Solaris
 
  [DOCUMENTATION]
 


### PR DESCRIPTION
This PR is a proposal to fix #1628 by checking the memory detection command's return code on Solaris, and only try to parse the output on success, otherwise return a generic “all zeros” result (like other similar fallback scenarios.)

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)