### PR TITLE
Fix parsing FreeBSD memory details

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,7 @@ Revision history for Rex
  - Fix parsing free memory on Solaris
  - Fix shared variable lockfile on Solaris
  - Prefer GNU tools on Solaris
+ - Fix parsing FreeBSD memory details
 
  [DOCUMENTATION]
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -10,6 +10,7 @@ Revision history for Rex
  - Fix shared variable lockfile on Solaris
  - Prefer GNU tools on Solaris
  - Fix parsing FreeBSD memory details
+ - Recognize laundry memory on FreeBSD
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Hardware/Memory.pm
+++ b/lib/Rex/Hardware/Memory.pm
@@ -234,4 +234,28 @@ sub get {
   return $data;
 }
 
+sub __parse_top_output {
+  my $top_output = shift;
+
+  my @matches = $top_output =~ m{
+        \d+   # one or more digits
+        [KMG] # unit
+        [ ]   # space
+        \w+   # memory use type
+    }gmsx;
+
+  @matches = map { split qr{[ ]}msx } @matches;
+
+  if ( $matches[0] =~ qr{\d}msx ) {
+    @matches = reverse @matches;
+  }
+
+  my %top_memory_data = @matches;
+
+  %top_memory_data =
+    map { lc $_ => $top_memory_data{$_} } keys %top_memory_data;
+
+  return \%top_memory_data;
+}
+
 1;

--- a/lib/Rex/Hardware/Memory.pm
+++ b/lib/Rex/Hardware/Memory.pm
@@ -137,7 +137,7 @@ sub get {
 
     my $memory_details = __parse_top_output($mem_str);
 
-    for my $stat (qw(active inactive wired cache buf free)) {
+    for my $stat (qw(active inactive wired laundry cache buf free)) {
 
       if ( exists $memory_details->{$stat} ) {
 
@@ -156,7 +156,8 @@ sub get {
       total => $total_mem,
       used  => $memory_details->{active} +
         $memory_details->{inactive} +
-        $memory_details->{wired},
+        $memory_details->{wired} +
+        $memory_details->{laundry},
       free    => $memory_details->{free},
       cached  => $memory_details->{cache},
       buffers => $memory_details->{buf},

--- a/t/hardware/memory.t
+++ b/t/hardware/memory.t
@@ -1,0 +1,62 @@
+#!/usr/bin/env perl
+
+use v5.12.5;
+use warnings;
+
+our $VERSION = '9999.99.99_99'; # VERSION
+
+use Test::More;
+use Test::Warnings;
+use Test::Deep;
+
+use Rex::Hardware::Memory;
+
+$::QUIET = 1;
+
+my @test_cases = (
+  {
+    name             => 'FreeBSD sample 4 elements',
+    top_output       => 'Mem: 12M Active, 34M Inact, 56M Wired, 78M Free',
+    expected_results => {
+      active => '12M',
+      inact  => '34M',
+      wired  => '56M',
+      free   => '78M',
+    },
+  },
+  {
+    name       => 'FreeBSD sample 5 elements',
+    top_output =>
+      'Mem: 123K Active, 456M Inact, 789M Wired, 1011K Buf, 1213M Free',
+    expected_results => {
+      active => '123K',
+      inact  => '456M',
+      wired  => '789M',
+      buf    => '1011K',
+      free   => '1213M',
+    },
+  },
+  {
+    name       => 'FreeBSD sample 6 elements',
+    top_output =>
+      'Mem: 1415K Active, 1617M Inact, 1819M Laundry, 2021K Wired, 2223M Buf, 2425M Free',
+    expected_results => {
+      active  => '1415K',
+      inact   => '1617M',
+      laundry => '1819M',
+      wired   => '2021K',
+      buf     => '2223M',
+      free    => '2425M',
+    },
+  },
+);
+
+plan tests => 1 + scalar @test_cases;
+
+for my $case (@test_cases) {
+  cmp_deeply(
+    Rex::Hardware::Memory::__parse_top_output( $case->{top_output} ),
+    $case->{expected_results},
+    $case->{name}
+  );
+}


### PR DESCRIPTION
This pull request proposes to fix #1645 by:

- making the parsing of `top` output testable
- avoiding to assume the list of available fields
- using the new approach on FreeBSD
- letting Rex recognize laundry

## Checklist towards merging

- [x] (re)based on top of latest source code <!-- (Re)base the changes on top of the latest commits of the default branch.-->
- [x] has changelog entry <!-- Mention user-facing changes in the changelog. -->
- [x] automated tests pass <!-- Demonstrate solid changes. Push new tests first, let them fail, then push the fix, making test pass. -->
- [x] has clean git history <!-- Ideally two commits: one to add new tests that fail, and one that makes them pass. -->
- [x] has [well-written](https://chris.beams.io/posts/git-commit/#seven-rules) commit messages