### PR TITLE
Support command environment variables on Windows

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Revision history for Rex
 
  [ENHANCEMENTS]
  - Quote command arguments on Windows
+ - Support command environment variables on Windows
 
  [MAJOR]
 

--- a/lib/Rex/Interface/Exec/Local.pm
+++ b/lib/Rex/Interface/Exec/Local.pm
@@ -39,7 +39,7 @@ sub set_env {
     if ( ref $env ne "HASH" );
 
   while ( my ( $k, $v ) = each(%$env) ) {
-    $cmd .= "export $k='$v'; ";
+    $cmd .= $OSNAME eq 'MSWin32' ? "set $k=$v && " : "export $k='$v'; ";
   }
   $self->{env} = $cmd;
 }
@@ -86,6 +86,11 @@ sub exec {
     }
 
     $cmd = $new_cmd;
+  }
+  else {
+    if ( $self->{env} ) {
+      $cmd = $self->{env} . " $cmd";
+    }
   }
 
   Rex::Logger::debug("Executing: $cmd");

--- a/t/env.t
+++ b/t/env.t
@@ -12,9 +12,6 @@ use Rex::Commands::Run;
 
 $::QUIET = 1;
 
-SKIP: {
-  skip 'Do not run tests on Windows', 1 if $^O =~ m/^MSWin/;
+my $s = run( 'perl', [ '-e', 'print $ENV{REX}' ], env => { 'REX' => 'XER' } );
 
-  my $s = run( q(perl -e 'print $ENV{REX}'), env => { 'REX' => 'XER' } );
-  like( $s, qr/XER/, "run with env" );
-}
+like( $s, qr/XER/, "run with env" );

--- a/t/scm/git.t
+++ b/t/scm/git.t
@@ -9,6 +9,7 @@ use Test::More;
 use Test::Warnings;
 use Test::Exception;
 
+use English qw(-no_match_vars);
 use File::Spec;
 use File::Temp qw(tempdir);
 use Rex::Commands;
@@ -27,9 +28,11 @@ else {
   plan skip_all => 'Can not find git command';
 }
 
+my $empty_config_file = $OSNAME eq 'MSWin32' ? q() : File::Spec->devnull();
+
 my $git_environment = {
-  GIT_CONFIG_GLOBAL => File::Spec->devnull(),
-  GIT_CONFIG_SYSTEM => File::Spec->devnull(),
+  GIT_CONFIG_GLOBAL => $empty_config_file,
+  GIT_CONFIG_SYSTEM => $empty_config_file,
 };
 
 ok( $git, "Found git command at $git" );


### PR DESCRIPTION
This PR is a proposal to fix #1632 by prefixing commands on Windows with `set` calls to set environment variables.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)