### PR TITLE
Strip ANSI color from Linux ip  output

### DIFF
--- a/lib/Rex/Hardware/Network/Linux.pm
+++ b/lib/Rex/Hardware/Network/Linux.pm
@@ -14,6 +14,7 @@ use Rex::Helper::Run;
 use Rex::Commands::Run;
 use Rex::Helper::Array;
 use Data::Dumper;
+use Term::ANSIColor qw(colorstrip);
 
 sub get_bridge_devices {
   unless ( can_run("brctl") ) {
@@ -141,6 +142,7 @@ sub _parse_ip {
 
   my $cur_dev;
   for my $line (@ip_lines) {
+    $line = colorstrip($line);
     if ( $line =~ m/^\d+:\s*([^\s]+):/ ) {
       my $new_dev = $1;
 


### PR DESCRIPTION
On latest Debian versions the command "Ip add show" outputs color chars on interface names. This patch uses the Term::ANSIColor lib to strip them fixing garbage in keys of Rex Template vars.
To test the problem simply dump gathered infos from a Debian Trixie (with iproute2 package installed) , and check the output of key interfaces for "$__36m" word:
 rex -H MyDebian-e "say dump_system_information;"
...
$__36mens192_ip = ''
$__36mlo_netmask = ''
$__36mens192_netmask = ''
....
