### PR TITLE
Fix git branch checkout operations

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix git branch checkout operations
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Revision history for Rex
  [ENHANCEMENTS]
  - Quote command arguments on Windows
  - Support command environment variables on Windows
+ - Detect default branch of git origin
 
  [MAJOR]
 

--- a/lib/Rex/SCM/Git.pm
+++ b/lib/Rex/SCM/Git.pm
@@ -41,6 +41,9 @@ sub checkout {
     ( my $default_origin_branch = $head_ref ) =~ s{refs/remotes/origin/}{}msx;
 
     my $branch = $checkout_opt->{"branch"} || $default_origin_branch;
+
+    i_run "git checkout -B $branch", cwd => $checkout_to, %run_opt;
+
     Rex::Logger::info( "Pulling "
         . $repo_info->{"url"} . " to "
         . ( $checkout_to ? $checkout_to : "." ) );

--- a/lib/Rex/SCM/Git.pm
+++ b/lib/Rex/SCM/Git.pm
@@ -34,7 +34,13 @@ sub checkout {
   my $clone_args = join( " ", @{ $checkout_opt->{clone_args} || [''] } );
 
   if ( is_dir("$checkout_to/.git") ) {
-    my $branch = $checkout_opt->{"branch"} || "master";
+    my $head_ref = i_run 'git symbolic-ref refs/remotes/origin/HEAD',
+      cwd => $checkout_to,
+      %run_opt;
+
+    ( my $default_origin_branch = $head_ref ) =~ s{refs/remotes/origin/}{}msx;
+
+    my $branch = $checkout_opt->{"branch"} || $default_origin_branch;
     Rex::Logger::info( "Pulling "
         . $repo_info->{"url"} . " to "
         . ( $checkout_to ? $checkout_to : "." ) );

--- a/t/scm/git.t
+++ b/t/scm/git.t
@@ -28,6 +28,9 @@ else {
   plan skip_all => 'Can not find git command';
 }
 
+my $git_user_name  = 'Rex';
+my $git_user_email = 'noreply@rexify.org';
+
 my $empty_config_file = $OSNAME eq 'MSWin32' ? q() : File::Spec->devnull();
 
 my $git_environment = {
@@ -86,10 +89,7 @@ sub prepare_test_repo {
 
   i_run 'git init', cwd => $directory, env => $git_environment;
 
-  i_run 'git config user.name Rex', cwd => $directory, env => $git_environment;
-  i_run 'git config user.email noreply@rexify.org',
-    cwd => $directory,
-    env => $git_environment;
+  configure_git_user($directory);
 
   i_run 'git commit --allow-empty -m commit',
     cwd => $directory,
@@ -111,6 +111,20 @@ sub git_repo_ok {
     i_run 'git rev-parse --git-dir', cwd => $directory, env => $git_environment
   }
   "$directory looks like a git repository now";
+
+  return;
+}
+
+sub configure_git_user {
+  my $directory = shift;
+
+  i_run "git config user.name $git_user_name",
+    cwd => $directory,
+    env => $git_environment;
+
+  i_run "git config user.email $git_user_email",
+    cwd => $directory,
+    env => $git_environment;
 
   return;
 }

--- a/t/scm/git.t
+++ b/t/scm/git.t
@@ -48,12 +48,12 @@ git_repo_ok($test_repo_dir);
 
 my $test_repo_name = 'test_repo';
 
+set repository => $test_repo_name, url => $test_repo_dir;
+
 subtest 'clone into non-existing directory', sub {
   plan tests => 6;
 
   my $clone_target_dir = tempdir( CLEANUP => 1 );
-
-  set repository => $test_repo_name, url => $test_repo_dir;
 
   ok( -d $clone_target_dir, "$clone_target_dir could be created" );
 
@@ -71,8 +71,6 @@ subtest 'clone into existing directory', sub {
   plan tests => 5;
 
   my $clone_target_dir = tempdir( CLEANUP => 1 );
-
-  set repository => $test_repo_name, url => $test_repo_dir;
 
   ok( -d $clone_target_dir,
     "$clone_target_dir is the clone target directory now" );

--- a/t/scm/git.t
+++ b/t/scm/git.t
@@ -53,7 +53,7 @@ set repository => $test_repo_name, url => $test_repo_dir;
 subtest 'clone into non-existing directory', sub {
   plan tests => 6;
 
-  my $clone_target_dir = tempdir( CLEANUP => 1 );
+  my $clone_target_dir = init_test();
 
   ok( -d $clone_target_dir, "$clone_target_dir could be created" );
 
@@ -70,7 +70,7 @@ subtest 'clone into non-existing directory', sub {
 subtest 'clone into existing directory', sub {
   plan tests => 5;
 
-  my $clone_target_dir = tempdir( CLEANUP => 1 );
+  my $clone_target_dir = init_test();
 
   ok( -d $clone_target_dir,
     "$clone_target_dir is the clone target directory now" );
@@ -113,4 +113,10 @@ sub git_repo_ok {
   "$directory looks like a git repository now";
 
   return;
+}
+
+sub init_test {
+  my $clone_target_dir = tempdir( CLEANUP => 1 );
+
+  return $clone_target_dir;
 }


### PR DESCRIPTION
This PR is a proposal to fix #1630 by switching to the requested branch in the local copy of a git repo before other operations.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)