### PR TITLE
Fix command existence checks without which

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@ Revision history for Rex
  - Prefer GNU tools on Solaris
  - Fix parsing FreeBSD memory details
  - Recognize laundry memory on FreeBSD
+ - Fix command existence checks without which
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Interface/Exec/Base.pm
+++ b/lib/Rex/Interface/Exec/Base.pm
@@ -54,7 +54,7 @@ sub execute_line_based_operation {
 sub can_run {
   my ( $self, $commands_to_check, $check_with_command ) = @_;
 
-  $check_with_command ||= "which";
+  $check_with_command ||= "command -v";
 
   my $exec  = Rex::Interface::Exec->create;
   my $cache = Rex::get_cache();

--- a/lib/Rex/Interface/Exec/Local.pm
+++ b/lib/Rex/Interface/Exec/Local.pm
@@ -114,7 +114,7 @@ sub exec {
 sub can_run {
   my ( $self, $commands_to_check, $check_with_command ) = @_;
 
-  $check_with_command ||= $^O =~ /^MSWin/i ? 'where' : 'which';
+  $check_with_command ||= $^O =~ /^MSWin/i ? 'where' : 'command -v';
 
   return $self->SUPER::can_run( $commands_to_check, $check_with_command );
 }

--- a/t/can_run.t
+++ b/t/can_run.t
@@ -11,7 +11,7 @@ use Test::Warnings;
 use Rex::Commands::Run;
 
 {
-  my $command_to_check = $^O =~ /^MSWin/ ? 'where' : 'which';
+  my $command_to_check = $^O =~ /^MSWin/ ? 'where' : 'sh';
   my $result           = can_run($command_to_check);
   ok( $result, 'Found checker command' );
 }
@@ -23,14 +23,14 @@ use Rex::Commands::Run;
 }
 
 {
-  my @commands_to_check = $^O =~ /^MSWin/ ? 'where' : 'which';
+  my @commands_to_check = $^O =~ /^MSWin/ ? 'where' : 'sh';
   push @commands_to_check, 'non-existing command';
   my $result = can_run(@commands_to_check);
   ok( $result, 'Multiple commands - existing first' );
 }
 
 {
-  my @commands_to_check = $^O =~ /^MSWin/ ? 'where' : 'which';
+  my @commands_to_check = $^O =~ /^MSWin/ ? 'where' : 'sh';
   unshift @commands_to_check, 'non-existing command';
   my $result = can_run(@commands_to_check);
   ok( $result, 'Multiple commands - non-existing first' );


### PR DESCRIPTION
This pull request proposes to fix #1641 by replacing `which` usage with `command -v`.

## Checklist towards merging

- [x] (re)based on top of latest source code <!-- (Re)base the changes on top of the latest commits of the default branch.-->
- [x] has changelog entry <!-- Mention user-facing changes in the changelog. -->
- [ ] automated tests pass <!-- Demonstrate solid changes. Push new tests first, let them fail, then push the fix, making test pass. -->
- [x] has clean git history <!-- Ideally two commits: one to add new tests that fail, and one that makes them pass. -->
- [x] has [well-written](https://chris.beams.io/posts/git-commit/#seven-rules) commit messages