### PR TITLE
Test members of all hostgroups

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Revision history for Rex
  [API CHANGES]
 
  [BUG FIXES]
+ - Fix hostgroup membership list for all groups
 
  [DOCUMENTATION]
 

--- a/lib/Rex/Group.pm
+++ b/lib/Rex/Group.pm
@@ -15,7 +15,7 @@ use attributes;
 use Rex::Group::Entry::Server;
 
 use vars qw(%groups);
-use List::Util 1.45 qw(any uniq);
+use List::Util 1.45 qw(uniq);
 use Data::Dumper;
 
 sub new {
@@ -30,8 +30,11 @@ sub new {
 
     for my $group ( keys %groups ) {
 
-      if ( any { $_ eq $srv } $groups{$group}->get_servers ) {
-        $srv->append_to_group($group);
+      for my $host ( $groups{$group}->get_servers ) {
+        if ( $host eq $srv ) {
+          $host->append_to_group( $self->{name} );
+          $srv->append_to_group($group);
+        }
       }
     }
   }

--- a/t/group.t
+++ b/t/group.t
@@ -5,7 +5,7 @@ use warnings;
 
 our $VERSION = '9999.99.99_99'; # VERSION
 
-use Test::More tests => 102;
+use Test::More tests => 103;
 use Test::Warnings;
 use Test::Exception;
 use Test::Deep;
@@ -90,26 +90,25 @@ dies_ok( sub { Rex::Commands::evaluate_hostname('s[78]') },
 group first  => qw(one two);
 group second => qw(two three);
 
-my $expected_groups_for = {
-  one   => [qw(first)],
-  two   => [qw(first second)],
-  three => [qw(second)],
+my $expected_results_for = {
+  first => {
+    one => [qw(first)],
+    two => [qw(first second)],
+  },
+  second => {
+    two   => [qw(first second)],
+    three => [qw(second)],
+  },
 };
-
-my $groups_of;
 
 for my $group (qw(first second)) {
   my @hosts = Rex::Group->get_group($group);
 
   for my $host (@hosts) {
-    $groups_of->{ $host->to_s } = [ $host->groups ];
+    cmp_bag(
+      [ $host->groups ],
+      $expected_results_for->{$group}->{$host},
+      "correct host groups for host $host in group $group"
+    );
   }
-}
-
-for my $host ( keys %{$expected_groups_for} ) {
-  cmp_bag(
-    $groups_of->{$host},
-    $expected_groups_for->{$host},
-    "correct host groups for host $host"
-  );
 }


### PR DESCRIPTION
This pull request proposes to add a follow-up change to fix #1648 by ensuring that members of all hostgroups get their membership info properly recorded.

After #1649, only the last hostgroup defined for a given host had the full info.

<!-- Ask for a specific expected course of action, like: -->
<!-- Please review, then either merge, or let me know how to improve it further. -->

## Checklist towards merging

- [x] (re)based on top of latest source code <!-- (Re)base the changes on top of the latest commits of the default branch.-->
- [x] has changelog entry <!-- Mention user-facing changes in the changelog. -->
- [x] automated tests pass <!-- Demonstrate solid changes. Push new tests first, let them fail, then push the fix, making test pass. -->
- [x] has clean git history <!-- Ideally two commits: one to add new tests that fail, and one that makes them pass. -->
- [x] has [well-written](https://chris.beams.io/posts/git-commit/#seven-rules) commit messages