### PR TITLE
Set minimum required Perl version to 5.14.4

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -179,12 +179,9 @@ jobs:
           - '5.18'
           - '5.16'
           - '5.14'
-          - '5.12'
         exclude:
           - os: windows
             perl: '5.34' # not released yet
-          - os: windows
-            perl: '5.12' # no 64-bit portable binaries
 
     runs-on: ${{ matrix.os }}-latest
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,11 +61,10 @@ As a general rule, managing an endpoint with Rex is only supported for platforms
 
 ### Supported Perl versions
 
-Rex aims to run even on older Perl versions up to 10 years old. Currently this means 5.12.5.
+Rex aims to run even on older Perl versions up to 10 years old. Currently this means 5.14.4.
 
 On top of the supported minimum version of Perl, the goal is to support the latest versions of all minor Perl 5 releases. That makes the full list the following:
 
-- 5.12.5
 - 5.14.4
 - 5.16.3
 - 5.18.4

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,7 @@ Revision history for Rex
  [MAJOR]
 
  [MINOR]
+ - Set minimum required Perl version to 5.14.4
 
  [NEW FEATURES]
 

--- a/dist.ini
+++ b/dist.ini
@@ -75,7 +75,7 @@ overwrite = 1
 [RunExtraTests]
 
 [Prereqs]
-perl = 5.12.5
+perl = 5.14.4
 Text::Wrap = != 2023.0509
 YAML = != 1.25
 
@@ -128,7 +128,7 @@ DBD::mysql = 0
 Config::Augeas = 0
 
 [Test::MinimumVersion]
-max_target_perl = 5.12.5
+max_target_perl = 5.14.4
 
 [Test::Kwalitee]
 


### PR DESCRIPTION
This PR is a proposal related to #1638 and requires minimum perl-5.14.4 to install Rex.

## Checklist

- [x] based on top of latest source code <!-- Make sure your changes are based on the latest version of the source code, rebase your branch if necessary. -->
- [x] changelog entry included <!-- If the change is interesting for the users or developers, it should be mentioned in the changelog. -->
- [x] automated tests pass <!-- Demonstrate the code is solid. Include new tests first, let them fail, then push the fix, allowing tests to pass. -->
- [x] git history is clean <!-- Ideally two commits are needed: one for adding new tests that fail, and one that fixes them. -->
- [x] git commit messages are [well-written](https://chris.beams.io/posts/git-commit/#seven-rules)